### PR TITLE
feat: add draft-16 support with dual draft-14/16 negotiation

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -6,6 +6,7 @@
  */
 import { LoggerFactory, LogLevel } from "./logger";
 import { Player } from "./player";
+import { DraftVersion } from "./transport/client";
 
 // DOM Elements
 let serverUrlInput: HTMLInputElement;
@@ -20,6 +21,7 @@ let logContainerEl: HTMLDivElement;
 // Using a type assertion when needed instead of storing the element
 // let logLevelSelect: HTMLSelectElement;
 let componentFilterSelect: HTMLSelectElement;
+let draftVersionSelect: HTMLSelectElement;
 let startBtn: HTMLButtonElement;
 let stopBtn: HTMLButtonElement;
 let browserWarning: HTMLDivElement;
@@ -129,6 +131,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   document.getElementById("logLevel");
   componentFilterSelect = document.getElementById(
     "componentFilter",
+  ) as HTMLSelectElement;
+  draftVersionSelect = document.getElementById(
+    "draftVersion",
   ) as HTMLSelectElement;
   startBtn = document.getElementById("startBtn") as HTMLButtonElement;
   stopBtn = document.getElementById("stopBtn") as HTMLButtonElement;
@@ -242,6 +247,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     statusEl,
     legacyLogMessage,
     fingerprintUrlInput.value || undefined,
+    draftVersionSelect.value as DraftVersion,
   );
 
   // Set connection state callback to manage button states
