### PR TITLE
chore: add commitlint ignore rule for Dependabot commits

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -22,4 +22,11 @@ export default {
     "header-max-length": [2, "always", 120],
     "body-max-line-length": [2, "always", 120],
   },
+  // Ignore Dependabot commit messages
+  ignores: [
+    (message) =>
+      message.includes("bump") &&
+      message.includes("from") &&
+      message.includes("to"),
+  ],
 };


### PR DESCRIPTION
## Summary
- Add ignore rule to commitlint configuration for Dependabot commit messages
- Prevents Dependabot PRs from failing commitlint checks due to long commit messages

## Why
Dependabot often creates commit messages that exceed the 120 character limit when updating multiple dependencies. This causes the commitlint check to fail on Dependabot PRs (see PR #35 for example).

## Solution
Added an `ignores` function that skips commitlint validation for any commit message containing "bump", "from", and "to" - the typical pattern used by Dependabot.

## Test plan
- [x] Tested that Dependabot-style commits are ignored
- [x] Tested that normal commits still work
- [ ] Verify this fixes the issue on actual Dependabot PRs

🤖 Generated with [Claude Code](https://claude.ai/code)