### PR TITLE
chore: add max-len rule to ESLint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,17 @@ export default typescriptEslint.config(
       "no-constant-condition": "off", // Allow constant conditions like while(true)
       "no-case-declarations": "off", // Allow lexical declarations in case blocks
       "no-unused-vars": "off", // Using TypeScript's no-unused-vars instead
+      "max-len": [
+        "error",
+        {
+          code: 120,
+          ignoreComments: true,
+          ignoreStrings: true,
+          ignoreTemplateLiterals: true,
+          ignoreUrls: true,
+          ignoreRegExpLiterals: true,
+        },
+      ],
 
       // Import rules
       "import/no-unresolved": "off", // Turning off as TypeScript handles this


### PR DESCRIPTION
## Summary
- Added max-len rule to ESLint configuration with 120 character limit
- Configured to ignore URLs, comments, strings, template literals, and regex patterns

## Why
This helps resolve linting issues in dependabot PRs (like #24) that may contain long URLs or strings.

## Changes
- Added `max-len` rule to `eslint.config.js` with the following configuration:
  - Maximum line length: 120 characters
  - Ignores comments
  - Ignores strings
  - Ignores template literals
  - Ignores URLs (important for dependabot PRs)
  - Ignores regular expression literals

## Test plan
- [x] Ran `npm run lint` - all checks pass
- [x] Ran `npm run typecheck` - no TypeScript errors
- [x] Ran `npm test` - all tests pass
- [x] Pre-push hooks passed successfully

🤖 Generated with [Claude Code](https://claude.ai/code)