### PR TITLE
feat: multi-namespace UI with FETCH and DRM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.6.0",
+  "version": "0.6.0+dev",
   "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -159,6 +159,28 @@ document.addEventListener("DOMContentLoaded", async () => {
   serverUrlInput.value = serverUrl;
   fingerprintUrlInput.value = fingerprintUrl;
 
+  // Hide fingerprint section if no fingerprint URL is configured, with toggle to show/hide
+  if (!fingerprintUrl) {
+    const fingerprintSection = document.getElementById("fingerprintSection");
+    if (fingerprintSection) {
+      fingerprintSection.style.display = "none";
+      const toggle = document.createElement("a");
+      toggle.textContent = "Fingerprint URL...";
+      toggle.href = "#";
+      toggle.style.cssText =
+        "font-size: 0.75rem; color: var(--text-secondary); cursor: pointer;";
+      toggle.addEventListener("click", (e) => {
+        e.preventDefault();
+        const visible = fingerprintSection.style.display !== "none";
+        fingerprintSection.style.display = visible ? "none" : "";
+      });
+      fingerprintSection.parentElement?.insertBefore(
+        toggle,
+        fingerprintSection,
+      );
+    }
+  }
+
   // Log source of configuration
   if (urlParams.get("serverUrl")) {
     logger.info("Server URL loaded from URL parameters");

--- a/src/index.html
+++ b/src/index.html
@@ -376,28 +376,38 @@
         margin-top: 0;
       }
 
-      /* Published namespace styles */
-      .published-namespace {
-        background-color: var(--bg-secondary);
-        border: 1px solid var(--border-color);
-        border-radius: 8px;
-        padding: 1rem;
+      /* Namespace selector styles */
+      .published-namespaces-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
         margin-bottom: 1rem;
       }
 