@@ -650,6 +656,7 @@ async function connect() {
     statusEl,
     legacyLogMessage,
     fingerprintUrlInput.value || undefined,
+    draftVersionSelect.value as DraftVersion,
   );
 
   // Set connection state callback to manage button states

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MOQ Player - CMSF (draft-14)</title>
+    <title>MOQ Player - CMSF (draft-14/16)</title>
     <style>
       * {
         margin: 0;
@@ -748,6 +748,24 @@
                 >Learn more</a
               >
             </div>
+          </div>
+          <div class="form-group">
+            <label for="draftVersion">Protocol Version</label>
+            <select
+              id="draftVersion"
+              style="
+                background: var(--input-bg);
+                color: var(--text-primary);
+                border: 1px solid var(--border-color);
+                padding: 0.5rem;
+                border-radius: 0.5rem;
+                width: 100%;
+              "
+            >
+              <option value="auto">Auto (negotiate)</option>
+              <option value="draft-14">Draft 14</option>
+              <option value="draft-16">Draft 16</option>
+            </select>
           </div>
           <div class="connection-controls">
             <div class="button-group">

--- a/src/player.ts
+++ b/src/player.ts
@@ -6,7 +6,7 @@ import {
 
 import { MediaBuffer, MediaSegmentBuffer } from "./buffer";
 import { ILogger, LoggerFactory } from "./logger";
-import { Client } from "./transport/client";
+import { Client, DraftVersion } from "./transport/client";
 import { MOQObject } from "./transport/tracks";
 import {
   WarpCatalog,
@@ -38,6 +38,7 @@ export class Player {
   private trackSubscriptions: Map<string, bigint> = new Map(); // Track name -> trackAlias
   private isDisconnecting: boolean = false; // Flag to prevent recursive disconnect calls
   private onConnectionStateChange: ((connected: boolean) => void) | null = null;
+  private draftVersion: DraftVersion = "auto";
 
   // Shared media elements for synchronized playback
   private sharedMediaSource: MediaSource | null = null;
@@ -108,9 +109,11 @@ export class Player {
       type?: "info" | "success" | "error" | "warn",
     ) => void,
     fingerprintUrl?: string,
+    draftVersion?: DraftVersion,
   ) {
     this.serverUrl = serverUrl;
     this.fingerprintUrl = fingerprintUrl;
+    this.draftVersion = draftVersion || "auto";
     this.tracksContainerEl = tracksContainerEl;
     this.statusEl = statusEl;
     // Get logger for Player component
@@ -185,13 +188,16 @@ export class Player {
       this.client = new Client({
         url: this.serverUrl,
         fingerprint: this.fingerprintUrl,
+        draftVersion: this.draftVersion,
       });
 
       this.connection = await this.client.connect();
 
-      // Update status
+      // Update status with negotiated version
+      const versionStr =
+        this.client.negotiatedVersion === 0xff000010 ? "draft-16" : "draft-14";
       this.statusEl.className = "status connected";
-      this.statusEl.innerHTML = "<span>●</span> Connected";
+      this.statusEl.innerHTML = `<span>●</span> Connected (${versionStr})`;
 
       this.logger.info("Connected to MOQ server successfully!");
 
@@ -368,8 +374,12 @@ export class Player {
           // Re-render the namespace selector with all known namespaces
           this.renderNamespaceSelector();
 
-          // Auto-select the first namespace if none is selected yet
-          if (this.selectedNamespace === null) {
+          // Auto-select the first media namespace if none is selected yet
+          // Skip non-media namespaces (e.g. moq-test/interop)
+          if (
+            this.selectedNamespace === null &&
+            !this.isNonMediaNamespace(namespace)
+          ) {
             this.selectNamespace(namespace);
           }
         },
@@ -387,6 +397,15 @@ export class Player {
         }`,
       );
     }
+  }
+
+  /** Known non-media namespace prefixes (e.g. interop test namespaces) */
+  private static readonly NON_MEDIA_PREFIXES = ["moq-test"];
+
+  private isNonMediaNamespace(namespace: string[]): boolean {
+    return Player.NON_MEDIA_PREFIXES.some(
+      (prefix) => namespace.length > 0 && namespace[0] === prefix,
+    );
   }
 
   /**
@@ -726,11 +745,23 @@ export class Player {
     }
 
     this.publishedNamespacesEl.innerHTML = "";
+    this.publishedNamespacesEl.style.cssText =
+      "display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; flex-wrap: wrap;";
 
     const selectedStr = this.selectedNamespace?.join("/") ?? "";
 
-    const container = this.publishedNamespacesEl;
-    for (const ns of this.publishedNamespaces) {
+    const mediaNs = this.publishedNamespaces.filter(
+      (ns) => !this.isNonMediaNamespace(ns),
+    );
+    const otherNs = this.publishedNamespaces.filter((ns) =>
+      this.isNonMediaNamespace(ns),
+    );
+
+    // Media namespace buttons on the left
+    const mediaGroup = document.createElement("div");
+    mediaGroup.style.cssText = "display: flex; gap: 0.5rem; flex-wrap: wrap;";
+
+    for (const ns of mediaNs) {
       const nsStr = ns.join("/");
       const isEccp = nsStr.includes("/eccp-");
       const disabled = isEccp && !this.clearKeySupported;
@@ -749,7 +780,26 @@ export class Player {
           }
         });
       }
-      container.appendChild(btn);
+      mediaGroup.appendChild(btn);
+    }
+    this.publishedNamespacesEl.appendChild(mediaGroup);
+
+    // Non-media namespaces as a small list on the right
+    if (otherNs.length > 0) {
+      const otherGroup = document.createElement("div");
+      otherGroup.style.cssText =
+        "max-height: 3rem; overflow-y: auto; text-align: right;";
+
+      for (const ns of otherNs) {
+        const nsStr = ns.join("/");
+        const item = document.createElement("div");
+        item.style.cssText =
+          "font-size: 0.7rem; color: var(--text-secondary); white-space: nowrap; text-decoration: line-through; opacity: 0.5;";
+        item.textContent = nsStr;
+        item.title = "Non-content namespace";
+        otherGroup.appendChild(item);
+      }
+      this.publishedNamespacesEl.appendChild(otherGroup);
     }
   }
 

--- a/src/transport/bufferctrlwriter.test.ts
+++ b/src/transport/bufferctrlwriter.test.ts
@@ -509,7 +509,7 @@ describe("BufferCtrlWriter", () => {
   describe("Buffer management", () => {
     it("should resize the buffer when needed", () => {
       // Create a writer with a very small initial buffer
-      const smallWriter = new BufferCtrlWriter(3); // Only enough for type and part of length
+      const smallWriter = new BufferCtrlWriter(undefined, 3); // Only enough for type and part of length
 
       // Create a message that will require more than 3 bytes
       // Since AnnounceOk is now very small, use a Subscribe message instead

--- a/src/transport/bufferctrlwriter.ts
+++ b/src/transport/bufferctrlwriter.ts
@@ -2,6 +2,7 @@ import {
   Subscribe,
   SubscribeOk,
   SubscribeError,
+  SubscribeUpdate,
   PublishDone,
   Unsubscribe,
   Fetch,
@@ -13,6 +14,7 @@ import {
   FilterType,
 } from "./control";
 import { KeyValuePair } from "./stream";
+import { Version, isDraft16 } from "./version";
 
 /**
  * Enum for message type IDs, matching the draft-14 specification
@@ -42,19 +44,23 @@ enum Id {
  * marshal methods to write a message to the buffer. The format is always:
  * wire format type, 16-bit length, message fields, etc.
  */
+// Draft-16 parameter type keys for fields moved from message body to params
+const PARAM_FORWARD = 0x10n;
+const PARAM_SUBSCRIBER_PRIORITY = 0x20n;
+const PARAM_SUBSCRIPTION_FILTER = 0x21n;
+const PARAM_GROUP_ORDER = 0x22n;
+
 export class BufferCtrlWriter {
   private buffer: Uint8Array;
   private position: number;
   private tempBuffer: Uint8Array;
+  private version: Version;
 
-  /**
-   * Creates a new BufferCtrlWriter with an initial buffer size
-   * @param initialSize Initial size of the buffer (default: 1024 bytes)
-   */
-  constructor(initialSize: number = 1024) {
+  constructor(version: Version = Version.DRAFT_14, initialSize: number = 1024) {
     this.buffer = new Uint8Array(initialSize);
     this.position = 0;
-    this.tempBuffer = new Uint8Array(8); // For temporary operations
+    this.tempBuffer = new Uint8Array(8);
+    this.version = version;
   }
 
   /**
@@ -298,6 +304,102 @@ export class BufferCtrlWriter {
   }
 
   /**
+   * Writes delta-encoded key-value pairs (draft-16+).
+   * Parameters are sorted by ascending type, then each type is encoded
+   * as a delta from the previous type.
+   */
+  private writeDeltaKeyValuePairs(pairs?: KeyValuePair[]): void {
+    const numPairs = pairs ? pairs.length : 0;
+    this.writeVarInt53(numPairs);
+
+    if (!pairs || pairs.length === 0) {
+      return;
+    }
+
+    // Sort by ascending type for delta encoding
+    const sorted = [...pairs].sort((a, b) => {
+      if (a.type < b.type) {
+        return -1;
+      }
+      if (a.type > b.type) {
+        return 1;
+      }
+      return 0;
+    });
+
+    let prevType = 0n;
+    for (const pair of sorted) {
+      // Write delta type
+      const delta = pair.type - prevType;
+      this.writeVarInt62(delta);
+      prevType = pair.type;
+
+      if (pair.type % 2n === 0n) {
+        if (typeof pair.value !== "bigint") {
+          throw new Error(
+            `Invalid value type for even key ${pair.type}: expected bigint`,
+          );
+        }
+        this.writeVarInt62(pair.value);
+      } else {
+        if (!(pair.value instanceof Uint8Array)) {
+          throw new Error(
+            `Invalid value type for odd key ${pair.type}: expected Uint8Array`,
+          );
+        }
+        this.writeVarInt53(pair.value.byteLength);
+        this.ensureSpace(pair.value.byteLength);
+        this.buffer.set(pair.value, this.position);
+        this.position += pair.value.byteLength;
+      }
+    }
+  }
+
+  /** Writes params using the appropriate encoding for the current version */
+  private writeParams(pairs?: KeyValuePair[]): void {
+    if (isDraft16(this.version)) {
+      this.writeDeltaKeyValuePairs(pairs);
+    } else {
+      this.writeKeyValuePairs(pairs);
+    }
+  }
+
+  /** Encodes a Location into a Uint8Array (for packing into parameter bytes) */
+  private encodeLocationBytes(location: Location): Uint8Array {
+    const tempWriter = new BufferCtrlWriter(this.version, 16);
+    tempWriter.writeVarInt62(location.group);
+    tempWriter.writeVarInt62(location.object);
+    return tempWriter.getBytes();
+  }
+
+  /** Encodes a subscription filter into bytes for the SUBSCRIPTION_FILTER parameter */
+  private encodeFilterBytes(
+    filterType: FilterType,
+    startLocation?: Location,
+    endGroup?: bigint,
+  ): Uint8Array {
+    const tempWriter = new BufferCtrlWriter(this.version, 32);
+    tempWriter.writeVarInt53(filterType);
+    if (
+      filterType === FilterType.AbsoluteStart ||
+      filterType === FilterType.AbsoluteRange
+    ) {
+      if (!startLocation) {
+        throw new Error("Missing startLocation for absolute filter");
+      }
+      tempWriter.writeVarInt62(startLocation.group);
+      tempWriter.writeVarInt62(startLocation.object);
+    }
+    if (filterType === FilterType.AbsoluteRange) {
+      if (endGroup === undefined) {
+        throw new Error("Missing endGroup for absolute range filter");
+      }
+      tempWriter.writeVarInt62(endGroup);
+    }
+    return tempWriter.getBytes();
+  }
+
+  /**
    * Helper method to marshal a message with proper type and length
    * @param messageType The message type ID
    * @param writeContent Function to write the message content
@@ -331,49 +433,59 @@ export class BufferCtrlWriter {
    */
   public marshalSubscribe(msg: Subscribe): BufferCtrlWriter {
     this.marshalWithLength(Id.Subscribe, () => {
-      // Write the subscription ID
       this.writeVarInt62(msg.requestId);
-
-      // trackAlias removed in draft-14 - publisher assigns it in SUBSCRIBE_OK
-
-      // Write the namespace
       this.writeTuple(msg.namespace);
-
-      // Write the track name
       this.writeString(msg.name);
 
-      // Write the subscriber priority
-      this.writeUint8(msg.subscriber_priority);
+      if (isDraft16(this.version)) {
+        // Draft-16: fields moved to parameters
+        const params: KeyValuePair[] = [...(msg.params || [])];
+        params.push({
+          type: PARAM_FORWARD,
+          value: BigInt(msg.forward ? 1 : 0),
+        });
+        params.push({
+          type: PARAM_SUBSCRIBER_PRIORITY,
+          value: BigInt(msg.subscriber_priority),
+        });
+        params.push({
+          type: PARAM_SUBSCRIPTION_FILTER,
+          value: this.encodeFilterBytes(
+            msg.filterType,
+            msg.startLocation,
+            msg.endGroup,
+          ),
+        });
+        params.push({
+          type: PARAM_GROUP_ORDER,
+          value: BigInt(msg.group_order),
+        });
+        this.writeDeltaKeyValuePairs(params);
+      } else {
+        // Draft-14: inline fields
+        this.writeUint8(msg.subscriber_priority);
+        this.writeUint8(msg.group_order);
+        this.writeBoolAsUint8(msg.forward);
+        this.writeUint8(msg.filterType);
 
-      // Write the group order
-      this.writeUint8(msg.group_order);
-
-      // Write the forward flag
-      this.writeBoolAsUint8(msg.forward);
-
-      // Write the filter type
-      this.writeUint8(msg.filterType);
-
-      if (
-        msg.filterType === FilterType.AbsoluteStart ||
-        msg.filterType === FilterType.AbsoluteRange
-      ) {
-        // Write the location
-        if (!msg.startLocation) {
-          throw new Error("Missing startLocation for absolute filter");
+        if (
+          msg.filterType === FilterType.AbsoluteStart ||
+          msg.filterType === FilterType.AbsoluteRange
+        ) {
+          if (!msg.startLocation) {
+            throw new Error("Missing startLocation for absolute filter");
+          }
+          this.writeLocation(msg.startLocation);
         }
-        this.writeLocation(msg.startLocation);
-      }
 
-      if (msg.filterType === FilterType.AbsoluteRange) {
-        // Write the end group
-        if (!msg.endGroup) {
-          throw new Error("Missing endGroup for absolute range filter");
+        if (msg.filterType === FilterType.AbsoluteRange) {
+          if (!msg.endGroup) {
+            throw new Error("Missing endGroup for absolute range filter");
+          }
+          this.writeVarInt62(msg.endGroup);
         }
-        this.writeVarInt62(msg.endGroup);
+        this.writeKeyValuePairs(msg.params);
       }
-      // Write parameters (if any)
-      this.writeKeyValuePairs(msg.params);
     });
 
     return this;
@@ -419,17 +531,20 @@ export class BufferCtrlWriter {
    */
   public marshalSubscribeError(msg: SubscribeError): BufferCtrlWriter {
     this.marshalWithLength(Id.SubscribeError, () => {
-      // Write the request ID
       this.writeVarInt62(msg.requestId);
-
-      // Write the error code
       this.writeVarInt62(msg.code);
 
-      // Write the error reason
+      if (isDraft16(this.version)) {
+        // Draft-16 REQUEST_ERROR: includes retryInterval
+        this.writeVarInt62(msg.retryInterval ?? 0n);
+      }
+
       this.writeString(msg.reason);
 
-      // Write the track alias
-      this.writeVarInt62(msg.trackAlias);
+      if (!isDraft16(this.version) && msg.trackAlias !== undefined) {
+        // Draft-14 only: trackAlias
+        this.writeVarInt62(msg.trackAlias);
+      }
     });
 
     return this;
@@ -486,28 +601,24 @@ export class BufferCtrlWriter {
    */
   public marshalPublishNamespace(msg: PublishNamespace): BufferCtrlWriter {
     this.marshalWithLength(Id.PublishNamespace, () => {
-      // Write the request ID
       this.writeVarInt62(msg.requestId);
-
-      // Write the namespace
       this.writeTuple(msg.namespace);
-
-      // Convert Parameters map to KeyValuePair array and write them
-      this.writeKeyValuePairs(msg.params);
+      this.writeParams(msg.params);
     });
 
     return this;
   }
 
   /**
-   * Marshals a PublishNamespaceOk message to the buffer (draft-14: renamed from AnnounceOk)
-   * @param msg The PublishNamespaceOk message to marshal
-   * @returns The BufferCtrlWriter instance for chaining
+   * Marshals a PublishNamespaceOk / REQUEST_OK message to the buffer
    */
   public marshalPublishNamespaceOk(msg: PublishNamespaceOk): BufferCtrlWriter {
     this.marshalWithLength(Id.PublishNamespaceOk, () => {
-      // Write the request ID
       this.writeVarInt62(msg.requestId);
+      if (isDraft16(this.version)) {
+        // Draft-16 REQUEST_OK includes parameters
+        this.writeDeltaKeyValuePairs([]);
+      }
     });
 
     return this;
@@ -572,36 +683,82 @@ export class BufferCtrlWriter {
     params?: KeyValuePair[];
   }): BufferCtrlWriter {
     this.marshalWithLength(Id.ClientSetup, () => {
-      // Write version count
-      this.writeVarInt53(msg.versions.length);
-
-      // Write each version
-      for (const version of msg.versions) {
-        this.writeVarInt53(version);
+      if (!isDraft16(this.version)) {
+        // Draft-14: include version list for in-band negotiation
+        this.writeVarInt53(msg.versions.length);
+        for (const version of msg.versions) {
+          this.writeVarInt53(version);
+        }
       }
+      // Draft-16 omits version list (negotiated via protocol)
+      this.writeParams(msg.params);
+    });
 
-      // Write parameters (if any)
-      this.writeKeyValuePairs(msg.params);
+    return this;
+  }
+
+  public marshalServerSetup(msg: {
+    version: number;
+    params?: KeyValuePair[];
+  }): BufferCtrlWriter {
+    this.marshalWithLength(Id.ServerSetup, () => {
+      if (!isDraft16(this.version)) {
+        // Draft-14: include selected version
+        this.writeVarInt53(msg.version);
+      }
+      // Draft-16 omits selected version (negotiated via protocol)
+      this.writeParams(msg.params);
     });
 
     return this;
   }
 
   /**
-   * Marshals a Server setup message to the buffer
-   * @param msg The Server setup message to marshal
-   * @returns The BufferCtrlWriter instance for chaining
+   * Marshals a SubscribeUpdate / REQUEST_UPDATE message to the buffer
    */
-  public marshalServerSetup(msg: {
-    version: number;
-    params?: KeyValuePair[];
-  }): BufferCtrlWriter {
-    this.marshalWithLength(Id.ServerSetup, () => {
-      // Write the selected version
-      this.writeVarInt53(msg.version);
+  public marshalSubscribeUpdate(msg: SubscribeUpdate): BufferCtrlWriter {
+    this.marshalWithLength(Id.SubscribeUpdate, () => {
+      this.writeVarInt62(msg.requestId);
+      // draft-14: SubscriptionRequestID; draft-16 calls it Existing Request ID
+      // In warp-player the field name on the interface hasn't changed
+      // but we need to check if this field exists. For draft-14:
+      // requestId is the new request ID, and we need the subscription request ID.
+      // Looking at the interface, requestId serves as REQUEST_UPDATE's own ID in draft-16
+      // and startLocation/endGroup/etc are inline in draft-14 or in params in draft-16.
 
-      // Write parameters (if any)
-      this.writeKeyValuePairs(msg.params);
+      if (isDraft16(this.version)) {
+        // Draft-16: all fields in parameters
+        const params: KeyValuePair[] = [...(msg.params || [])];
+        params.push({
+          type: PARAM_FORWARD,
+          value: BigInt(msg.forward ? 1 : 0),
+        });
+        params.push({
+          type: PARAM_SUBSCRIBER_PRIORITY,
+          value: BigInt(msg.subscriberPriority),
+        });
+        // Encode filter
+        const filterType =
+          msg.endGroup > 0n
+            ? FilterType.AbsoluteRange
+            : FilterType.AbsoluteStart;
+        params.push({
+          type: PARAM_SUBSCRIPTION_FILTER,
+          value: this.encodeFilterBytes(
+            filterType,
+            msg.startLocation,
+            msg.endGroup,
+          ),
+        });
+        this.writeDeltaKeyValuePairs(params);
+      } else {
+        // Draft-14: inline fields
+        this.writeLocation(msg.startLocation);
+        this.writeVarInt62(msg.endGroup);
+        this.writeUint8(msg.subscriberPriority);
+        this.writeBoolAsUint8(msg.forward);
+        this.writeKeyValuePairs(msg.params);
+      }
     });
 
     return this;

--- a/src/transport/client.ts
+++ b/src/transport/client.ts
@@ -11,6 +11,14 @@ import {
 import * as Setup from "./setup";
 import * as Stream from "./stream";
 import { TracksManager, ObjectCallback } from "./tracks";
+import {
+  Version,
+  isDraft16,
+  PROTOCOL_DRAFT_14,
+  PROTOCOL_DRAFT_16,
+} from "./version";
+
+export type DraftVersion = "auto" | "draft-14" | "draft-16";
 
 export interface ClientConfig {
   url: string;
@@ -18,6 +26,9 @@ export interface ClientConfig {
   // If set, the server fingerprint will be fetched from this URL.
   // This is required to use self-signed certificates with Chrome
   fingerprint?: string;
+
+  // Protocol draft version: "auto" (default), "draft-14", or "draft-16"
+  draftVersion?: DraftVersion;
 }
 
 // Type for message handlers based on message kind and request ID
@@ -28,6 +39,8 @@ export class Client {
   readonly config: ClientConfig;
   // Track the next request ID to use (client IDs are even, starting at 0)
   #nextRequestId: bigint = 0n;
+  // The negotiated protocol version (set during connect)
+  #negotiatedVersion: Version = Version.DRAFT_14;
   // Store the trackAlias used for catalog subscription
   // eslint-disable-next-line no-unused-private-class-members
   #catalogTrackAlias: bigint | null = null;
@@ -56,7 +69,6 @@ export class Client {
   #publishNamespaceCallbacks: Set<(namespace: string[]) => void> = new Set();
 
   async connect(): Promise<Connection> {
-    // Create WebTransport options
     const options: WebTransportOptions = {};
 
     const fingerprint = await this.#fingerprint;
@@ -75,10 +87,49 @@ export class Client {
       );
     }
 
+    // Set WebTransport protocols for version negotiation
+    const draftVersion = this.config.draftVersion || "auto";
+    if (draftVersion === "draft-16") {
+      (options as any).protocols = [PROTOCOL_DRAFT_16];
+      this.logger.info(
+        `Requesting WebTransport protocol: ${PROTOCOL_DRAFT_16}`,
+      );
+    } else if (draftVersion === "auto") {
+      // Offer both protocols, server picks the best match
+      (options as any).protocols = [PROTOCOL_DRAFT_16, PROTOCOL_DRAFT_14];
+      this.logger.info(
+        `Requesting WebTransport protocols: ${PROTOCOL_DRAFT_16}, ${PROTOCOL_DRAFT_14}`,
+      );
+    }
+
     this.logger.info(`Connecting to ${this.config.url}...`);
     const wt = new WebTransport(this.config.url, options);
     await wt.ready;
     this.logger.info("WebTransport connection established");
+
+    // Determine negotiated version from WebTransport protocol
+    const negotiatedProtocol = (wt as any).protocol as string | undefined;
+    let version: Version;
+
+    if (draftVersion === "draft-14") {
+      // Forced draft-14
+      version = Version.DRAFT_14;
+      this.logger.info("Using forced draft-14");
+    } else if (negotiatedProtocol === PROTOCOL_DRAFT_16) {
+      // Server accepted draft-16 protocol
+      version = Version.DRAFT_16;
+      this.logger.info(
+        `Server negotiated protocol: ${negotiatedProtocol} -> draft-16`,
+      );
+    } else {
+      // Fall back to draft-14 in-band negotiation
+      version = Version.DRAFT_14;
+      this.logger.info(
+        `WebTransport protocol: ${negotiatedProtocol || "(none)"} -> falling back to draft-14`,
+      );
+    }
+
+    this.#negotiatedVersion = version;
 
     const stream = await wt.createBidirectionalStream();
     this.logger.info("Bidirectional stream created");
@@ -86,16 +137,18 @@ export class Client {
     const writer = new Stream.Writer(stream.writable);
     const reader = new Stream.Reader(new Uint8Array(), stream.readable);
 
-    const setup = new Setup.Stream(reader, writer);
+    const setup = new Setup.Stream(reader, writer, version);
 
     // Send the client setup message
-    this.logger.info("Sending client setup message");
+    this.logger.info(
+      `Sending client setup message (${isDraft16(version) ? "draft-16" : "draft-14"})`,
+    );
     await setup.send.client({
-      versions: [Setup.Version.DRAFT_14],
+      versions: isDraft16(version) ? [] : [Version.DRAFT_14],
       params: [
         {
           type: 0x02n, // MAX_REQUEST_ID parameter type
-          value: 64n, // Allow server to send up to 64 request-type messages
+          value: 64n,
         },
       ],
     });
@@ -105,13 +158,21 @@ export class Client {
     const server = await setup.recv.server();
     this.logger.info("Received server setup:", server);
 
-    if (server.version !== Setup.Version.DRAFT_14) {
-      throw new Error(`Unsupported server version: ${server.version}`);
+    if (!isDraft16(version)) {
+      // Draft-14: validate server version
+      if (
+        server.version !== Version.DRAFT_14 &&
+        server.version !== Version.DRAFT_16
+      ) {
+        throw new Error(`Unsupported server version: ${server.version}`);
+      }
     }
 
-    // Create control stream for handling control messages
-    const control = new CtrlStream(reader, writer);
-    this.logger.info("Control stream established");
+    // Create control stream with version
+    const control = new CtrlStream(reader, writer, version);
+    this.logger.info(
+      `Control stream established (${isDraft16(version) ? "draft-16" : "draft-14"})`,
+    );
 
     // Create tracks manager for handling data streams
     this.#tracksManager = new TracksManager(wt, control, this);
@@ -119,13 +180,17 @@ export class Client {
       "Tracks manager created with control stream and client reference",
     );
 
-    // Create a Connection object with the client instance to access request ID management
     const connection = new Connection(wt, control, this);
 
     // Start listening for control messages
     this.#listenForControlMessages(control);
 
     return connection;
+  }
+
+  /** Get the negotiated protocol version */
+  get negotiatedVersion(): Version {
+    return this.#negotiatedVersion;
   }
 
   /**

--- a/src/transport/control.ts
+++ b/src/transport/control.ts
@@ -2,6 +2,7 @@ import { ILogger, LoggerFactory } from "../logger";
 
 import { BufferCtrlWriter } from "./bufferctrlwriter";
 import { Reader, Writer, KeyValuePair } from "./stream";
+import { Version, isDraft16 } from "./version";
 
 // Logger for control message operations
 const controlLogger: ILogger = LoggerFactory.getInstance().getLogger("Control");
@@ -135,8 +136,9 @@ export interface SubscribeError {
   kind: Msg.SubscribeError;
   requestId: bigint;
   code: bigint;
+  retryInterval?: bigint; // draft-16: minimum ms before retry (0 = don't retry)
   reason: string;
-  trackAlias: bigint;
+  trackAlias?: bigint; // draft-14 only
 }
 
 export interface SubscribeUpdate {
@@ -185,6 +187,7 @@ export interface FetchError {
   kind: Msg.FetchError;
   requestId: bigint;
   code: bigint;
+  retryInterval?: bigint; // draft-16
   reason: string;
 }
 
@@ -206,7 +209,7 @@ export interface PublishNamespace {
 export interface PublishNamespaceOk {
   kind: Msg.PublishNamespaceOk;
   requestId: bigint;
-  namespace: string[];
+  namespace?: string[]; // draft-14 only; draft-16 REQUEST_OK has params instead
 }
 
 export interface PublishNamespaceError {
@@ -232,9 +235,9 @@ export class CtrlStream {
 
   #mutex = Promise.resolve();
 
-  constructor(r: Reader, w: Writer) {
-    this.decoder = new Decoder(r);
-    this.encoder = new Encoder(w);
+  constructor(r: Reader, w: Writer, version: Version = Version.DRAFT_14) {
+    this.decoder = new Decoder(r, version);
+    this.encoder = new Encoder(w, version);
   }
 
   // Will error if two messages are read at once.
@@ -273,11 +276,18 @@ export class CtrlStream {
   }
 }
 
+// Draft-16 parameter type keys for decoding
+const PARAM_EXPIRES = 0x08n;
+const PARAM_LARGEST_OBJECT = 0x09n;
+const PARAM_GROUP_ORDER = 0x22n;
+
 export class Decoder {
   r: Reader;
+  private version: Version;
 
-  constructor(r: Reader) {
+  constructor(r: Reader, version: Version = Version.DRAFT_14) {
     this.r = r;
+    this.version = version;
   }
 
   private async msg(): Promise<Msg> {
@@ -510,15 +520,104 @@ export class Decoder {
     }
   }
 
+  /** Draft-16: decode delta-encoded parameters from the control stream */
+  private async deltaKeyValuePairs(): Promise<KeyValuePair[]> {
+    const count = await this.r.u53();
+    const params: KeyValuePair[] = [];
+    let prevType = 0n;
+
+    for (let i = 0; i < count; i++) {
+      const delta = await this.r.u62();
+      const paramType = prevType + delta;
+      prevType = paramType;
+
+      if (paramType % 2n === 0n) {
+        const value = await this.r.u62();
+        params.push({ type: paramType, value });
+      } else {
+        const length = await this.r.u53();
+        const value = await this.r.read(length);
+        params.push({ type: paramType, value });
+      }
+    }
+    return params;
+  }
+
+  /** Read params using the appropriate decoding for the current version */
+  private async readParams(): Promise<KeyValuePair[]> {
+    if (isDraft16(this.version)) {
+      return this.deltaKeyValuePairs();
+    }
+    return this.r.keyValuePairs();
+  }
+
+  /** Helper: find a varint param value by type key */
+  private findParamVarInt(
+    params: KeyValuePair[],
+    key: bigint,
+    defaultValue: bigint,
+  ): bigint {
+    const p = params.find((p) => p.type === key);
+    if (p && typeof p.value === "bigint") {
+      return p.value;
+    }
+    return defaultValue;
+  }
+
+  /** Helper: find a bytes param value by type key */
+  private findParamBytes(
+    params: KeyValuePair[],
+    key: bigint,
+  ): Uint8Array | undefined {
+    const p = params.find((p) => p.type === key);
+    if (p && p.value instanceof Uint8Array) {
+      return p.value;
+    }
+    return undefined;
+  }
+
   private async subscribe_ok(): Promise<SubscribeOk> {
     controlLogger.debug("Parsing SubscribeOk message...");
     const requestId = await this.r.u62();
     controlLogger.debug(`Request ID: ${requestId}`);
 
-    // draft-14: trackAlias is now in SUBSCRIBE_OK (assigned by publisher)
     const trackAlias = await this.r.u62();
     controlLogger.debug(`Track Alias: ${trackAlias}`);
 
+    if (isDraft16(this.version)) {
+      // Draft-16: fields are in parameters, followed by track extensions
+      const params = await this.deltaKeyValuePairs();
+
+      const expires = this.findParamVarInt(params, PARAM_EXPIRES, 0n);
+      const groupOrderVal = this.findParamVarInt(params, PARAM_GROUP_ORDER, 0n);
+      const group_order = this.parseGroupOrder(Number(groupOrderVal));
+      const largestBytes = this.findParamBytes(params, PARAM_LARGEST_OBJECT);
+
+      let content_exists = false;
+      let largest: Location | undefined;
+      if (largestBytes && largestBytes.length > 0) {
+        content_exists = true;
+        largest = this.parseLocationFromBytes(largestBytes);
+        controlLogger.debug(
+          `Largest: group ${largest.group}, object ${largest.object}`,
+        );
+      }
+
+      // TODO: read track extensions (currently skip any remaining bytes)
+
+      return {
+        kind: Msg.SubscribeOk,
+        requestId,
+        trackAlias,
+        expires,
+        group_order,
+        content_exists,
+        largest,
+        params,
+      };
+    }
+
+    // Draft-14: inline fields
     const expires = await this.r.u62();
     controlLogger.debug(`Expires: ${expires}`);
 
@@ -550,24 +649,97 @@ export class Decoder {
     };
   }
 
+  /** Parse a GroupOrder value from a number (used by both draft-14 and draft-16) */
+  private parseGroupOrder(orderCode: number): GroupOrder {
+    switch (orderCode) {
+      case 0:
+        return GroupOrder.Publisher;
+      case 1:
+        return GroupOrder.Ascending;
+      case 2:
+        return GroupOrder.Descending;
+      default:
+        controlLogger.warn(
+          `Unknown GroupOrder value: ${orderCode}, using Publisher`,
+        );
+        return GroupOrder.Publisher;
+    }
+  }
+
+  /** Parse a Location from raw bytes (for draft-16 parameter values) */
+  private parseLocationFromBytes(bytes: Uint8Array): Location {
+    // Decode two varints from the byte array
+    let offset = 0;
+    const { value: group, bytesRead: gb } = this.decodeVarIntFromBytes(
+      bytes,
+      offset,
+    );
+    offset += gb;
+    const { value: object } = this.decodeVarIntFromBytes(bytes, offset);
+    return { group, object };
+  }
+
+  /** Decode a QUIC varint from a byte array at a given offset */
+  private decodeVarIntFromBytes(
+    bytes: Uint8Array,
+    offset: number,
+  ): { value: bigint; bytesRead: number } {
+    const first = bytes[offset];
+    const prefix = first >> 6;
+    let length: number;
+    switch (prefix) {
+      case 0:
+        length = 1;
+        break;
+      case 1:
+        length = 2;
+        break;
+      case 2:
+        length = 4;
+        break;
+      case 3:
+        length = 8;
+        break;
+      default:
+        throw new Error(`Invalid varint prefix: ${prefix}`);
+    }
+    let value = BigInt(first & 0x3f);
+    for (let i = 1; i < length; i++) {
+      value = (value << 8n) | BigInt(bytes[offset + i]);
+    }
+    return { value, bytesRead: length };
+  }
+
   private async subscribe_error(): Promise<SubscribeError> {
-    controlLogger.debug("Parsing SubscribeError message...");
+    controlLogger.debug("Parsing SubscribeError / REQUEST_ERROR message...");
     const requestId = await this.r.u62();
-    controlLogger.debug(`Subscribe ID: ${requestId}`);
+    controlLogger.debug(`Request ID: ${requestId}`);
 
     const code = await this.r.u62();
     controlLogger.debug(`Code: ${code}`);
 
+    let retryInterval: bigint | undefined;
+    if (isDraft16(this.version)) {
+      // Draft-16 REQUEST_ERROR: includes retryInterval
+      retryInterval = await this.r.u62();
+      controlLogger.debug(`Retry interval: ${retryInterval}`);
+    }
+
     const reason = await this.r.string();
     controlLogger.debug(`Reason: ${reason}`);
 
-    const trackAlias = await this.r.u62();
-    controlLogger.debug(`Track Alias: ${trackAlias}`);
+    let trackAlias: bigint | undefined;
+    if (!isDraft16(this.version)) {
+      // Draft-14 only: trackAlias after reason
+      trackAlias = await this.r.u62();
+      controlLogger.debug(`Track Alias: ${trackAlias}`);
+    }
 
     return {
       kind: Msg.SubscribeError,
       requestId,
       code,
+      retryInterval,
       reason,
       trackAlias,
     };
@@ -598,9 +770,15 @@ export class Decoder {
   }
 
   private async fetch_error(): Promise<FetchError> {
-    controlLogger.debug("Parsing FetchError message...");
+    controlLogger.debug("Parsing FetchError / REQUEST_ERROR message...");
     const requestId = await this.r.u62();
     const code = await this.r.u62();
+
+    let retryInterval: bigint | undefined;
+    if (isDraft16(this.version)) {
+      retryInterval = await this.r.u62();
+    }
+
     const reason = await this.r.string();
 
     controlLogger.debug(
@@ -611,6 +789,7 @@ export class Decoder {
       kind: Msg.FetchError,
       requestId,
       code,
+      retryInterval,
       reason,
     };
   }
@@ -658,7 +837,7 @@ export class Decoder {
     const namespace = await this.r.tuple();
     controlLogger.debug(`Namespace: ${namespace.join("/")}`);
 
-    const params = await this.r.keyValuePairs();
+    const params = await this.readParams();
     controlLogger.debug(`Parameters: ${params.length}`);
 
     return {
@@ -670,10 +849,22 @@ export class Decoder {
   }
 
   private async publish_namespace_ok(): Promise<PublishNamespaceOk> {
-    controlLogger.debug("Parsing PublishNamespaceOk message...");
+    controlLogger.debug("Parsing PublishNamespaceOk / REQUEST_OK message...");
     const requestId = await this.r.u62();
     controlLogger.debug(`Request ID: ${requestId}`);
 
+    if (isDraft16(this.version)) {
+      // Draft-16 REQUEST_OK: includes parameters (no namespace)
+      const params = await this.deltaKeyValuePairs();
+      controlLogger.debug(`Parameters: ${params.length}`);
+
+      return {
+        kind: Msg.PublishNamespaceOk,
+        requestId,
+      };
+    }
+
+    // Draft-14: includes namespace
     const namespace = await this.r.tuple();
     controlLogger.debug(`Namespace: ${namespace.join("/")}`);
 
@@ -685,12 +876,20 @@ export class Decoder {
   }
 
   private async publish_namespace_error(): Promise<PublishNamespaceError> {
-    controlLogger.debug("Parsing PublishNamespaceError message...");
+    controlLogger.debug(
+      "Parsing PublishNamespaceError / REQUEST_ERROR message...",
+    );
     const requestId = await this.r.u62();
     controlLogger.debug(`Request ID: ${requestId}`);
 
     const code = await this.r.u62();
     controlLogger.debug(`Error code: ${code}`);
+
+    if (isDraft16(this.version)) {
+      // Draft-16: retryInterval before reason
+      const retryInterval = await this.r.u62();
+      controlLogger.debug(`Retry interval: ${retryInterval}`);
+    }
 
     const reason = await this.r.string();
     controlLogger.debug(`Error reason: ${reason}`);
@@ -730,16 +929,17 @@ export class Decoder {
 
 export class Encoder {
   w: Writer;
+  private version: Version;
 
-  constructor(w: Writer) {
+  constructor(w: Writer, version: Version = Version.DRAFT_14) {
     this.w = w;
+    this.version = version;
   }
 
   async message(msg: Message): Promise<void> {
     controlLogger.debug(`Encoding message of type: ${msg.kind}`);
 
-    // Create a BufferCtrlWriter to marshal the message
-    const writer = new BufferCtrlWriter();
+    const writer = new BufferCtrlWriter(this.version);
 
     // Marshal the message based on its type
     switch (msg.kind) {

--- a/src/transport/setup.ts
+++ b/src/transport/setup.ts
@@ -2,16 +2,20 @@ import { ILogger, LoggerFactory } from "../logger";
 
 import { BufferCtrlWriter } from "./bufferctrlwriter";
 import { KeyValuePair, Reader, Writer } from "./stream";
+import { Version, isDraft16 } from "./version";
+
+// Re-export version types for existing consumers
+export {
+  Version,
+  isDraft16,
+  PROTOCOL_DRAFT_14,
+  PROTOCOL_DRAFT_16,
+} from "./version";
 
 // Logger for setup message operations
 const setupLogger: ILogger = LoggerFactory.getInstance().getLogger("Setup");
 
 export type Message = Client | Server;
-
-export enum Version {
-  DRAFT_11 = 0xff00000b,
-  DRAFT_14 = 0xff00000e,
-}
 
 enum SetupType {
   Client = 0x20,
@@ -32,9 +36,9 @@ export class Stream {
   recv: Decoder;
   send: Encoder;
 
-  constructor(r: Reader, w: Writer) {
-    this.recv = new Decoder(r);
-    this.send = new Encoder(w);
+  constructor(r: Reader, w: Writer, version: Version = Version.DRAFT_14) {
+    this.recv = new Decoder(r, version);
+    this.send = new Encoder(w, version);
   }
 }
 
@@ -42,9 +46,11 @@ export type Parameters = KeyValuePair[];
 
 export class Decoder {
   r: Reader;
+  private version: Version;
 
-  constructor(r: Reader) {
+  constructor(r: Reader, version: Version = Version.DRAFT_14) {
     this.r = r;
+    this.version = version;
   }
 
   async client(): Promise<Client> {
@@ -67,39 +73,33 @@ export class Decoder {
     const messageLength = (lengthBytes[0] << 8) | lengthBytes[1]; // MSB format
     setupLogger.debug(`Message length (16-bit MSB): ${messageLength} bytes`);
 
-    const count = await this.r.u53();
-    setupLogger.debug(`Number of supported versions: ${count}`);
+    const versions: number[] = [];
+    if (!isDraft16(this.version)) {
+      // Draft-14: version list is in the message
+      const count = await this.r.u53();
+      setupLogger.debug(`Number of supported versions: ${count}`);
 
-    const versions = [];
-    for (let i = 0; i < count; i++) {
-      const version = await this.r.u53();
-      versions.push(version);
+      for (let i = 0; i < count; i++) {
+        const version = await this.r.u53();
+        versions.push(version);
+        setupLogger.debug(
+          `Supported version ${i + 1}: 0x${version.toString(16)}`,
+        );
+      }
+    } else {
       setupLogger.debug(
-        `Supported version ${i + 1}: 0x${version.toString(16)}`,
+        "Draft-16: version negotiated via protocol, not in SETUP",
       );
     }
 
-    const params = await this.parameters();
+    const params = isDraft16(this.version)
+      ? await this.deltaParameters()
+      : await this.parameters();
     setupLogger.debug(
       `Parameters: ${params ? `${params.length} parameters` : "none"}`,
     );
 
-    // Log each parameter in detail
-    if (params && params.length > 0) {
-      params.forEach((param) => {
-        if (typeof param.value === "bigint") {
-          setupLogger.debug(
-            `Parameter ID: ${param.type}, value: ${param.value} (bigint)`,
-          );
-        } else {
-          setupLogger.debug(
-            `Parameter ID: ${param.type}, length: ${
-              param.value.byteLength
-            } bytes, value: ${this.formatBytes(param.value)}`,
-          );
-        }
-      });
-    }
+    this.logParameters(params);
 
     const result = {
       versions,
@@ -134,30 +134,27 @@ export class Decoder {
     // Store the current position to validate length later
     const startPosition = this.r.getByteLength();
 
-    const version = await this.r.u53();
-    setupLogger.debug(`Server selected version: 0x${version.toString(16)}`);
+    let version: number;
+    if (!isDraft16(this.version)) {
+      // Draft-14: selected version is in the message
+      version = await this.r.u53();
+      setupLogger.debug(`Server selected version: 0x${version.toString(16)}`);
+    } else {
+      // Draft-16: version already negotiated via protocol
+      version = this.version;
+      setupLogger.debug(
+        `Draft-16: using protocol-negotiated version 0x${version.toString(16)}`,
+      );
+    }
 
-    const params = await this.parameters();
+    const params = isDraft16(this.version)
+      ? await this.deltaParameters()
+      : await this.parameters();
     setupLogger.debug(
       `Parameters: ${params ? `${params.length} parameters` : "none"}`,
     );
 
-    // Log each parameter in detail
-    if (params && params.length > 0) {
-      params.forEach((param) => {
-        if (typeof param.value === "bigint") {
-          setupLogger.debug(
-            `Parameter ID: ${param.type}, value: ${param.value} (bigint)`,
-          );
-        } else {
-          setupLogger.debug(
-            `Parameter ID: ${param.type}, length: ${
-              param.value.byteLength
-            } bytes, value: ${this.formatBytes(param.value)}`,
-          );
-        }
-      });
-    }
+    this.logParameters(params);
 
     // Validate that we read the expected number of bytes
     const endPosition = this.r.getByteLength();
@@ -176,6 +173,24 @@ export class Decoder {
 
     setupLogger.debug("Server setup message decoded:", result);
     return result;
+  }
+
+  private logParameters(params: Parameters | undefined): void {
+    if (params && params.length > 0) {
+      params.forEach((param) => {
+        if (typeof param.value === "bigint") {
+          setupLogger.debug(
+            `Parameter ID: ${param.type}, value: ${param.value} (bigint)`,
+          );
+        } else {
+          setupLogger.debug(
+            `Parameter ID: ${param.type}, length: ${
+              param.value.byteLength
+            } bytes, value: ${this.formatBytes(param.value)}`,
+          );
+        }
+      });
+    }
   }
 
   private formatBytes(bytes: Uint8Array): string {
@@ -276,32 +291,78 @@ export class Decoder {
 
     return params;
   }
+
+  /** Draft-16: decode delta-encoded parameters */
+  private async deltaParameters(): Promise<Parameters | undefined> {
+    const countResult = await this.r.u53WithSize();
+    const count = countResult.value;
+
+    setupLogger.debug(
+      `Delta parameter count: ${count}, count field: ${countResult.bytesRead} bytes`,
+    );
+
+    if (count === 0) {
+      return undefined;
+    }
+
+    const params: Parameters = [];
+    let prevType = 0n;
+
+    for (let i = 0; i < count; i++) {
+      // Read delta type
+      const delta = await this.r.u62();
+      const paramType = prevType + delta;
+      prevType = paramType;
+
+      const isEven = paramType % 2n === 0n;
+
+      if (isEven) {
+        const value = await this.r.u62();
+        setupLogger.debug(
+          `Delta parameter ${i + 1}/${count}: Type ${paramType} (delta ${delta}, even), Value: ${value}`,
+        );
+        params.push({ type: paramType, value });
+      } else {
+        const length = await this.r.u53();
+        if (length > 65535) {
+          throw new Error(
+            `Parameter value length exceeds maximum: ${length} > 65535`,
+          );
+        }
+        const value = await this.r.read(length);
+        setupLogger.debug(
+          `Delta parameter ${i + 1}/${count}: Type ${paramType} (delta ${delta}, odd), Length: ${length}`,
+        );
+        params.push({ type: paramType, value });
+      }
+    }
+
+    return params;
+  }
 }
 
 export class Encoder {
   w: Writer;
+  private version: Version;
 
-  constructor(w: Writer) {
+  constructor(w: Writer, version: Version = Version.DRAFT_14) {
     this.w = w;
+    this.version = version;
   }
 
   async client(c: Client): Promise<void> {
     setupLogger.debug("Encoding client setup message:", c);
 
-    // Create a BufferCtrlWriter instance
-    const writer = new BufferCtrlWriter();
+    const writer = new BufferCtrlWriter(this.version);
 
-    // Marshal the client setup message
     writer.marshalClientSetup({
       versions: c.versions,
       params: c.params,
     });
 
-    // Get the bytes from the writer
     const bytes = writer.getBytes();
     setupLogger.debug(`Client setup message created: ${bytes.length} bytes`);
 
-    // Write the entire message in a single operation
     await this.w.write(bytes);
 
     setupLogger.debug("Client setup message sent successfully");
@@ -310,20 +371,16 @@ export class Encoder {
   async server(s: Server): Promise<void> {
     setupLogger.debug("Encoding server setup message:", s);
 
-    // Create a BufferCtrlWriter instance
-    const writer = new BufferCtrlWriter();
+    const writer = new BufferCtrlWriter(this.version);
 
-    // Marshal the server setup message
     writer.marshalServerSetup({
       version: s.version,
       params: s.params,
     });
 
-    // Get the bytes from the writer
     const bytes = writer.getBytes();
     setupLogger.debug(`Server setup message created: ${bytes.length} bytes`);
 
-    // Write the entire message in a single operation
     await this.w.write(bytes);
 
     setupLogger.debug("Server setup message sent successfully");

--- a/src/transport/tracks.ts
+++ b/src/transport/tracks.ts
@@ -19,9 +19,21 @@ import { TrackAliasRegistry } from "./trackaliasregistry";
 
 // Bigint versions of stream types for comparison
 const FETCH_HEADER_BIGINT = 0x05n;
-// Draft-14 SUBGROUP_HEADER stream types: 0x10-0x15 (without EOG), 0x18-0x1D (with EOG)
-const SUBGROUP_HEADER_MIN_BIGINT = 0x10n;
-const SUBGROUP_HEADER_MAX_BIGINT = 0x1dn;
+
+/** Check if a stream type is a valid SUBGROUP_HEADER type.
+ * Draft-14: 0x10-0x15, 0x18-0x1D
+ * Draft-16: adds 0x30-0x35, 0x38-0x3D (with DEFAULT_PRIORITY bit 0x20)
+ */
+function isSubgroupStreamType(streamType: bigint): boolean {
+  // Strip the DEFAULT_PRIORITY bit (0x20) to normalize
+  const low = streamType & 0x1fn;
+  return (low >= 0x10n && low <= 0x15n) || (low >= 0x18n && low <= 0x1dn);
+}
+
+/** Draft-16: returns true when the DEFAULT_PRIORITY bit (0x20) is set */
+function hasDefaultPriority(streamType: bigint): boolean {
+  return (streamType & 0x20n) !== 0n;
+}
 
 // Object received in a data stream
 export interface MOQObject {
@@ -118,12 +130,10 @@ export class TracksManager {
       const streamType = await reader.u62();
       this.logger.debug(`Incoming Unidirectional Stream. Type: ${streamType}`);
 
-      // Check if this is a SUBGROUP_HEADER stream (draft-14: 0x10-0x15, 0x18-0x1D)
-      const isSubgroup =
-        streamType >= SUBGROUP_HEADER_MIN_BIGINT &&
-        streamType <= SUBGROUP_HEADER_MAX_BIGINT &&
-        !(streamType >= 0x16n && streamType <= 0x17n); // gap: 0x16-0x17 are not valid
-      if (isSubgroup) {
+      // Check if this is a SUBGROUP_HEADER stream
+      // Draft-14: 0x10-0x15, 0x18-0x1D
+      // Draft-16: adds 0x30-0x35, 0x38-0x3D (DEFAULT_PRIORITY bit)
+      if (isSubgroupStreamType(streamType)) {
         await this.handleSubgroupStream(reader, streamType);
       } else if (streamType === FETCH_HEADER_BIGINT) {
         await this.handleFetchStream(reader);
@@ -155,31 +165,38 @@ export class TracksManager {
       const groupId = await reader.u62();
       this.logger.debug(`Track alias: ${trackAlias} Group ID: ${groupId}`);
 
-      // Determine subgroup ID based on the stream type (draft-14)
-      // Stream types 0x10-0x15 (no EOG) and 0x18-0x1D (with EOG)
+      // Determine subgroup ID based on the stream type
+      // Strip the DEFAULT_PRIORITY bit (0x20) to get the base type for SID mode
       // Bit 0: has extensions, Bits 1-2: SID mode (00=zero, 01=firstObjID, 10=explicit)
-      // Bit 3: contains End of Group
+      // Bit 3: contains End of Group, Bit 5: DEFAULT_PRIORITY (draft-16)
       let subgroupId: bigint | null = null;
-      const hasExtensions = (streamType & 0x01n) === 0x01n; // odd types have extensions
-      // Strip the high nibble and EOG bit to get the base SID mode from lower 3 bits
-      const baseType = streamType & 0x07n;
+      const normalizedType = streamType & 0x1fn; // strip DEFAULT_PRIORITY bit
+      const hasExtensions = (normalizedType & 0x01n) === 0x01n;
+      const baseType = normalizedType & 0x07n;
 
       if (baseType === 0x00n || baseType === 0x01n) {
-        // ZeroSID: 0x10, 0x11, 0x18, 0x19 - Subgroup ID is implicitly 0
+        // ZeroSID: Subgroup ID is implicitly 0
         subgroupId = 0n;
         this.logger.debug(`Subgroup ID: ${subgroupId} (implicit zero)`);
       } else if (baseType === 0x02n || baseType === 0x03n) {
-        // NoSID: 0x12, 0x13, 0x1A, 0x1B - Subgroup ID is the first Object ID
+        // NoSID: Subgroup ID is the first Object ID
         this.logger.debug("Subgroup ID will be set to the first Object ID");
       } else if (baseType === 0x04n || baseType === 0x05n) {
-        // ExplicitSID: 0x14, 0x15, 0x1C, 0x1D - Subgroup ID is explicitly provided
+        // ExplicitSID: Subgroup ID is explicitly provided
         subgroupId = await reader.u62();
         this.logger.debug(`Subgroup ID: ${subgroupId} (explicit)`);
       }
 
-      // Read the Publisher Priority (as specified in the SUBGROUP_HEADER format)
-      const publisherPriority = await reader.u8();
-      this.logger.debug(`Publisher Priority: ${publisherPriority}`);
+      // Read Publisher Priority unless DEFAULT_PRIORITY bit is set (draft-16)
+      let publisherPriority = 0;
+      if (hasDefaultPriority(streamType)) {
+        this.logger.debug(
+          "Publisher Priority: default (omitted, DEFAULT_PRIORITY bit set)",
+        );
+      } else {
+        publisherPriority = await reader.u8();
+        this.logger.debug(`Publisher Priority: ${publisherPriority}`);
+      }
 
       // Buffer for objects while waiting for track registration
       const bufferedObjects: MOQObject[] = [];

--- a/src/transport/version.ts
+++ b/src/transport/version.ts
@@ -1,0 +1,15 @@
+/** MOQ Transport protocol version constants */
+export enum Version {
+  DRAFT_11 = 0xff00000b,
+  DRAFT_14 = 0xff00000e,
+  DRAFT_16 = 0xff000010,
+}
+
+/** WebTransport protocol strings for version negotiation */
+export const PROTOCOL_DRAFT_14 = "moq-00";
+export const PROTOCOL_DRAFT_16 = "moqt-16";
+
+/** Draft-16+ uses ALPN/protocol negotiation instead of in-band SETUP version fields */
+export function isDraft16(v: Version | number): boolean {
+  return v >= Version.DRAFT_16;
+}


### PR DESCRIPTION
## Summary

- Add MOQ Transport draft-16 wire protocol support alongside existing draft-14
- Version negotiation via WebTransport `protocols` option (`moqt-16` / `moq-00`)
- Draft-16 wire format: delta-encoded parameters, SUBSCRIBE/SUBSCRIBE_OK fields moved to params, REQUEST_ERROR with retryInterval, SUBGROUP_HEADER DEFAULT_PRIORITY bit
- Protocol version selector in UI (Auto / Draft 14 / Draft 16)
- Non-media namespaces (e.g. `moq-test/interop`) shown as secondary, struck-through text
- Updated README and CLAUDE.md documentation

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 31/31 tests pass
- [x] `npm run build` — production build succeeds
- [x] Tested draft-16 connection against local moqlivemock (draft-16 branch): WebTransport protocol negotiation, SETUP, PUBLISH_NAMESPACE, SUBSCRIBE, catalog reception all working
- [x] Test draft-14 fallback against a draft-14-only server
- [x] Test against moqlivemock.demo.osaas.io after deployment