### PR TITLE
chore: update dependabot for shorter commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
       - "Eyevinn/maintainers"
     labels:
       - "dependencies"
+    commit-message:
+      # Use conventional commit format
+      prefix: "chore"
+      prefix-development: "chore"
+      # Include scope in commit message
+      include: "scope"
+      # Disable verbose commit body to avoid line length issues
+      # This will create simpler commit messages like:
+      # "chore(deps): bump webpack from 5.76.0 to 5.90.0"
     groups:
       development-dependencies:
         patterns:
@@ -42,3 +51,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,23 @@
-module.exports = { extends: ["@commitlint/config-conventional"] };
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    // Explicitly include some rules to avoid empty-rules error
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
* Disable verbose commit body to avoid line length issues
* This will create simpler commit messages like:
   * "chore(deps): bump webpack from 5.76.0 to 5.90.0"