### PR TITLE
fix: remove invalid reviewers and labels from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "Eyevinn/maintainers"
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
## Summary
Fixed Dependabot configuration error by removing invalid team reference.

## Problem
Dependabot was reporting an error:
- The team `Eyevinn/maintainers` either doesn't exist or doesn't have correct permissions to be added as a reviewer

## Solution
- Removed the `reviewers` section referencing non-existent team
- Kept the `labels` configuration since the `dependencies` label has now been created in the repository

## Changes
- Updated `.github/dependabot.yml` to remove invalid `reviewers` configuration
- Kept all other settings intact (schedule, commit message format, dependency groups, labels, etc.)

## Note
The `github-actions` label referenced in the configuration will need to be created separately if you want GitHub Actions PRs to have that additional label.

## Test plan
- [x] Validated YAML syntax
- [x] Removed only the problematic configuration
- [x] Maintained all other Dependabot settings
- [x] Verified `dependencies` label exists in repository

This should resolve the Dependabot configuration error and allow it to function properly.

🤖 Generated with [Claude Code](https://claude.ai/code)