### PR TITLE
feat: add ManagedMediaSource support for iOS Safari playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {

--- a/src/buffer/mediaSegmentBuffer.ts
+++ b/src/buffer/mediaSegmentBuffer.ts
@@ -33,7 +33,7 @@ export class MediaSegmentBuffer {
   private initSegment: MediaSegment | null = null;
   private pendingSegments: MediaSegment[] = [];
   private isAppending: boolean = false;
-  private sourceBuffer: SourceBuffer | null = null;
+  private sourceBuffer: SourceBuffer | ManagedSourceBuffer | null = null;
   private mediaType: "video" | "audio" | "unknown" = "unknown";
   private logger: ILogger;
 
@@ -251,7 +251,9 @@ export class MediaSegmentBuffer {
    * Set the source buffer to use for appending segments
    * @param sourceBuffer The SourceBuffer instance to use
    */
-  public setSourceBuffer(sourceBuffer: SourceBuffer): void {
+  public setSourceBuffer(
+    sourceBuffer: SourceBuffer | ManagedSourceBuffer,
+  ): void {
     this.sourceBuffer = sourceBuffer;
 
     // Add event listeners to the source buffer

--- a/src/index.html
+++ b/src/index.html
@@ -673,7 +673,7 @@
 
       <!-- Video Player Section -->
       <div class="player-section">
-        <video id="videoPlayer" controls muted></video>
+        <video id="videoPlayer" controls muted playsinline></video>
         <div class="controls-section">
           <button id="startBtn" class="btn btn-primary" disabled>
             <span>▶</span> Start

--- a/src/player.ts
+++ b/src/player.ts
@@ -41,7 +41,8 @@ export class Player {
   private draftVersion: DraftVersion = "auto";
 
   // Shared media elements for synchronized playback
-  private sharedMediaSource: MediaSource | null = null;
+  private sharedMediaSource: MediaSource | ManagedMediaSource | null = null;
+  private usingManagedMediaSource = false;
   private videoSourceBuffer: SourceBuffer | null = null;
   private audioSourceBuffer: SourceBuffer | null = null;
   private videoMediaSegmentBuffer: MediaSegmentBuffer | null = null;
@@ -1079,6 +1080,7 @@ export class Player {
     this.videoMediaBuffer = null;
     this.audioMediaBuffer = null;
     this.sharedMediaSource = null;
+    this.usingManagedMediaSource = false;
 
     // Reset error handling state
     this.recoveryInProgress = false;
@@ -2659,7 +2661,7 @@ export class Player {
     initData: ArrayBuffer,
     mediaBuffer: MediaBuffer,
     mediaSegmentBuffer: MediaSegmentBuffer,
-    sourceBuffer: SourceBuffer,
+    sourceBuffer: SourceBuffer | ManagedSourceBuffer,
     type: string,
   ): void {
     this.logger.info(`[${type}MediaBuffer] Processing init segment`);
@@ -2696,11 +2698,31 @@ export class Player {
     // Reset previous source if any
     videoEl.pause();
     videoEl.removeAttribute("src");
+    videoEl.srcObject = null;
     videoEl.load();
 
-    // Create and store the shared MediaSource
-    this.sharedMediaSource = new MediaSource();
-    videoEl.src = URL.createObjectURL(this.sharedMediaSource);
+    // Create the appropriate MediaSource implementation.
+    // iOS Safari does not support MediaSource but provides ManagedMediaSource
+    // (Safari 17+). ManagedMediaSource must be attached via srcObject.
+    if (
+      typeof ManagedMediaSource !== "undefined" &&
+      typeof MediaSource === "undefined"
+    ) {
+      this.sharedMediaSource = new ManagedMediaSource();
+      this.usingManagedMediaSource = true;
+      videoEl.disableRemotePlayback = true;
+      // ManagedMediaSource is a valid MediaProvider in Safari, but our type
+      // declaration doesn't extend MediaSource (the APIs differ), so we cast.
+      videoEl.srcObject = this.sharedMediaSource as unknown as MediaSource;
+      this.logger.info(
+        "[SharedMediaSource] Using ManagedMediaSource (iOS/Safari)",
+      );
+    } else {
+      this.sharedMediaSource = new MediaSource();
+      this.usingManagedMediaSource = false;
+      videoEl.src = URL.createObjectURL(this.sharedMediaSource);
+      this.logger.info("[SharedMediaSource] Using standard MediaSource");
+    }
 
     // Create and store media segment buffers for video
     this.videoMediaSegmentBuffer = new MediaSegmentBuffer({
@@ -3243,10 +3265,14 @@ export class Player {
       return;
     }
 
-    // Check if MediaSource is already open (from video setup)
-    if (!videoEl.src || !videoEl.src.startsWith("blob:")) {
+    // Check if MediaSource is already set up (from video setup).
+    // Standard MediaSource uses a blob: URL, ManagedMediaSource uses srcObject.
+    const mediaSourceAttached = this.usingManagedMediaSource
+      ? videoEl.srcObject !== null
+      : videoEl.src && videoEl.src.startsWith("blob:");
+    if (!mediaSourceAttached) {
       this.logger.info(
-        "MediaSource not set up yet (no blob URL). Audio setup should happen after video setup.",
+        "MediaSource not set up yet. Audio setup should happen after video setup.",
       );
       return;
     }

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,1 +1,48 @@
 declare const __APP_VERSION__: string;
+
+/**
+ * ManagedMediaSource API — available in Safari 17+ (including iOS).
+ * On iOS, standard MediaSource is not available; ManagedMediaSource is the
+ * only path to MSE playback.
+ *
+ * Attach via `video.srcObject = mms` (not URL.createObjectURL).
+ */
+// ManagedSourceBuffer extends SourceBuffer. The browser adds a `bufferedchange`
+// event but we model only what we use here.
+type ManagedSourceBuffer = SourceBuffer;
+
+interface ManagedMediaSource extends EventTarget {
+  readonly readyState: "closed" | "open" | "ended";
+  readonly sourceBuffers: SourceBufferList;
+  readonly activeSourceBuffers: SourceBufferList;
+  duration: number;
+
+  addSourceBuffer(type: string): ManagedSourceBuffer;
+  removeSourceBuffer(sourceBuffer: SourceBuffer): void;
+  endOfStream(error?: EndOfStreamError): void;
+
+  // Standard MediaSource events
+  onstartstreaming: ((this: ManagedMediaSource, ev: Event) => void) | null;
+  onendstreaming: ((this: ManagedMediaSource, ev: Event) => void) | null;
+  onsourceopen: ((this: ManagedMediaSource, ev: Event) => void) | null;
+  onsourceended: ((this: ManagedMediaSource, ev: Event) => void) | null;
+  onsourceclose: ((this: ManagedMediaSource, ev: Event) => void) | null;
+
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
+// eslint-disable-next-line no-var -- ambient declarations require `var` (standard TS pattern)
+declare var ManagedMediaSource: {
+  prototype: ManagedMediaSource;
+  new (): ManagedMediaSource;
+  isTypeSupported(type: string): boolean;
+};


### PR DESCRIPTION
## Summary
- Add ManagedMediaSource/ManagedSourceBuffer support for iOS Safari (Safari 17+), where standard MediaSource is unavailable
- Use `srcObject` attachment instead of `URL.createObjectURL` when ManagedMediaSource is detected
- Add `playsinline` attribute to the video element so iOS keeps playback inline instead of entering fullscreen
- Bump version to 0.7.1

## Test plan
- [x] Verify playback works on desktop browsers (Chrome, Firefox, Edge) — standard MediaSource path unchanged
- [x] Verify playback works on iOS Safari 17+ using ManagedMediaSource
- [x] Verify video stays inline on iOS (not fullscreen)
- [x] Verify audio+video sync still works on both paths