-      .published-namespace-title {
-        font-size: 0.875rem;
-        color: var(--text-secondary);
-        margin-bottom: 0.5rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-      }
-
-      .published-namespace-value {
+      .namespace-btn {
         font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
         font-size: 0.875rem;
-        color: var(--accent-green);
-        word-break: break-all;
+        padding: 0.5rem 1rem;
+        border-radius: 8px;
+        border: 1px solid var(--border-color);
+        background-color: var(--bg-secondary);
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition:
+          background-color 0.15s,
+          border-color 0.15s,
+          color 0.15s;
+      }
+
+      .namespace-btn:hover {
+        border-color: var(--bg-button-primary);
+        color: var(--text-primary);
+      }
+
+      .namespace-btn.selected {
+        background-color: var(--bg-button-primary);
+        border-color: var(--bg-button-primary);
+        color: #fff;
       }
 
       .track-selector {

--- a/src/index.html
+++ b/src/index.html
@@ -410,6 +410,15 @@
         color: #fff;
       }
 
+      .fetch-option {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+      }
+
       .track-selector {
         background-color: var(--bg-secondary);
         border: 1px solid var(--border-color);
@@ -739,6 +748,10 @@
             </div>
             <div id="status" class="status disconnected">
               <span>●</span> Disconnected
+            </div>
+            <div class="fetch-option">
+              <input type="checkbox" id="useFetchCatalog" />
+              <label for="useFetchCatalog">Use FETCH for catalog</label>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -258,9 +258,9 @@
 
       .connection-controls {
         display: flex;
-        justify-content: space-between;
+        flex-wrap: wrap;
         align-items: center;
-        gap: 1rem;
+        gap: 0.75rem;
       }
 
       /* Status */
@@ -376,6 +376,15 @@
         margin-top: 0;
       }
 
+      .tracks-section {
+        margin-bottom: 0.25rem;
+      }
+
+      .tracks-section h3 {
+        margin: 0.5rem 0 0.25rem;
+        font-size: 0.9rem;
+      }
+
       /* Namespace selector styles */
       .published-namespaces-container {
         display: flex;
@@ -410,44 +419,45 @@
         color: #fff;
       }
 
+      .namespace-btn.disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+
       .fetch-option {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        margin-top: 0.5rem;
-        font-size: 0.8rem;
-        color: var(--text-secondary);
-      }
-
-      .track-selector {
-        background-color: var(--bg-secondary);
-        border: 1px solid var(--border-color);
-        border-radius: 8px;
-        padding: 1rem;
-        margin-bottom: 1rem;
-      }
-
-      .track-selector label {
-        display: block;
         font-size: 0.875rem;
         color: var(--text-secondary);
-        margin-bottom: 0.5rem;
+      }
+
+      .selector-container {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
       }
 
       .track-select {
-        width: 100%;
-        padding: 0.75rem;
+        padding: 0.4rem 0.5rem;
         background-color: var(--input-bg);
         border: 1px solid var(--border-color);
-        border-radius: 8px;
+        border-radius: 6px;
         color: var(--text-primary);
-        font-size: 0.875rem;
+        font-size: 0.8rem;
         cursor: pointer;
+        min-width: 0;
       }
 
       .track-select:focus {
         outline: none;
         border-color: var(--bg-button-primary);
+      }
+
+      .track-details-container {
+        font-size: 0.75rem;
+        color: var(--text-secondary);
+        white-space: nowrap;
       }
 
       /* Logging Section */
@@ -710,7 +720,7 @@
               placeholder="Enter server URL"
             />
           </div>
-          <div class="form-group">
+          <div class="form-group" id="fingerprintSection">
             <label for="fingerprintUrl"
               >Fingerprint URL
               <span style="font-size: 0.75rem; color: var(--text-secondary)"
@@ -794,9 +804,26 @@
 
       <!-- Content Section -->
       <div class="card" style="margin-bottom: 2rem">
-        <h2>Content</h2>
+        <h2>Content Namespaces</h2>
         <!-- Tracks Container -->
         <div id="tracks-container" class="tracks-container"></div>
+        <div id="catalog-section" style="display: none">
+          <pre
+            id="catalogJson"
+            style="
+              background: var(--bg-secondary);
+              border: 1px solid var(--border-color);
+              border-radius: 6px;
+              padding: 0.75rem;
+              font-size: 0.75rem;
+              max-height: 400px;
+              overflow: auto;
+              white-space: pre-wrap;
+              word-break: break-all;
+              color: var(--text-secondary);
+            "
+          ></pre>
+        </div>
       </div>
 
       <!-- Logging Section -->

--- a/src/player.ts
+++ b/src/player.ts
@@ -404,14 +404,28 @@ export class Player {
     // Update the visual selection state
     this.renderNamespaceSelector();
 
-    // Subscribe to the catalog in this namespace
-    this.subscribeToCatalog(namespace).catch((error) => {
-      this.logger.error(
-        `Error subscribing to catalog: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    });
+    // Check if we should use FETCH instead of SUBSCRIBE
+    const useFetch = (
+      document.getElementById("useFetchCatalog") as HTMLInputElement
+    )?.checked;
+
+    if (useFetch) {
+      this.fetchCatalog(namespace).catch((error) => {
+        this.logger.error(
+          `Error fetching catalog: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    } else {
+      this.subscribeToCatalog(namespace).catch((error) => {
+        this.logger.error(
+          `Error subscribing to catalog: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    }
   }
 
   /**
@@ -481,6 +495,49 @@ export class Player {
     } catch (error) {
       this.logger.error(
         `Error subscribing to catalog: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Fetch the catalog using FETCH (one-shot) instead of SUBSCRIBE
+   */
+  private async fetchCatalog(namespace: string[]): Promise<void> {
+    if (!this.client) {
+      this.logger.error("Cannot fetch catalog: Not connected");
+      return;
+    }
+
+    const namespaceStr = namespace.join("/");
+    this.logger.info(`Fetching catalog in namespace: ${namespaceStr}`);
+
+    try {
+      await this.client.fetchTrack(
+        namespaceStr,
+        "catalog",
+        (obj: MOQObject) => {
+          try {
+            const text = new TextDecoder().decode(obj.data);
+            const catalog = JSON.parse(text);
+            this.catalogManager.handleCatalogData(catalog);
+          } catch (e) {
+            this.logger.error(
+              `Failed to decode fetched catalog data: ${
+                e instanceof Error ? e.message : String(e)
+              }`,
+            );
+          }
+        },
+      );
+
+      this.logger.info(
+        `Successfully fetched catalog in namespace: ${namespaceStr}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Error fetching catalog: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );

--- a/src/player.ts
+++ b/src/player.ts
@@ -30,6 +30,7 @@ export class Player {
   private unregisterPublishNamespaceCallback: (() => void) | null = null;
   private publishedNamespaces: string[][] = [];
   private selectedNamespace: string[] | null = null;
+  private clearKeySupported: boolean | null = null;
   private tracksContainerEl: HTMLElement;
   private statusEl: HTMLElement;
   private publishedNamespacesEl: HTMLElement | null = null;
@@ -199,6 +200,10 @@ export class Player {
         this.onConnectionStateChange(true);
       }
 
+      // ClearKey is not supported in Safari
+      this.clearKeySupported = !this.isSafari();
+      this.logger.info(`ClearKey supported: ${this.clearKeySupported}`);
+
       // Create the published namespaces section
       this.createPublishedNamespacesSection();
 
@@ -291,6 +296,16 @@ export class Player {
 
       // Clear tracks display
       this.tracksContainerEl.innerHTML = "";
+
+      // Hide and clear catalog view
+      const catalogSection = document.getElementById("catalog-section");
+      if (catalogSection) {
+        catalogSection.style.display = "none";
+      }
+      const catalogJson = document.getElementById("catalogJson");
+      if (catalogJson) {
+        catalogJson.textContent = "";
+      }
 
       // Remove the published namespaces section completely
       this.removePublishedNamespacesSection();
@@ -573,9 +588,82 @@ export class Player {
       `Found ${videoTracks.length} video tracks and ${audioTracks.length} audio tracks`,
     );
 
+    // Determine DRM label from catalog contentProtections
+    const drmLabel = this.getDrmLabel();
+
     // Display tracks in the UI
-    this.displayTracks("Video Tracks", videoTracks);
-    this.displayTracks("Audio Tracks", audioTracks);
+    this.displayTracks("video-tracks", `Video Tracks${drmLabel}`, videoTracks);
+    this.displayTracks("audio-tracks", `Audio Tracks${drmLabel}`, audioTracks);
+
+    // Update catalog JSON view
+    const catalogSection = document.getElementById("catalog-section");
+    const catalogJson = document.getElementById("catalogJson");
+    if (catalogJson) {
+      // Shorten initData for readability
+      const displayCatalog = {
+        ...catalog,
+        tracks: catalog.tracks.map((t: WarpTrack & { initData?: string }) => {
+          if (t.initData && t.initData.length > 40) {
+            return {
+              ...t,
+              initData: t.initData.substring(0, 40) + "...",
+            };
+          }
+          return t;
+        }),
+      };
+      catalogJson.textContent = JSON.stringify(displayCatalog, null, 2);
+    }
+
+    // Add catalog toggle button if not already present
+    if (
+      this.tracksContainerEl &&
+      !document.getElementById("catalogToggleBtn")
+    ) {
+      const btn = document.createElement("a");
+      btn.id = "catalogToggleBtn";
+      btn.href = "#";
+      btn.textContent = "Show catalog";
+      btn.style.cssText =
+        "font-size: 0.75rem; color: var(--text-secondary); cursor: pointer; display: inline-block; margin-top: 0.5rem;";
+      btn.addEventListener("click", (e) => {
+        e.preventDefault();
+        if (catalogSection) {
+          const visible = catalogSection.style.display !== "none";
+          catalogSection.style.display = visible ? "none" : "";
+          btn.textContent = visible ? "Show catalog" : "Hide catalog";
+        }
+      });
+      this.tracksContainerEl.appendChild(btn);
+    }
+  }
+
+  /**
+   * Get a DRM label string from the current catalog's contentProtections.
+   * Returns e.g. " 🔒 Widevine" or " 🔒 ClearKey" or "" if no DRM.
+   */
+  private getDrmLabel(): string {
+    const catalog = this.catalogManager.getCatalog();
+    if (
+      !catalog?.contentProtections ||
+      catalog.contentProtections.length === 0
+    ) {
+      return "";
+    }
+    const systemNames: string[] = [];
+    for (const cp of catalog.contentProtections) {
+      const sysId = cp.drmSystem?.systemID;
+      if (sysId) {
+        const name = this.drmSystems[sysId];
+        if (name && !systemNames.includes(name)) {
+          systemNames.push(name);
+        }
+      }
+    }
+    if (systemNames.length === 0) {
+      return "";
+    }
+    return ` 🔒 ${systemNames.join(", ")}`;
   }
 
   /**
@@ -603,47 +691,18 @@ export class Player {
       return;
     }
 
-    // Create published namespaces section
-    const heading = document.createElement("h3");
-    heading.textContent = "Namespaces";
-    heading.id = "published-namespaces-heading";
-
+    // Create published namespaces container before the tracks container
     this.publishedNamespacesEl = document.createElement("div");
     this.publishedNamespacesEl.id = "published-namespaces";
     this.publishedNamespacesEl.className = "published-namespaces-container";
 
-    // Find the "Available Tracks" heading that is the sibling of tracksContainerEl
-    let tracksHeading = null;
-    for (let i = 0; i < container.children.length; i++) {
-      const child = container.children[i];
-      if (child.tagName === "H3" && child.textContent === "Available Tracks") {
-        tracksHeading = child;
-        break;
-      }
-    }
-
-    if (tracksHeading) {
-      container.insertBefore(heading, tracksHeading);
-      container.insertBefore(this.publishedNamespacesEl, tracksHeading);
-    } else {
-      container.insertBefore(heading, this.tracksContainerEl);
-      container.insertBefore(
-        this.publishedNamespacesEl,
-        this.tracksContainerEl,
-      );
-    }
+    container.insertBefore(this.publishedNamespacesEl, this.tracksContainerEl);
   }
 
   /**
    * Remove the published namespaces section from the DOM
    */
   private removePublishedNamespacesSection(): void {
-    // Remove the published namespaces heading
-    const heading = document.getElementById("published-namespaces-heading");
-    if (heading && heading.parentNode) {
-      heading.parentNode.removeChild(heading);
-    }
-
     // Remove the published namespaces container
     if (this.publishedNamespacesEl && this.publishedNamespacesEl.parentNode) {
       this.publishedNamespacesEl.parentNode.removeChild(
@@ -673,25 +732,34 @@ export class Player {
     const container = this.publishedNamespacesEl;
     for (const ns of this.publishedNamespaces) {
       const nsStr = ns.join("/");
+      const isEccp = nsStr.includes("/eccp-");
+      const disabled = isEccp && !this.clearKeySupported;
+
       const btn = document.createElement("button");
       btn.className =
-        "namespace-btn" + (nsStr === selectedStr ? " selected" : "");
+        "namespace-btn" +
+        (nsStr === selectedStr ? " selected" : "") +
+        (disabled ? " disabled" : "");
       btn.textContent = nsStr;
-      btn.addEventListener("click", () => {
-        if (nsStr !== selectedStr) {
-          this.selectNamespace(ns);
-        }
-      });
+
+      if (!disabled) {
+        btn.addEventListener("click", () => {
+          if (nsStr !== selectedStr) {
+            this.selectNamespace(ns);
+          }
+        });
+      }
       container.appendChild(btn);
     }
   }
 
   /**
    * Display tracks in the UI
-   * @param title The title for the tracks section
+   * @param id Stable ID base for the select element (e.g. "video-tracks")
+   * @param title Display title for the section heading
    * @param tracks The tracks to display
    */
-  private displayTracks(title: string, tracks: WarpTrack[]): void {
+  private displayTracks(id: string, title: string, tracks: WarpTrack[]): void {
     if (!this.tracksContainerEl || tracks.length === 0) {
       return;
     }
@@ -705,15 +773,11 @@ export class Player {
     titleEl.textContent = title;
     section.appendChild(titleEl);
 
-    // Create selector and label in a container
+    // Create selector container with dropdown and details side by side
     const selectorContainer = document.createElement("div");
     selectorContainer.className = "selector-container";
 
-    const selectorLabel = document.createElement("label");
-    const selectId = `${title.toLowerCase().replace(/\s+/g, "-")}-select`;
-    selectorLabel.htmlFor = selectId;
-    selectorLabel.textContent = `Select ${title.toLowerCase()}: `;
-    selectorContainer.appendChild(selectorLabel);
+    const selectId = `${id}-select`;
 
     // Create dropdown select element
     const select = document.createElement("select");
@@ -727,9 +791,7 @@ export class Player {
       option.value = track.name;
       option.dataset.trackName = track.name;
       option.dataset.namespace = track.namespace || "";
-      option.textContent = `${track.name}${
-        track.namespace ? ` (${track.namespace})` : ""
-      }`;
+      option.textContent = track.name;
 
       // Select first track by default
       if (index === 0) {
@@ -791,8 +853,8 @@ export class Player {
     }, 0);
 
     selectorContainer.appendChild(select);
+    selectorContainer.appendChild(detailsContainer);
     section.appendChild(selectorContainer);
-    section.appendChild(detailsContainer);
 
     this.tracksContainerEl.appendChild(section);
 
@@ -1986,6 +2048,22 @@ export class Player {
 
       this.logger.info("Audio track found in catalog, preparing for setup");
     }
+    // Warn if HEVC + Widevine — not fully compatible in Chrome
+    if (
+      videoTrack?.codec?.startsWith("hvc") &&
+      videoTrack?.contentProtectionRefIDs
+    ) {
+      const catalog = this.catalogManager.getCatalog();
+      const isWidevine = catalog?.contentProtections?.some(
+        (cp: ContentProtection) => cp.drmSystem?.systemID === this.widevine,
+      );
+      if (isWidevine) {
+        this.logger.warn(
+          "HEVC with Widevine (CENC) is not fully supported in Chrome. Consider selecting an AVC track instead.",
+        );
+      }
+    }
+
     const tracks = [videoTrack, audioTrack].filter(
       (track) => track?.contentProtectionRefIDs !== undefined,
     ) as WarpTrack[];
@@ -2097,6 +2175,21 @@ export class Player {
             break;
           case this.fairplay:
             drmSystemSupported = await isFairplaySupported();
+            break;
+          case this.clearkey:
+            try {
+              await navigator.requestMediaKeySystemAccess("org.w3.clearkey", [
+                {
+                  initDataTypes: ["cenc"],
+                  videoCapabilities: [
+                    { contentType: 'video/mp4; codecs="avc1.4D401F"' },
+                  ],
+                },
+              ]);
+              drmSystemSupported = true;
+            } catch {
+              drmSystemSupported = false; // Safari does not support ClearKey
+            }
             break;
         }
         if (!drmSystemSupported) {
@@ -2962,6 +3055,15 @@ export class Player {
   /**
    * Decode base64 to ArrayBuffer
    */
+  private isSafari(): boolean {
+    const ua = navigator.userAgent;
+    return (
+      ua.includes("Safari") &&
+      !ua.includes("Chrome") &&
+      !ua.includes("Chromium")
+    );
+  }
+
   private base64ToArrayBuffer(base64: string): ArrayBuffer {
     const binary = atob(base64);
     const len = binary.length;

--- a/src/player.ts
+++ b/src/player.ts
@@ -29,6 +29,7 @@ export class Player {
   private unregisterCatalogCallback: (() => void) | null = null;
   private unregisterPublishNamespaceCallback: (() => void) | null = null;
   private publishedNamespaces: string[][] = [];
+  private selectedNamespace: string[] | null = null;
   private tracksContainerEl: HTMLElement;
   private statusEl: HTMLElement;
   private publishedNamespacesEl: HTMLElement | null = null;
@@ -297,6 +298,7 @@ export class Player {
 
     // Clear published namespaces
     this.publishedNamespaces = [];
+    this.selectedNamespace = null;
 
     // Notify connection state change
     if (this.onConnectionStateChange) {
@@ -348,17 +350,13 @@ export class Player {
           // Store the namespace
           this.publishedNamespaces.push(namespace);
 
-          // Display the published namespace in the UI
-          this.displayPublishedNamespace(namespace);
+          // Re-render the namespace selector with all known namespaces
+          this.renderNamespaceSelector();
 
-          // Subscribe to the catalog in this namespace
-          this.subscribeToCatalog(namespace).catch((error) => {
-            this.logger.error(
-              `Error subscribing to catalog: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            );
-          });
+          // Auto-select the first namespace if none is selected yet
+          if (this.selectedNamespace === null) {
+            this.selectNamespace(namespace);
+          }
         },
       );
 
@@ -374,6 +372,46 @@ export class Player {
         }`,
       );
     }
+  }
+
+  /**
+   * Select a namespace: unsubscribe from previous catalog, clear tracks,
+   * subscribe to the new namespace's catalog.
+   */
+  private selectNamespace(namespace: string[]): void {
+    const namespaceStr = namespace.join("/");
+    this.logger.info(`Selecting namespace: ${namespaceStr}`);
+
+    // Unsubscribe from previous catalog if any
+    if (this.unregisterCatalogCallback) {
+      this.logger.info("Unsubscribing from previous catalog");
+      this.unregisterCatalogCallback();
+      this.unregisterCatalogCallback = null;
+    }
+
+    // Clear previous catalog and tracks display
+    this.catalogManager.clearCatalog();
+    this.tracksContainerEl.innerHTML = "";
+
+    // Hide start/stop buttons until new tracks are loaded
+    const startBtn = document.getElementById("startBtn") as HTMLButtonElement;
+    if (startBtn) {
+      startBtn.disabled = true;
+    }
+
+    this.selectedNamespace = namespace;
+
+    // Update the visual selection state
+    this.renderNamespaceSelector();
+
+    // Subscribe to the catalog in this namespace
+    this.subscribeToCatalog(namespace).catch((error) => {
+      this.logger.error(
+        `Error subscribing to catalog: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
   }
 
   /**
@@ -510,7 +548,7 @@ export class Player {
 
     // Create published namespaces section
     const heading = document.createElement("h3");
-    heading.textContent = "Published Namespaces";
+    heading.textContent = "Namespaces";
     heading.id = "published-namespaces-heading";
 
     this.publishedNamespacesEl = document.createElement("div");
@@ -528,15 +566,9 @@ export class Player {
     }
 
     if (tracksHeading) {
-      // Insert before the "Available Tracks" heading
-      this.logger.debug(
-        'Found "Available Tracks" heading, inserting published namespaces before it',
-      );
       container.insertBefore(heading, tracksHeading);
       container.insertBefore(this.publishedNamespacesEl, tracksHeading);
     } else {
-      // If we can't find the heading, insert before the tracks container itself
-      this.logger.debug("Using tracks container as reference for insertion");
       container.insertBefore(heading, this.tracksContainerEl);
       container.insertBefore(
         this.publishedNamespacesEl,
@@ -565,48 +597,36 @@ export class Player {
   }
 
   /**
-   * Display a published namespace on the page
-   * @param namespace The namespace that was published
+   * Render the namespace selector showing all known namespaces as buttons.
+   * The currently selected namespace is highlighted.
    */
-  private displayPublishedNamespace(namespace: string[]): void {
-    this.logger.info(
-      `Attempting to display published namespace: ${namespace.join("/")}`,
-    );
-
+  private renderNamespaceSelector(): void {
     if (!this.publishedNamespacesEl) {
-      this.logger.warn(
-        "Published namespaces element not found, creating it now",
-      );
       this.createPublishedNamespacesSection();
-
       if (!this.publishedNamespacesEl) {
         this.logger.error("Failed to create published namespaces element");
         return;
       }
     }
 
-    // Clear any existing published namespaces
     this.publishedNamespacesEl.innerHTML = "";
 
-    // Create published namespace element with more compact styling
-    const nsEl = document.createElement("div");
-    nsEl.className = "published-namespace";
+    const selectedStr = this.selectedNamespace?.join("/") ?? "";
 
-    // Create a compact inline display for the namespace
-    const namespaceStr = namespace.join("/");
-    nsEl.innerHTML = `
-      <div class="published-namespace-container">
-        <span class="published-namespace-title">Published Namespace:</span>
-        <span class="published-namespace-value">${namespaceStr}</span>
-      </div>
-    `;
-
-    // Add to the published namespaces container
-    this.publishedNamespacesEl.appendChild(nsEl);
-
-    this.logger.info(
-      `Successfully displayed published namespace: ${namespaceStr}`,
-    );
+    const container = this.publishedNamespacesEl;
+    for (const ns of this.publishedNamespaces) {
+      const nsStr = ns.join("/");
+      const btn = document.createElement("button");
+      btn.className =
+        "namespace-btn" + (nsStr === selectedStr ? " selected" : "");
+      btn.textContent = nsStr;
+      btn.addEventListener("click", () => {
+        if (nsStr !== selectedStr) {
+          this.selectNamespace(ns);
+        }
+      });
+      container.appendChild(btn);
+    }
   }
 
   /**

--- a/src/transport/bufferctrlwriter.ts
+++ b/src/transport/bufferctrlwriter.ts
@@ -4,6 +4,7 @@ import {
   SubscribeError,
   PublishDone,
   Unsubscribe,
+  Fetch,
   PublishNamespace,
   PublishNamespaceOk,
   PublishNamespaceError,
@@ -23,6 +24,7 @@ enum Id {
   SubscribeUpdate = 0x2,
   PublishDone = 0xb, // draft-14: renamed from SubscribeDone
   Unsubscribe = 0xa,
+  Fetch = 0x16,
   PublishNamespace = 0x6, // draft-14: renamed from Announce
   PublishNamespaceOk = 0x7, // draft-14: renamed from AnnounceOk
   PublishNamespaceError = 0x8, // draft-14: renamed from AnnounceError
@@ -453,6 +455,27 @@ export class BufferCtrlWriter {
       this.writeVarInt53(msg.streamCount);
     });
 
+    return this;
+  }
+
+  /**
+   * Marshals a Fetch message to the buffer (standalone fetch type)
+   */
+  public marshalFetch(msg: Fetch): BufferCtrlWriter {
+    this.marshalWithLength(Id.Fetch, () => {
+      this.writeVarInt62(msg.requestId);
+      this.writeUint8(msg.subscriberPriority);
+      this.writeUint8(msg.groupOrder);
+      this.writeVarInt62(BigInt(msg.fetchType));
+      // Standalone fetch includes namespace, trackName, start/end
+      this.writeTuple(msg.namespace);
+      this.writeString(msg.trackName);
+      this.writeVarInt62(msg.startGroup);
+      this.writeVarInt62(msg.startObject);
+      this.writeVarInt62(msg.endGroup);
+      this.writeVarInt62(msg.endObject);
+      this.writeKeyValuePairs(msg.params);
+    });
     return this;
   }
 

--- a/src/transport/client.ts
+++ b/src/transport/client.ts
@@ -438,6 +438,22 @@ export class Client {
   }
 
   /**
+   * Fetch a track (one-shot retrieval instead of ongoing subscription)
+   */
+  async fetchTrack(
+    namespace: string,
+    trackName: string,
+    callback: ObjectCallback,
+  ): Promise<void> {
+    if (!this.#tracksManager) {
+      throw new Error("Cannot fetch: Tracks manager not initialized");
+    }
+
+    this.logger.info(`Client fetching track ${namespace}:${trackName}`);
+    return this.#tracksManager.fetchTrack(namespace, trackName, callback);
+  }
+
+  /**
    * Unsubscribe from a track by track alias
    * @param trackAlias The track alias to unsubscribe from
    * @returns A promise that resolves when the unsubscribe message has been sent

--- a/src/transport/control.ts
+++ b/src/transport/control.ts
@@ -12,6 +12,7 @@ export type Message = Subscriber | Publisher;
 export type Subscriber =
   | Subscribe
   | Unsubscribe
+  | Fetch
   | PublishNamespaceOk
   | PublishNamespaceError;
 
@@ -19,6 +20,7 @@ export function isSubscriber(m: Message): m is Subscriber {
   return (
     m.kind === Msg.Subscribe ||
     m.kind === Msg.Unsubscribe ||
+    m.kind === Msg.Fetch ||
     m.kind === Msg.PublishNamespaceOk ||
     m.kind === Msg.PublishNamespaceError
   );
@@ -28,6 +30,8 @@ export function isSubscriber(m: Message): m is Subscriber {
 export type Publisher =
   | SubscribeOk
   | SubscribeError
+  | FetchOk
+  | FetchError
   | PublishDone
   | PublishNamespace
   | UnpublishNamespace
@@ -37,6 +41,8 @@ export function isPublisher(m: Message): m is Publisher {
   return (
     m.kind === Msg.SubscribeOk ||
     m.kind === Msg.SubscribeError ||
+    m.kind === Msg.FetchOk ||
+    m.kind === Msg.FetchError ||
     m.kind === Msg.PublishDone ||
     m.kind === Msg.PublishNamespace ||
     m.kind === Msg.UnpublishNamespace ||
@@ -51,6 +57,9 @@ export enum Msg {
   SubscribeUpdate = "subscribe_update",
   PublishDone = "publish_done", // draft-14: renamed from subscribe_done
   Unsubscribe = "unsubscribe",
+  Fetch = "fetch",
+  FetchOk = "fetch_ok",
+  FetchError = "fetch_error",
   PublishNamespace = "publish_namespace", // draft-14: renamed from announce
   PublishNamespaceOk = "publish_namespace_ok", // draft-14: renamed from announce_ok
   PublishNamespaceError = "publish_namespace_error", // draft-14: renamed from announce_error
@@ -65,6 +74,9 @@ enum Id {
   SubscribeUpdate = 0x2,
   PublishDone = 0xb, // draft-14: renamed from SubscribeDone
   Unsubscribe = 0xa,
+  Fetch = 0x16,
+  FetchOk = 0x18,
+  FetchError = 0x19,
   PublishNamespace = 0x6, // draft-14: renamed from Announce
   PublishNamespaceOk = 0x7, // draft-14: renamed from AnnounceOk
   PublishNamespaceError = 0x8, // draft-14: renamed from AnnounceError
@@ -140,6 +152,40 @@ export interface SubscribeUpdate {
 export interface Unsubscribe {
   kind: Msg.Unsubscribe;
   requestId: bigint;
+}
+
+export const FetchTypeStandalone = 0x01;
+
+export interface Fetch {
+  kind: Msg.Fetch;
+  requestId: bigint;
+  subscriberPriority: number;
+  groupOrder: number;
+  fetchType: number;
+  namespace: string[];
+  trackName: string;
+  startGroup: bigint;
+  startObject: bigint;
+  endGroup: bigint;
+  endObject: bigint;
+  params: KeyValuePair[];
+}
+
+export interface FetchOk {
+  kind: Msg.FetchOk;
+  requestId: bigint;
+  groupOrder: number;
+  endOfTrack: number;
+  endGroup: bigint;
+  endObject: bigint;
+  params: KeyValuePair[];
+}
+
+export interface FetchError {
+  kind: Msg.FetchError;
+  requestId: bigint;
+  code: bigint;
+  reason: string;
 }
 
 export interface PublishDone {
@@ -263,6 +309,12 @@ export class Decoder {
       case Id.Unsubscribe:
         msgType = Msg.Unsubscribe;
         break;
+      case Id.FetchOk:
+        msgType = Msg.FetchOk;
+        break;
+      case Id.FetchError:
+        msgType = Msg.FetchError;
+        break;
       case Id.PublishNamespace:
         msgType = Msg.PublishNamespace;
         break;
@@ -307,6 +359,12 @@ export class Decoder {
         break;
       case Msg.PublishDone:
         result = await this.publish_done();
+        break;
+      case Msg.FetchOk:
+        result = await this.fetch_ok();
+        break;
+      case Msg.FetchError:
+        result = await this.fetch_error();
         break;
       case Msg.Unsubscribe:
         result = await this.unsubscribe();
@@ -515,6 +573,48 @@ export class Decoder {
     };
   }
 
+  private async fetch_ok(): Promise<FetchOk> {
+    controlLogger.debug("Parsing FetchOk message...");
+    const requestId = await this.r.u62();
+    const groupOrder = await this.r.u8();
+    const endOfTrack = await this.r.u8();
+    const endGroup = await this.r.u62();
+    const endObject = await this.r.u62();
+    const params = await this.r.keyValuePairs();
+
+    controlLogger.debug(
+      `FetchOk: requestId=${requestId}, endOfTrack=${endOfTrack}`,
+    );
+
+    return {
+      kind: Msg.FetchOk,
+      requestId,
+      groupOrder,
+      endOfTrack,
+      endGroup,
+      endObject,
+      params,
+    };
+  }
+
+  private async fetch_error(): Promise<FetchError> {
+    controlLogger.debug("Parsing FetchError message...");
+    const requestId = await this.r.u62();
+    const code = await this.r.u62();
+    const reason = await this.r.string();
+
+    controlLogger.debug(
+      `FetchError: requestId=${requestId}, code=${code}, reason=${reason}`,
+    );
+
+    return {
+      kind: Msg.FetchError,
+      requestId,
+      code,
+      reason,
+    };
+  }
+
   private async publish_done(): Promise<PublishDone> {
     controlLogger.debug("Parsing PublishDone message...");
     const requestId = await this.r.u62();
@@ -657,6 +757,9 @@ export class Encoder {
         break;
       case Msg.Unsubscribe:
         writer.marshalUnsubscribe(msg as Unsubscribe);
+        break;
+      case Msg.Fetch:
+        writer.marshalFetch(msg as Fetch);
         break;
       case Msg.PublishNamespace:
         writer.marshalPublishNamespace(msg as PublishNamespace);

--- a/src/transport/tracks.ts
+++ b/src/transport/tracks.ts
@@ -7,6 +7,9 @@ import {
   Msg,
   Subscribe,
   SubscribeOk,
+  Fetch,
+  FetchError,
+  FetchTypeStandalone,
   FilterType,
   GroupOrder,
   Message,
@@ -34,6 +37,7 @@ export type ObjectCallback = (obj: MOQObject) => void;
 export class TracksManager {
   private wt: WebTransport;
   private objectCallbacks: Map<string, ObjectCallback[]> = new Map();
+  private fetchCallbacks: Map<bigint, ObjectCallback> = new Map();
   private trackRegistry: TrackAliasRegistry = new TrackAliasRegistry();
   private controlStream: CtrlStream | null = null;
   private nextRequestId: bigint = 0n;
@@ -122,8 +126,7 @@ export class TracksManager {
       if (isSubgroup) {
         await this.handleSubgroupStream(reader, streamType);
       } else if (streamType === FETCH_HEADER_BIGINT) {
-        // Handle FETCH_HEADER streams if needed
-        this.logger.debug("Received FETCH_HEADER stream (not implemented yet)");
+        await this.handleFetchStream(reader);
       } else {
         this.logger.warn(`Unknown stream type: ${streamType}`);
       }
@@ -566,6 +569,129 @@ export class TracksManager {
    * Returns the track alias that can be used to unsubscribe later
    * @throws Error if control stream is not set
    */
+  /**
+   * Handle an incoming FETCH_HEADER stream (stream type 0x05).
+   * Reads the requestId, then reads objects and dispatches to the registered callback.
+   */
+  private async handleFetchStream(reader: Reader): Promise<void> {
+    const requestId = await reader.u62();
+    this.logger.info(`Received FETCH_HEADER stream, requestId=${requestId}`);
+
+    const callback = this.fetchCallbacks.get(requestId);
+    if (!callback) {
+      this.logger.warn(
+        `No callback registered for fetch requestId=${requestId}`,
+      );
+      return;
+    }
+
+    // Read objects from the fetch stream
+    // Each object: groupId, subgroupId, objectId, publisherPriority, extensionsLen, [extensions], payloadLen, payload
+    while (!(await reader.done())) {
+      const groupId = await reader.u62();
+      const subgroupId = await reader.u62();
+      const objectId = await reader.u62();
+      await reader.u8(); // publisherPriority - not needed
+      const extensionsLen = await reader.u62();
+      if (extensionsLen > 0n) {
+        await reader.read(Number(extensionsLen)); // skip extensions
+      }
+      const payloadLen = await reader.u62();
+      const payload =
+        payloadLen > 0n
+          ? await reader.read(Number(payloadLen))
+          : new Uint8Array(0);
+
+      this.logger.debug(
+        `Fetch object: group=${groupId}, subgroup=${subgroupId}, obj=${objectId}, len=${payload.length}`,
+      );
+
+      callback({
+        trackAlias: 0n,
+        location: { group: groupId, object: objectId },
+        data: payload,
+      });
+    }
+
+    // Clean up the callback
+    this.fetchCallbacks.delete(requestId);
+  }
+
+  /**
+   * Send a FETCH request for a track and register a callback for the response data.
+   * Returns a promise that resolves when the FETCH_OK is received.
+   */
+  public async fetchTrack(
+    namespace: string,
+    trackName: string,
+    callback: ObjectCallback,
+  ): Promise<void> {
+    this.logger.info(`Fetching track ${namespace}:${trackName}`);
+
+    if (!this.controlStream) {
+      throw new Error("Cannot fetch: Control stream not set");
+    }
+    if (!this.client) {
+      throw new Error("Cannot fetch: Client not set");
+    }
+
+    const requestId = this.getNextRequestId();
+
+    const fetchMsg: Fetch = {
+      kind: Msg.Fetch,
+      requestId,
+      subscriberPriority: 0,
+      groupOrder: 0, // Publisher order
+      fetchType: FetchTypeStandalone,
+      namespace: [namespace],
+      trackName,
+      startGroup: 0n,
+      startObject: 0n,
+      endGroup: 0n,
+      endObject: 0n,
+      params: [],
+    };
+
+    // Register callback for fetch data before sending the message
+    this.fetchCallbacks.set(requestId, callback);
+
+    const client = this.client;
+
+    const fetchPromise = new Promise<void>((resolve, reject) => {
+      const unregisterOk = client.registerMessageHandler(
+        Msg.FetchOk,
+        requestId,
+        () => {
+          this.logger.info(
+            `Received FetchOk for ${namespace}:${trackName}, requestId=${requestId}`,
+          );
+          unregisterErr();
+          resolve();
+        },
+      );
+
+      const unregisterErr = client.registerMessageHandler(
+        Msg.FetchError,
+        requestId,
+        (response: Message) => {
+          const fetchError = response as FetchError;
+          this.logger.error(
+            `Fetch error for ${namespace}:${trackName}: ${fetchError.reason}`,
+          );
+          unregisterOk();
+          this.fetchCallbacks.delete(requestId);
+          reject(new Error(`Fetch error: ${fetchError.reason}`));
+        },
+      );
+    });
+
+    this.logger.info(
+      `Sending FETCH for ${namespace}:${trackName} with requestId ${requestId}`,
+    );
+    await this.controlStream.send(fetchMsg);
+    await fetchPromise;
+  }
+
   public async subscribeTrack(
     namespace: string,
     trackName: string,


### PR DESCRIPTION
## Summary
- Namespace selector: shows announced namespaces as clickable buttons, auto-selects first
- FETCH support for catalog (toggle checkbox) with full transport layer implementation
- ClearKey/ECCP DRM support in EME flow (probed, disabled on Safari)
- DRM system label shown in track headings (e.g. "Video Tracks 🔒 widevine")
- Toggleable catalog JSON viewer
- Compact track layout with inline details
- Fingerprint URL field hidden by default with toggle

## Test plan
- [x] TypeScript, ESLint, tests all pass
- [x] Connect to server with multiple namespaces, verify selector works
- [x] Switch between namespaces, verify tracks update
- [x] Play clear content
- [x] Play ClearKey/ECCP content in Chrome
- [x] Play commercial DRM content in Chrome (Widevine)
- [x] Verify ECCP button disabled on Safari
- [x] Test FETCH checkbox for catalog retrieval