### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eyevinn/warp-player",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@eyevinn/is-drm-supported": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.6.0+dev",
+  "version": "0.6.1",
   "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version from 0.6.0+dev to 0.6.1