### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-11
+
+Full [MOQ Transport draft-14][moqt-d14] compliance release.
+
 ### Added
 
 - DRM support via Encrypted Media Extensions (EME)
   - ClearKey DRM for development and testing
   - Commercial DRM support (Widevine, PlayReady, FairPlay)
   - DRM configuration via common field at the root level in the CMSF catalog
+- Safari 26.4+ and Firefox browser support
 
 ### Fixed
 
+- Object ID delta encoding in subgroup streams per draft-14 spec
+- FairPlay DRM support with event-driven key session flow
 - Updated draft-14 stream types to match specification
-- Added ANNOUNCE_OK response to server announcements
+- Added PUBLISH_NAMESPACE_OK response to server announcements
 
 ### Changed
 
+- Renamed announce terminology to publish namespace per draft-14
 - Bumped development dependencies (@types/node, jest, webpack)
 - Bumped production dependencies (@commitlint/cli, @typescript-eslint/\*, globals, serve, typescript-eslint)
 
@@ -116,7 +124,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for video and audio track selection
 - Real-time playback metrics (buffer levels, latency, playback rate)
 
-[Unreleased]: https://github.com/Eyevinn/warp-player/releases/tag/v0.5.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/warp-player/releases/tag/v0.6.0...HEAD
+[0.6.0]: https://github.com/Eyevinn/warp-player/releases/tag/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Eyevinn/warp-player/releases/tag/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Eyevinn/warp-player/releases/tag/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Eyevinn/warp-player/releases/tag/v0.2.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,9 +116,9 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 
 ### Added
 
-- Initial WARP player implementation following MOQ Transport draft-11
+- Initial player implementation following MOQ Transport draft-11
 - WebTransport client with bidirectional control stream support
-- WARP catalog parsing and track subscription
+- Catalog parsing and track subscription
 - MSE-based media playback with CMAF segment handling
 - Basic UI with connection controls and playback information
 - Support for video and audio track selection

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eyevinn/warp-player",
   "version": "0.6.0",
-  "description": "Browser-based Media Player for MOQ protocol with WARP support",
+  "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Browser-based Media Player for MOQ protocol with WARP support",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WARP Player - MOQ</title>
+    <title>MOQ Player - CMSF (draft-14)</title>
     <style>
       * {
         margin: 0;
@@ -571,7 +571,7 @@
             src="eyevinn-technology-logo-white-400px.png"
             alt="Eyevinn Technology"
           />
-          <span class="logo-text">WARP Player</span>
+          <span class="logo-text">MOQ Player</span>
           <span class="version" id="appVersion"></span>
         </div>
         <nav class="nav-links">


### PR DESCRIPTION
Full [MOQ Transport draft-14][moqt-d14] compliance release.

### Added

- DRM support via Encrypted Media Extensions (EME)
  - ClearKey DRM for development and testing
  - Commercial DRM support (Widevine, PlayReady, FairPlay)
  - DRM configuration via common field at the root level in the CMSF catalog
- Safari 26.4+ and Firefox browser support

### Fixed

- Object ID delta encoding in subgroup streams per draft-14 spec
- FairPlay DRM support with event-driven key session flow
- Updated draft-14 stream types to match specification
- Added PUBLISH_NAMESPACE_OK response to server announcements

### Changed

- Renamed announce terminology to publish namespace per draft-14
- Bumped development dependencies (@types/node, jest, webpack)
- Bumped production dependencies (@commitlint/cli, @typescript-eslint/\*, globals, serve, typescript-eslint)