### PR TITLE
feat: add WebCodecs LOC render engine alongside MSE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,22 @@ These ensure code quality before changes are pushed to the repository.
 ## Project Overview
 
 WARP Player is a browser-based TypeScript implementation of a media player,
-using MOQ transport protocol via WebTransport.
-It uses the MSF/CMSF catalog format (draft-ietf-moq-msf-00 / draft-ietf-moq-cmsf-00)
-to fetch a catalog with media tracks.
-The actual media playback is done using MSE, and the media container is CMAF.
-This player allows browsers to connect to MOQ servers, subscribe to media tracks, and receive media segments over WebTransport.
+using the MOQ Transport protocol via WebTransport. It supports MOQ Transport
+draft-14 and draft-16 (negotiated through WebTransport ALPN, can be forced
+from the UI) and uses the MSF/CMSF catalog format
+(draft-ietf-moq-msf-00 / draft-ietf-moq-cmsf-00) to discover media tracks.
+
+Playback runs through one of two interchangeable render pipelines selected
+per session:
+
+- **MSE / CMAF** for `packaging: "cmaf"` tracks, with optional EME for
+  encrypted content (Widevine, PlayReady, FairPlay, ClearKey).
+- **WebCodecs / LOC** for `packaging: "loc"` tracks (draft-mzanaty-moq-loc),
+  clear content only, supporting AVC and HEVC video plus AAC and Opus audio.
+
+Both pipelines implement a common `IPlaybackPipeline` interface so the
+buffer-control loop, latency reporting, mute toggle, and namespace selector
+work uniformly regardless of which engine is active.
 
 ### Project Structure
 
@@ -68,15 +79,27 @@ The project follows the Eyevinn TypeScript project template structure:
 ```
 warp-player/
 ├── src/
-│   ├── transport/        # MOQ protocol implementation
+│   ├── transport/        # MOQ protocol implementation (draft-14 / draft-16)
 │   │   ├── client.ts     # WebTransport client implementation
 │   │   ├── setup.ts      # Setup message handling
 │   │   ├── tracks.ts     # Track subscription and management
-│   │   └── control.ts    # Control stream handling
-│   ├── buffer/           # Media buffering components
+│   │   ├── control.ts    # Control stream handling
+│   │   └── version.ts    # Draft version constants and ALPN strings
+│   ├── buffer/           # CMAF segment buffering for the MSE pipeline
 │   │   ├── mediaBuffer.ts         # CMAF segment parsing
 │   │   └── mediaSegmentBuffer.ts  # Buffer management for MSE
-│   ├── player.ts         # Core player implementation with MSE integration
+│   ├── loc/              # LOC payload helpers for the WebCodecs pipeline
+│   │   ├── avc.ts        # AVC NALU walker, AVCDecoderConfigurationRecord
+│   │   ├── hevc.ts       # HEVC NALU walker, HEVCDecoderConfigurationRecord
+│   │   ├── aac.ts        # AAC AudioSpecificConfig from catalog metadata
+│   │   ├── opus.ts       # Opus ID-header (OpusHead) builder
+│   │   └── extensions.ts # LOC extension-header parsing (capture timestamps)
+│   ├── pipeline/         # Pluggable render pipelines
+│   │   ├── index.ts                # IPlaybackPipeline + capability matrix
+│   │   ├── msePipeline.ts          # MSE/CMAF pipeline (with optional EME)
+│   │   └── webcodecsLocPipeline.ts # WebCodecs/LOC pipeline (clear only)
+│   ├── warpcatalog.ts    # MSF/CMSF catalog types and parsing
+│   ├── player.ts         # Core player: catalog → tracks → pipeline
 │   ├── browser.ts        # Browser entry point and UI handling
 │   └── index.html        # HTML template and UI components
 ├── FINGERPRINT.md        # Documentation for fingerprint feature
@@ -94,10 +117,12 @@ warp-player/
 
 ### Core Architecture
 
-The transport used is MOQ Transport, currently draft-14.
+The transport used is MOQ Transport, draft-14 or draft-16 (auto-negotiated
+via WebTransport ALPN strings `moq-00` and `moqt-16`).
 
 For the catalog, the specification used is MSF (draft-ietf-moq-msf-00)
-with CMSF (draft-ietf-moq-cmsf-00) for CMAF packaging.
+with CMSF (draft-ietf-moq-cmsf-00) for CMAF packaging. LOC packaging
+follows draft-mzanaty-moq-loc.
 
 The codebase is organized into several key modules:
 
@@ -107,22 +132,56 @@ The codebase is organized into several key modules:
    - Manages bidirectional control streams and unidirectional data streams
    - Implements client-server setup messaging, track subscription, and data reception
 
-2. **Buffer Layer**:
+2. **Catalog Layer**:
+   - Located in `src/warpcatalog.ts`
+   - Parses MSF/CMSF catalogs, including delta updates, content protection,
+     and namespace inheritance for tracks that omit an explicit namespace
+
+3. **Buffer Layer (MSE)**:
    - Located in `src/buffer/`
    - Processes incoming media segments (CMAF format)
    - Parses segments and extracts timing information
-   - Manages buffering of media segments for playback
+   - Manages buffering of media segments for the MSE `SourceBuffer`
 
-3. **Player Integration**:
+4. **LOC Layer (WebCodecs)**:
+   - Located in `src/loc/`
+   - Walks length-prefixed NALUs for AVC/HEVC and synthesizes
+     `VideoDecoderConfig.description` (avcC / hvcC) on parameter-set changes
+   - Synthesizes `AudioDecoderConfig.description` for AAC (AudioSpecificConfig)
+     and Opus (OpusHead) from catalog metadata
+   - Parses MoQ Object extension headers to extract LOC capture timestamps
+
+5. **Pipeline Layer**:
+   - Located in `src/pipeline/`
+   - Defines `IPlaybackPipeline` (`engine`, `setup`, `routeObject`,
+     `getLatencySnapshot`, `setBufferConfig`, `setPlaybackRate`,
+     `setMuted`, `dispose`) — the common surface used by `player.ts`
+   - `MsePipeline` owns the `MediaSource`, `SourceBuffer`s, and (eventually)
+     `MediaKeys` / EME state for CMAF tracks
+   - `WebCodecsLocPipeline` owns the `VideoDecoder` / `AudioDecoder`,
+     a canvas overlay on the `<video>` element, and a wallclock-anchored
+     `requestAnimationFrame` render loop synchronized with a single
+     `AudioContext` schedule
+   - `engineSupports` / `defaultEngineForTracks` / `resolveEngine` encode
+     the (engine × packaging × encryption) capability matrix
+
+6. **Player Integration**:
    - Located in `src/player.ts` and `src/browser.ts`
-   - Provides the high-level API for connecting to MOQ servers
-   - Handles user interface interaction for track discovery and subscription
+   - Selects the pipeline based on the user's "Render engine" choice
+     (`auto` / `mse` / `webcodecs`) and the selected tracks' packaging
+   - Filters the namespace selector so namespaces incompatible with the
+     active engine (or with ClearKey when unsupported) dim out
+   - Drives a buffer-control loop that adjusts playback rate via
+     `IPlaybackPipeline.setPlaybackRate` for either engine
+   - Renders the engine legend overlay (namespace, engine, DRM, video/audio
+     track names)
 
 ### Key Components
 
 1. **Client** (`src/transport/client.ts`):
    - Main entry point for establishing WebTransport connections
    - Handles connection setup, track subscription, and message routing
+   - Negotiates draft-14 (`moq-00`) vs draft-16 (`moqt-16`) via ALPN
 
 2. **TrackAliasRegistry** (`src/transport/trackaliasregistry.ts`):
    - Manages mappings between track namespaces, names, and aliases
@@ -131,24 +190,63 @@ The codebase is organized into several key modules:
 3. **TracksManager** (`src/transport/tracks.ts`):
    - Manages incoming unidirectional streams for data
    - Processes and routes incoming data objects to registered callbacks
+   - Surfaces MoQ Object extension headers (used by LOC for capture
+     timestamps) on `MOQObject.extensions`
 
-4. **MediaBuffer** (`src/buffer/mediaBuffer.ts`):
+4. **WarpCatalogManager** (`src/warpcatalog.ts`):
+   - Parses MSF/CMSF catalogs (full and delta) and applies catalog-level
+     namespace inheritance
+   - Looks up tracks by namespace + name + role for subscription
+
+5. **IPlaybackPipeline** (`src/pipeline/index.ts`):
+   - Common interface for both render engines
+   - Capability matrix functions (`engineSupports`, `engineCanPlayTracks`,
+     `defaultEngineForTracks`, `resolveEngine`) determine which engine
+     plays a given (packaging, encrypted) combination
+
+6. **MsePipeline** (`src/pipeline/msePipeline.ts`):
+   - Owns the `MediaSource` / `ManagedMediaSource`, `SourceBuffer`s, and
+     the segment + box parsers that feed them
+   - Targeted to also own `MediaKeys` / EME state in upcoming phases
+
+7. **WebCodecsLocPipeline** (`src/pipeline/webcodecsLocPipeline.ts`):
+   - Owns `VideoDecoder` / `AudioDecoder`, the overlay canvas, the
+     `AudioContext`, and the wallclock-anchored render loop
+   - Re-configures decoders on parameter-set changes (SPS/PPS for AVC;
+     VPS/SPS/PPS for HEVC); audio decoders are configured once from
+     catalog metadata
+   - Mute is implemented through a `GainNode` between every
+     `AudioBufferSourceNode` and the destination
+
+8. **MediaBuffer** (`src/buffer/mediaBuffer.ts`):
    - Parses CMAF initialization and media segments
    - Extracts timing information for media synchronization
 
-5. **MediaSegmentBuffer** (`src/buffer/mediaSegmentBuffer.ts`):
+9. **MediaSegmentBuffer** (`src/buffer/mediaSegmentBuffer.ts`):
    - Manages the queue of media segments with timing information
-   - Provides interfaces for appending to SourceBuffer for playback
+   - Provides interfaces for appending to `SourceBuffer` for playback
+
+10. **LOC helpers** (`src/loc/`):
+    - `avc.ts` / `hevc.ts` — walk length-prefixed NALUs, extract parameter
+      sets, build `VideoDecoderConfig.description` (avcC / hvcC), and
+      detect IDR / IRAP keyframes
+    - `aac.ts` — build AudioSpecificConfig from catalog `samplerate`,
+      `channels`, and `mp4a.OO.A` codec strings
+    - `opus.ts` — build the `OpusHead` ID Header from catalog metadata
+    - `extensions.ts` — parse moqtransport KeyValuePair extension blobs
+      and read LOC property `0x06` (capture timestamp in microseconds
+      since the Unix epoch)
 
 ## Technical Notes
 
-1. The implementation follows the MOQ Transport protocol draft version 14, with MSF/CMSF catalog format (draft-ietf-moq-msf-00 / draft-ietf-moq-cmsf-00).
-2. WebTransport is available in Chrome 87+, Edge 87+, Firefox, and Safari 26.4+.
+1. The implementation supports MOQ Transport draft-14 and draft-16, with the MSF/CMSF catalog format (draft-ietf-moq-msf-00 / draft-ietf-moq-cmsf-00) and LOC packaging (draft-mzanaty-moq-loc).
+2. WebTransport is available in Chrome 87+, Edge 87+, Firefox, and Safari 26.4+. The WebCodecs render engine additionally requires WebCodecs (Chrome 94+, Edge 94+, Safari 16.4+, Firefox 130+).
 3. The client uses MSB (Most Significant Byte) 16-bit length fields for control messages.
-4. Media data is expected in CMAF format with ISO BMFF container structure.
+4. Media data is delivered either as CMAF (ISO BMFF) for the MSE pipeline or as raw codec payloads (length-prefixed AVC/HEVC NALUs, raw AAC access units, raw Opus packets) for the WebCodecs pipeline.
 5. The client includes proper handling of bidirectional control streams for subscribing to content.
-6. The player should work fine towards https://github.com/Eyevinn/moqlivemock/cmd/mlmpub as a source
-7. The project follows the Eyevinn code quality standards with:
+6. The player should work fine towards https://github.com/Eyevinn/moqlivemock/cmd/mlmpub as a source.
+7. Encrypted content always flows through the MSE engine; production browsers do not expose Encrypted WebCodecs.
+8. The project follows the Eyevinn code quality standards with:
    - Conventional commits using commitlint
    - Prettier for code formatting
    - ESLint for code linting
@@ -156,9 +254,74 @@ The codebase is organized into several key modules:
 
 ## Recent Features
 
+### MSF/CMSF Catalog Format
+
+- Catalog parsing follows draft-ietf-moq-msf-00 with CMSF
+  (draft-ietf-moq-cmsf-00) for CMAF packaging
+- Tracks identify their payload format via the `packaging` field
+  (`"cmaf"`, `"loc"`, ...)
+- Tracks that omit `namespace` inherit it from the announce namespace of
+  the catalog track they were delivered on (see
+  `WarpCatalogManager.processCatalog`)
+- Delta updates via `addTracks` / `removeTracks` / `cloneTracks` are
+  applied on top of the previously delivered catalog
+- Content protection is signaled through the `contentProtections` array
+  at the catalog root and referenced by `contentProtectionRefIDs` on
+  individual tracks (CMSF ContentProtection signaling)
+
+### WebCodecs LOC Pipeline
+
+The player has a second render engine that decodes LOC-packaged tracks
+directly with WebCodecs:
+
+- Selectable from the UI ("Auto" / "MSE (CMAF)" / "WebCodecs (LOC)")
+- Capability matrix in `src/pipeline/index.ts` decides which engine can
+  play a given (packaging, encryption) combination; Auto picks MSE for
+  CMAF / encrypted content and WebCodecs for clear LOC content
+- Video codecs supported today: AVC (H.264) and HEVC (H.265). Parameter
+  sets are extracted from each access unit; the decoder is reconfigured
+  whenever VPS / SPS / PPS bytes change
+- Audio codecs supported today: AAC-LC and Opus. AudioSpecificConfig
+  (AAC) and OpusHead (Opus) are synthesized from the catalog metadata
+  and passed as `AudioDecoderConfig.description`
+- Render strategy: a canvas overlays the `<video>` element; a wallclock-
+  anchored `requestAnimationFrame` loop draws `VideoFrame`s whose
+  presentation time is at or before the playhead
+- Audio strategy: one `AudioContext` for the session, decoded
+  `AudioData` is converted to an `AudioBuffer` and scheduled on a fresh
+  `AudioBufferSourceNode` against the same wallclock anchor used by the
+  video render loop; a shared `GainNode` implements mute
+- Capture timestamps travel in MoQ Object extension headers as LOC
+  property `0x06` (microseconds since the Unix epoch); see
+  `src/loc/extensions.ts`
+
+### Render Engine Selector and Namespace Filter
+
+- The "Render engine" dropdown lets the user force MSE or WebCodecs (or
+  leave it on Auto). Engine choice changes re-render the namespace
+  selector so namespaces incompatible with the chosen engine — or with
+  ClearKey when the browser does not support it — dim out and become
+  unselectable.
+- An "Engine legend" overlay on the player surface shows the active
+  namespace, render engine, DRM system, and selected video / audio
+  track names while playback is active.
+
+### Mute Toggle
+
+- A "Mute / Unmute" button next to Start / Stop controls audio for both
+  pipelines. The MSE pipeline uses the `<video>` element's `muted`
+  attribute; the WebCodecs pipeline drives a shared `GainNode`. Both
+  start muted to match the legacy `<video muted>` UX.
+
+### Draft-14 / Draft-16 Negotiation
+
+- The transport layer supports both MOQ Transport draft-14 (`moq-00`)
+  and draft-16 (`moqt-16`), negotiated via WebTransport ALPN. The UI
+  exposes an "MOQ Transport draft" dropdown (Auto / Draft 14 / Draft 16) for forcing a specific version.
+
 ### Fingerprint Support for Self-Signed Certificates
 
-The player now supports connecting to servers with self-signed certificates by providing a fingerprint URL:
+The player supports connecting to servers with self-signed certificates by providing a fingerprint URL:
 
 - The `Player` constructor accepts an optional `fingerprintUrl` parameter
 - The fingerprint is fetched from the URL and used for WebTransport connection

--- a/README.md
+++ b/README.md
@@ -25,18 +25,24 @@
 This project implements a media player that:
 
 1. Establishes a WebTransport connection to a MOQ server
-2. Subscribes to and parses WARP catalogs for available media
-3. Subscribes to selected media tracks through MOQ transport protocol
-4. Receives media segments in CMAF format through the MOQ protocol
-5. (Optional) Uses EME to handle decryption of protected content
-6. Uses Media Source Extensions (MSE) to decode and play media content
-7. Provides adaptive buffer management for smooth playback experience
-8. This player is intended to work towards [moqlivemock][moqlivemock] publisher and uses the CMSF ContentProtection signaling ([moq-wg/cmsf](https://github.com/moq-wg/cmsf)) for DRM
+2. Negotiates MOQ Transport draft-14 or draft-16 with the server
+3. Subscribes to and parses MSF/CMSF catalogs for available media
+   ([draft-ietf-moq-msf-00], [draft-ietf-moq-cmsf-00])
+4. Subscribes to selected media tracks through the MOQ transport protocol
+5. Renders media through one of two interchangeable pipelines:
+   - **MSE** for CMAF (`packaging: "cmaf"`), with optional EME for protected content
+   - **WebCodecs** for LOC (`packaging: "loc"`, [draft-mzanaty-moq-loc]), clear content only
+6. Provides adaptive buffer management for a smooth playback experience
+7. This player is intended to work towards the [moqlivemock][moqlivemock]
+   publisher and uses the CMSF ContentProtection signaling
+   ([moq-wg/cmsf](https://github.com/moq-wg/cmsf)) for DRM
 
 ## Requirements
 
 - A modern browser that supports WebTransport (Chrome 87+, Edge 87+, Firefox, or Safari 26.4+)
-- A MOQ server that supports draft-14 such as moqlivemock
+- For the WebCodecs pipeline, a browser that exposes the WebCodecs API
+  (Chrome 94+, Edge 94+, Safari 16.4+, Firefox 130+)
+- A MOQ server that supports draft-14 or draft-16 such as moqlivemock
 - Node.js version 20+
 
 ## Project Structure
@@ -44,18 +50,30 @@ This project implements a media player that:
 ```
 warp-player/
 ├── src/
-│   ├── transport/        # MOQ protocol implementation
+│   ├── transport/        # MOQ protocol implementation (draft-14 / draft-16)
 │   │   ├── client.ts     # WebTransport client implementation
 │   │   ├── setup.ts      # Setup message handling
 │   │   ├── tracks.ts     # Track subscription and management
-│   │   └── control.ts    # Control stream handling
-│   ├── buffer/           # Media buffering components
+│   │   ├── control.ts    # Control stream handling
+│   │   └── version.ts    # Draft version constants and ALPN negotiation
+│   ├── buffer/           # CMAF segment buffering for the MSE pipeline
 │   │   ├── mediaBuffer.ts         # CMAF segment parsing
 │   │   └── mediaSegmentBuffer.ts  # Buffer management for MSE
-│   ├── player.ts         # Core player implementation with MSE integration
+│   ├── loc/              # LOC payload helpers for the WebCodecs pipeline
+│   │   ├── avc.ts        # AVC (H.264) NALU walker / avcC builder
+│   │   ├── hevc.ts       # HEVC (H.265) NALU walker / hvcC builder
+│   │   ├── aac.ts        # AAC AudioSpecificConfig from catalog metadata
+│   │   ├── opus.ts       # Opus ID-header (OpusHead) from catalog metadata
+│   │   └── extensions.ts # LOC extension-header parsing (capture timestamps)
+│   ├── pipeline/         # Pluggable render pipelines
+│   │   ├── index.ts                # IPlaybackPipeline + capability matrix
+│   │   ├── msePipeline.ts          # MSE/CMAF pipeline (with optional EME)
+│   │   └── webcodecsLocPipeline.ts # WebCodecs/LOC pipeline (clear only)
+│   ├── warpcatalog.ts    # MSF/CMSF catalog types and parsing
+│   ├── player.ts         # Core player: catalog → tracks → pipeline
 │   ├── browser.ts        # Browser entry point and UI handling
 │   └── index.html        # HTML template and UI components
-├── references/           # MOQ and WARP specification references
+├── references/           # MOQ, MSF, CMSF, and LOC specification references
 ├── tsconfig.json         # TypeScript configuration
 ├── webpack.config.js     # Webpack configuration
 └── package.json          # Project dependencies and scripts
@@ -195,16 +213,64 @@ See [CONFIG.md](CONFIG.md) for detailed configuration options.
 
 ## Features
 
-- Complete MOQ client implementation based on draft-14 of the specification
-- Full WARP catalog support for discovering available media streams
-- Media Source Extensions (MSE) integration for seamless playback in browsers
-- CMAF/ISO-BMFF media segment parsing and playback
-- Advanced two-parameter buffer control system (see Buffer Control Algorithm below)
+- MOQ client implementation supporting draft-14 and draft-16
+  (auto-negotiated via WebTransport ALPN; can be forced from the UI)
+- MSF/CMSF catalog support for discovering available media streams
+  ([draft-ietf-moq-msf-00], [draft-ietf-moq-cmsf-00])
+- Two interchangeable render engines selected per session:
+  - **MSE / CMAF** — the default for CMAF tracks, also handles encrypted content via EME
+  - **WebCodecs / LOC** — clear-only pipeline for `packaging: "loc"` tracks,
+    supporting AVC and HEVC video plus AAC and Opus audio
+    ([draft-mzanaty-moq-loc])
+- Engine selector with `Auto` mode that picks MSE or WebCodecs from the
+  selected tracks' packaging and encryption status, and namespace filtering
+  that dims out namespaces incompatible with the chosen engine
+- Engine legend overlay showing the active namespace, engine, DRM system,
+  and selected video / audio tracks
+- Advanced two-parameter buffer control system (see Buffer Control Algorithm
+  below) — applied to both pipelines through a common `IPlaybackPipeline`
+  interface
 - Adaptive playback rate adjustment based on buffer health and latency
-- Synchronized audio and video playback with automatic recovery
+- Synchronized audio and video playback with automatic recovery, including
+  a wallclock-anchored render loop and gap-free audio scheduling for the
+  WebCodecs pipeline
 - Configurable logging with support for debug, info, warn, and error levels
-- Clean and intuitive UI with real-time buffer and latency monitoring
-- DRM support for Widevine, PlayReady, and FairPlay, plus ClearKey for development, using the CMSF ContentProtection signaling merged into the [moq-wg/cmsf](https://github.com/moq-wg/cmsf) main branch for the next draft (also supported by [Shaka Player](https://github.com/shaka-project/shaka-player/pull/9972))
+- Clean and intuitive UI with real-time buffer and latency monitoring and
+  a Mute / Unmute toggle that works for both engines
+- DRM support for Widevine, PlayReady, and FairPlay, plus ClearKey for
+  development, using the CMSF ContentProtection signaling merged into the
+  [moq-wg/cmsf](https://github.com/moq-wg/cmsf) main branch for the next
+  draft (also supported by [Shaka Player](https://github.com/shaka-project/shaka-player/pull/9972));
+  encrypted content is always routed through the MSE engine
+
+## Render Engines
+
+Two render engines coexist behind a small `IPlaybackPipeline` interface
+(`src/pipeline/index.ts`). Player selects one per session based on the
+catalog and the user's "Render engine" choice in the UI:
+
+| Engine    | Packaging | Encryption | Notes                                                         |
+| --------- | --------- | ---------- | ------------------------------------------------------------- |
+| MSE       | `cmaf`    | clear, EME | Default for CMAF; required path for any DRM-protected content |
+| WebCodecs | `loc`     | clear only | Decodes directly with `VideoDecoder` / `AudioDecoder`         |
+
+The `Auto` engine choice resolves at subscribe time:
+
+- All-CMAF tracks → MSE
+- All-LOC tracks (clear) → WebCodecs
+- Any encrypted track → MSE (WebCodecs cannot play encrypted content
+  because production browsers do not expose Encrypted WebCodecs)
+
+Forcing `MSE (CMAF)` or `WebCodecs (LOC)` overrides the auto choice and
+filters the namespace selector so only compatible namespaces remain
+selectable.
+
+The WebCodecs pipeline draws decoded `VideoFrame`s onto a canvas overlaid
+on the `<video>` element using a wallclock-anchored `requestAnimationFrame`
+loop. Audio decoded via `AudioDecoder` is converted to `AudioBuffer`s and
+scheduled on a single `AudioContext` so video and audio share the same
+wallclock anchor. The capture timestamp travels in MoQ Object extension
+headers (LOC property `0x06`, microseconds since the Unix epoch).
 
 ## Buffer Control Algorithm
 
@@ -262,9 +328,13 @@ Without proper NTP synchronization on both client and server, latency measuremen
 ## Notes
 
 - WebTransport is supported in Chrome, Edge, Firefox, and Safari 26.4+
+- The WebCodecs render engine additionally requires WebCodecs support
+  (Chrome 94+, Edge 94+, Safari 16.4+, Firefox 130+); when WebCodecs is
+  unavailable the namespace selector dims any LOC-only namespaces
 - For development with self-signed certificates, see [FINGERPRINT.md](FINGERPRINT.md) for detailed instructions
 - Alternatively, you may need to accept the self-signed certificate warning in your browser
-- The UI includes controls for adjusting both minimal buffer and target latency
+- The UI includes controls for adjusting both minimal buffer and target latency,
+  picking the MOQ Transport draft, and picking the render engine
 
 ## Acknowledgments
 
@@ -312,3 +382,6 @@ Read our blogs and articles here:
 Want to know more about Eyevinn, contact us at info@eyevinn.se!
 
 [moqlivemock]: https://github.com/Eyevinn/moqlivemock
+[draft-ietf-moq-msf-00]: https://datatracker.ietf.org/doc/html/draft-ietf-moq-msf-00
+[draft-ietf-moq-cmsf-00]: https://datatracker.ietf.org/doc/html/draft-ietf-moq-cmsf-00
+[draft-mzanaty-moq-loc]: https://datatracker.ietf.org/doc/html/draft-mzanaty-moq-loc

--- a/src/index.html
+++ b/src/index.html
@@ -767,6 +767,24 @@
               <option value="draft-16">Draft 16</option>
             </select>
           </div>
+          <div class="form-group">
+            <label for="engineChoice">Render engine</label>
+            <select
+              id="engineChoice"
+              style="
+                background: var(--input-bg);
+                color: var(--text-primary);
+                border: 1px solid var(--border-color);
+                padding: 0.5rem;
+                border-radius: 0.5rem;
+                width: 100%;
+              "
+            >
+              <option value="auto">Auto (best for tracks)</option>
+              <option value="mse">MSE (CMAF)</option>
+              <option value="webcodecs">WebCodecs (LOC)</option>
+            </select>
+          </div>
           <div class="connection-controls">
             <div class="button-group">
               <button id="connectBtn" class="btn btn-primary">Connect</button>

--- a/src/index.html
+++ b/src/index.html
@@ -114,11 +114,49 @@
 
       /* Video Player Section */
       .player-section {
+        position: relative;
         background-color: var(--bg-card);
         border: 1px solid var(--border-color);
         border-radius: 12px;
         overflow: hidden;
         margin-bottom: 2rem;
+      }
+
+      .engine-legend {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        background: rgba(0, 0, 0, 0.65);
+        color: #f4f4f5;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.72rem;
+        line-height: 1.35;
+        border-radius: 6px;
+        white-space: nowrap;
+        pointer-events: none;
+        z-index: 5;
+        display: none;
+        max-width: calc(100% - 1rem);
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .engine-legend.active {
+        display: block;
+      }
+      .engine-legend .row {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .engine-legend .key {
+        color: #a1a1aa;
+        flex: 0 0 auto;
+        min-width: 5rem;
+      }
+      .engine-legend .val {
+        color: #f4f4f5;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       #videoPlayer {
@@ -673,13 +711,24 @@
 
       <!-- Video Player Section -->
       <div class="player-section">
-        <video id="videoPlayer" controls muted playsinline></video>
+        <video
+          id="videoPlayer"
+          controls
+          controlslist="nofullscreen"
+          disablepictureinpicture
+          muted
+          playsinline
+        ></video>
+        <div id="engineLegend" class="engine-legend" aria-live="polite"></div>
         <div class="controls-section">
           <button id="startBtn" class="btn btn-primary" disabled>
             <span>▶</span> Start
           </button>
           <button id="stopBtn" class="btn btn-danger" disabled>
             <span>■</span> Stop
+          </button>
+          <button id="muteBtn" class="btn" type="button" disabled>
+            <span aria-hidden="true">🔇</span> Unmute
           </button>
           <div class="buffer-control">
             <label for="minimalBuffer">Minimal Buffer (ms):</label>
@@ -749,41 +798,46 @@
               >
             </div>
           </div>
-          <div class="form-group">
-            <label for="draftVersion">Protocol Version</label>
-            <select
-              id="draftVersion"
-              style="
-                background: var(--input-bg);
-                color: var(--text-primary);
-                border: 1px solid var(--border-color);
-                padding: 0.5rem;
-                border-radius: 0.5rem;
-                width: 100%;
-              "
-            >
-              <option value="auto">Auto (negotiate)</option>
-              <option value="draft-14">Draft 14</option>
-              <option value="draft-16">Draft 16</option>
-            </select>
-          </div>
-          <div class="form-group">
-            <label for="engineChoice">Render engine</label>
-            <select
-              id="engineChoice"
-              style="
-                background: var(--input-bg);
-                color: var(--text-primary);
-                border: 1px solid var(--border-color);
-                padding: 0.5rem;
-                border-radius: 0.5rem;
-                width: 100%;
-              "
-            >
-              <option value="auto">Auto (best for tracks)</option>
-              <option value="mse">MSE (CMAF)</option>
-              <option value="webcodecs">WebCodecs (LOC)</option>
-            </select>
+          <div
+            class="form-group"
+            style="display: flex; gap: 1rem; align-items: flex-end"
+          >
+            <div style="flex: 1; min-width: 0">
+              <label for="draftVersion">Protocol Version</label>
+              <select
+                id="draftVersion"
+                style="
+                  background: var(--input-bg);
+                  color: var(--text-primary);
+                  border: 1px solid var(--border-color);
+                  padding: 0.5rem;
+                  border-radius: 0.5rem;
+                  width: 100%;
+                "
+              >
+                <option value="auto">Auto (negotiate)</option>
+                <option value="draft-14">Draft 14</option>
+                <option value="draft-16">Draft 16</option>
+              </select>
+            </div>
+            <div style="flex: 1; min-width: 0">
+              <label for="engineChoice">Render engine</label>
+              <select
+                id="engineChoice"
+                style="
+                  background: var(--input-bg);
+                  color: var(--text-primary);
+                  border: 1px solid var(--border-color);
+                  padding: 0.5rem;
+                  border-radius: 0.5rem;
+                  width: 100%;
+                "
+              >
+                <option value="auto">Auto (best for tracks)</option>
+                <option value="mse">MSE (CMAF)</option>
+                <option value="webcodecs">WebCodecs (LOC)</option>
+              </select>
+            </div>
           </div>
           <div class="connection-controls">
             <div class="button-group">

--- a/src/loc/aac.test.ts
+++ b/src/loc/aac.test.ts
@@ -1,0 +1,127 @@
+import {
+  AAC_OBJECT_TYPE_LC,
+  AacConfigError,
+  aacAudioObjectTypeFromCodec,
+  aacSamplingFrequencyIndex,
+  buildAacAudioSpecificConfig,
+  buildAacConfigFromCatalog,
+} from "./aac";
+
+describe("aacSamplingFrequencyIndex", () => {
+  it("returns the correct index for standard rates", () => {
+    expect(aacSamplingFrequencyIndex(96000)).toBe(0);
+    expect(aacSamplingFrequencyIndex(48000)).toBe(3);
+    expect(aacSamplingFrequencyIndex(44100)).toBe(4);
+    expect(aacSamplingFrequencyIndex(8000)).toBe(11);
+  });
+
+  it("returns null for non-standard rates", () => {
+    expect(aacSamplingFrequencyIndex(50000)).toBeNull();
+  });
+});
+
+describe("aacAudioObjectTypeFromCodec", () => {
+  it("parses mp4a.40.2 as AAC-LC", () => {
+    expect(aacAudioObjectTypeFromCodec("mp4a.40.2")).toBe(AAC_OBJECT_TYPE_LC);
+  });
+
+  it("is case-insensitive", () => {
+    expect(aacAudioObjectTypeFromCodec("MP4A.40.5")).toBe(5);
+  });
+
+  it("rejects non-mp4a codecs", () => {
+    expect(() => aacAudioObjectTypeFromCodec("opus")).toThrow(AacConfigError);
+    expect(() => aacAudioObjectTypeFromCodec("avc1.42c01f")).toThrow(
+      AacConfigError,
+    );
+  });
+
+  it("rejects mp4a codecs that aren't MPEG-4 audio", () => {
+    // OTI 0x69 = MPEG-2 audio.
+    expect(() => aacAudioObjectTypeFromCodec("mp4a.69.2")).toThrow(
+      AacConfigError,
+    );
+  });
+
+  it("rejects malformed strings", () => {
+    expect(() => aacAudioObjectTypeFromCodec("mp4a.40")).toThrow(
+      AacConfigError,
+    );
+    expect(() => aacAudioObjectTypeFromCodec("mp4a.40.0")).toThrow(
+      AacConfigError,
+    );
+  });
+});
+
+describe("buildAacAudioSpecificConfig", () => {
+  it("produces 0x11 0x90 for AAC-LC 48 kHz stereo", () => {
+    // AOT=2 (00010), SFI=3 (0011), chCfg=2 (0010), three trailing 0 bits → 0x11 0x90.
+    const out = buildAacAudioSpecificConfig(48000, 2);
+    expect(Array.from(out)).toEqual([0x11, 0x90]);
+  });
+
+  it("produces 0x12 0x10 for AAC-LC 44.1 kHz stereo", () => {
+    // AOT=2 (00010), SFI=4 (0100), chCfg=2 (0010), 000 → 00010 0100 0010 000 = 0x12 0x10.
+    const out = buildAacAudioSpecificConfig(44100, 2);
+    expect(Array.from(out)).toEqual([0x12, 0x10]);
+  });
+
+  it("produces 0x11 0x88 for AAC-LC 48 kHz mono", () => {
+    // AOT=2, SFI=3, chCfg=1 → 00010 0011 0001 000 = 0x11 0x88.
+    const out = buildAacAudioSpecificConfig(48000, 1);
+    expect(Array.from(out)).toEqual([0x11, 0x88]);
+  });
+
+  it("falls back to the explicit 24-bit sample-rate escape", () => {
+    // Non-standard rate → escape index 0xF + 24-bit value.
+    const rate = 50000;
+    const out = buildAacAudioSpecificConfig(rate, 2);
+    // Layout: 5 bits AOT + 4 bits 0xF + 24 bits rate + 4 bits chCfg + 3 bits = 40 bits = 5 bytes.
+    expect(out).toHaveLength(5);
+    // Sanity: round-trip the rate. Bit positions 9..32 hold the 24-bit rate.
+    let bitPos = 0;
+    function readBits(n: number): number {
+      let v = 0;
+      for (let i = 0; i < n; i++) {
+        const byte = out[(bitPos + i) >>> 3];
+        const bit = 7 - ((bitPos + i) & 7);
+        v = (v << 1) | ((byte >>> bit) & 1);
+      }
+      bitPos += n;
+      return v;
+    }
+    expect(readBits(5)).toBe(2); // AOT
+    expect(readBits(4)).toBe(0xf); // SFI escape
+    expect(readBits(24)).toBe(rate); // explicit rate
+    expect(readBits(4)).toBe(2); // channelConfig
+  });
+
+  it("rejects out-of-range channelConfig and AOT", () => {
+    expect(() => buildAacAudioSpecificConfig(48000, 16)).toThrow(
+      AacConfigError,
+    );
+    expect(() => buildAacAudioSpecificConfig(48000, -1)).toThrow(
+      AacConfigError,
+    );
+    expect(() => buildAacAudioSpecificConfig(48000, 2, 0)).toThrow(
+      AacConfigError,
+    );
+    expect(() => buildAacAudioSpecificConfig(48000, 2, 32)).toThrow(
+      AacConfigError,
+    );
+  });
+});
+
+describe("buildAacConfigFromCatalog", () => {
+  it("matches buildAacAudioSpecificConfig for the AAC-LC stereo case", () => {
+    const direct = buildAacAudioSpecificConfig(48000, 2);
+    const fromCat = buildAacConfigFromCatalog("mp4a.40.2", 48000, "2");
+    expect(Array.from(fromCat)).toEqual(Array.from(direct));
+  });
+
+  it("rejects non-numeric channelConfig strings", () => {
+    expect(() =>
+      buildAacConfigFromCatalog("mp4a.40.2", 48000, "stereo"),
+    ).toThrow(AacConfigError);
+  });
+});

--- a/src/loc/aac.ts
+++ b/src/loc/aac.ts
@@ -1,0 +1,163 @@
+// AAC helpers for the LOC payload path.
+//
+// LOC AAC objects are raw access units (no ADTS, no LATM). To set up a
+// WebCodecs `AudioDecoder` we need to synthesize an AudioSpecificConfig from
+// catalog metadata and pass it as `AudioDecoderConfig.description`.
+//
+// References:
+//   - ISO/IEC 14496-3 §1.6.2.1 (AudioSpecificConfig)
+//   - RFC 6381 §3.3 (mp4a.OO.A codec strings)
+//
+// mlmpub on feat/loc only emits AAC-LC (mp4a.40.2). The builder still
+// supports arbitrary audioObjectType so the same code path covers HE-AAC
+// when it shows up later.
+
+export const AAC_OBJECT_TYPE_LC = 2;
+
+export class AacConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AacConfigError";
+  }
+}
+
+/** Sampling-frequency-index table — ISO/IEC 14496-3 Table 1.16. */
+const SAMPLING_FREQUENCY_INDEX: ReadonlyArray<number> = [
+  96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025,
+  8000, 7350,
+];
+
+/** Look up the 4-bit index for a standard AAC sampling frequency, or null. */
+export function aacSamplingFrequencyIndex(sampleRate: number): number | null {
+  const idx = SAMPLING_FREQUENCY_INDEX.indexOf(sampleRate);
+  return idx === -1 ? null : idx;
+}
+
+/**
+ * Extract the AAC audioObjectType from a codec string like "mp4a.40.2".
+ * Returns the trailing decimal as a number. Throws on malformed input or on
+ * an OTI that isn't MPEG-4 audio (0x40).
+ */
+export function aacAudioObjectTypeFromCodec(codec: string): number {
+  const parts = codec.toLowerCase().split(".");
+  if (parts.length !== 3 || parts[0] !== "mp4a") {
+    throw new AacConfigError(`not an mp4a codec string: ${codec}`);
+  }
+  const oti = parseInt(parts[1], 16);
+  if (oti !== 0x40) {
+    throw new AacConfigError(
+      `expected MPEG-4 audio OTI 0x40, got 0x${oti.toString(16)} (${codec})`,
+    );
+  }
+  const aot = parseInt(parts[2], 10);
+  if (!Number.isInteger(aot) || aot < 1 || aot > 31) {
+    throw new AacConfigError(`invalid audioObjectType in codec: ${codec}`);
+  }
+  return aot;
+}
+
+/**
+ * Build a minimal AudioSpecificConfig (the bytes WebCodecs expects in
+ * `AudioDecoderConfig.description` for `mp4a.*` codecs).
+ *
+ * Bit layout — ISO/IEC 14496-3 §1.6.2.1:
+ *   5 bits  audioObjectType
+ *   4 bits  samplingFrequencyIndex (or 15 + explicit 24-bit frequency)
+ *   4 bits  channelConfiguration
+ *   1 bit   frameLengthFlag
+ *   1 bit   dependsOnCoreCoder
+ *   1 bit   extensionFlag
+ *
+ * frameLengthFlag/dependsOnCoreCoder/extensionFlag are all 0 for the common
+ * AAC-LC profile.
+ */
+export function buildAacAudioSpecificConfig(
+  sampleRate: number,
+  channelConfig: number,
+  audioObjectType: number = AAC_OBJECT_TYPE_LC,
+): Uint8Array {
+  if (
+    !Number.isInteger(audioObjectType) ||
+    audioObjectType < 1 ||
+    audioObjectType > 31
+  ) {
+    throw new AacConfigError(
+      `audioObjectType ${audioObjectType} outside [1, 31]`,
+    );
+  }
+  if (
+    !Number.isInteger(channelConfig) ||
+    channelConfig < 0 ||
+    channelConfig > 15
+  ) {
+    throw new AacConfigError(`channelConfig ${channelConfig} outside [0, 15]`);
+  }
+
+  const sfIndex = aacSamplingFrequencyIndex(sampleRate);
+  const writer = new BitWriter();
+  writer.write(audioObjectType, 5);
+  if (sfIndex !== null) {
+    writer.write(sfIndex, 4);
+  } else {
+    if (sampleRate <= 0 || sampleRate >= 1 << 24) {
+      throw new AacConfigError(`sample rate ${sampleRate} out of range`);
+    }
+    writer.write(0xf, 4); // escape
+    writer.write(sampleRate, 24);
+  }
+  writer.write(channelConfig, 4);
+  writer.write(0, 1); // frameLengthFlag
+  writer.write(0, 1); // dependsOnCoreCoder
+  writer.write(0, 1); // extensionFlag
+  return writer.finish();
+}
+
+/**
+ * Convenience: build the AudioSpecificConfig directly from the catalog
+ * fields. `channelConfig` arrives as a string per the MSF catalog schema.
+ */
+export function buildAacConfigFromCatalog(
+  codec: string,
+  sampleRate: number,
+  channelConfig: string,
+): Uint8Array {
+  const aot = aacAudioObjectTypeFromCodec(codec);
+  const ch = parseInt(channelConfig, 10);
+  if (!Number.isInteger(ch)) {
+    throw new AacConfigError(
+      `channelConfig "${channelConfig}" is not a decimal integer`,
+    );
+  }
+  return buildAacAudioSpecificConfig(sampleRate, ch, aot);
+}
+
+/** Tiny MSB-first bit writer. */
+class BitWriter {
+  private readonly bytes: number[] = [];
+  private buffer = 0;
+  private bits = 0;
+
+  write(value: number, width: number): void {
+    if (width < 1 || width > 24) {
+      throw new AacConfigError(`bit width ${width} outside [1, 24]`);
+    }
+    if (value < 0 || value >= 1 << width) {
+      throw new AacConfigError(`value ${value} doesn't fit in ${width} bits`);
+    }
+    this.buffer = (this.buffer << width) | value;
+    this.bits += width;
+    while (this.bits >= 8) {
+      this.bits -= 8;
+      this.bytes.push((this.buffer >>> this.bits) & 0xff);
+    }
+  }
+
+  finish(): Uint8Array {
+    if (this.bits > 0) {
+      // Pad the final byte with zero bits — matches the spec's reserved tail.
+      this.bytes.push((this.buffer << (8 - this.bits)) & 0xff);
+      this.bits = 0;
+    }
+    return new Uint8Array(this.bytes);
+  }
+}

--- a/src/loc/avc.test.ts
+++ b/src/loc/avc.test.ts
@@ -1,0 +1,222 @@
+import {
+  AvcParseError,
+  NALU_TYPE_IDR_SLICE,
+  NALU_TYPE_NON_IDR_SLICE,
+  NALU_TYPE_PPS,
+  NALU_TYPE_SEI,
+  NALU_TYPE_SPS,
+  buildAvcDecoderConfigDescription,
+  extractParameterSetsAndChunk,
+  payloadIsKey,
+  walkAvccNalus,
+} from "./avc";
+
+// Build a length-prefixed NALU stream from raw NALU bodies.
+function avcc(...nalus: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const n of nalus) {
+    total += 4 + n.length;
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const n of nalus) {
+    out[off++] = (n.length >>> 24) & 0xff;
+    out[off++] = (n.length >>> 16) & 0xff;
+    out[off++] = (n.length >>> 8) & 0xff;
+    out[off++] = n.length & 0xff;
+    out.set(n, off);
+    off += n.length;
+  }
+  return out;
+}
+
+// Construct a NALU with a given type and arbitrary payload bytes.
+function nalu(type: number, body: number[] = []): Uint8Array {
+  return new Uint8Array([type & 0x1f, ...body]);
+}
+
+// Minimal SPS: type byte + 3 bytes profile/compat/level. Real SPSs are
+// longer but the AVCDecoderConfigurationRecord builder only reads the first
+// four bytes.
+const SPS_BYTES = nalu(NALU_TYPE_SPS, [0x42, 0xc0, 0x1f, 0x00, 0x00]);
+const PPS_BYTES = nalu(NALU_TYPE_PPS, [0x12, 0x34]);
+
+describe("walkAvccNalus", () => {
+  it("returns an empty list for an empty payload", () => {
+    expect(walkAvccNalus(new Uint8Array())).toEqual([]);
+  });
+
+  it("splits a single NALU", () => {
+    const out = walkAvccNalus(avcc(nalu(NALU_TYPE_NON_IDR_SLICE, [1, 2, 3])));
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe(NALU_TYPE_NON_IDR_SLICE);
+    expect(Array.from(out[0].data)).toEqual([NALU_TYPE_NON_IDR_SLICE, 1, 2, 3]);
+  });
+
+  it("splits a stream of multiple NALUs preserving order", () => {
+    const out = walkAvccNalus(
+      avcc(SPS_BYTES, PPS_BYTES, nalu(NALU_TYPE_IDR_SLICE, [0xff])),
+    );
+    expect(out.map((n) => n.type)).toEqual([
+      NALU_TYPE_SPS,
+      NALU_TYPE_PPS,
+      NALU_TYPE_IDR_SLICE,
+    ]);
+  });
+
+  it("throws on a truncated length prefix", () => {
+    expect(() => walkAvccNalus(new Uint8Array([0x00, 0x00]))).toThrow(
+      AvcParseError,
+    );
+  });
+
+  it("throws when a NALU runs past the end", () => {
+    // Length prefix says 10 bytes but only 2 bytes follow.
+    const bad = new Uint8Array([0x00, 0x00, 0x00, 0x0a, 0x67, 0x42]);
+    expect(() => walkAvccNalus(bad)).toThrow(AvcParseError);
+  });
+
+  it("throws on a zero-length NALU", () => {
+    const bad = new Uint8Array([0x00, 0x00, 0x00, 0x00]);
+    expect(() => walkAvccNalus(bad)).toThrow(AvcParseError);
+  });
+});
+
+describe("payloadIsKey", () => {
+  it("returns true when an IDR slice is present", () => {
+    expect(payloadIsKey(avcc(nalu(NALU_TYPE_IDR_SLICE, [0])))).toBe(true);
+    expect(
+      payloadIsKey(avcc(SPS_BYTES, PPS_BYTES, nalu(NALU_TYPE_IDR_SLICE))),
+    ).toBe(true);
+  });
+
+  it("returns false for non-IDR slices only", () => {
+    expect(payloadIsKey(avcc(nalu(NALU_TYPE_NON_IDR_SLICE, [0])))).toBe(false);
+    expect(payloadIsKey(avcc(SPS_BYTES, PPS_BYTES))).toBe(false);
+  });
+
+  it("returns false for empty payload", () => {
+    expect(payloadIsKey(new Uint8Array())).toBe(false);
+  });
+});
+
+describe("extractParameterSetsAndChunk", () => {
+  it("separates SPS+PPS at IDR and rebuilds the chunk", () => {
+    const idr = nalu(NALU_TYPE_IDR_SLICE, [0xa1, 0xa2, 0xa3]);
+    const r = extractParameterSetsAndChunk(avcc(SPS_BYTES, PPS_BYTES, idr));
+    expect(r.sps).toHaveLength(1);
+    expect(Array.from(r.sps[0])).toEqual(Array.from(SPS_BYTES));
+    expect(r.pps).toHaveLength(1);
+    expect(Array.from(r.pps[0])).toEqual(Array.from(PPS_BYTES));
+    expect(r.isKey).toBe(true);
+    // chunk should be exactly the IDR re-wrapped with a 4-byte length prefix.
+    expect(Array.from(r.chunk)).toEqual([
+      0,
+      0,
+      0,
+      idr.length,
+      ...Array.from(idr),
+    ]);
+  });
+
+  it("passes through delta frames without parameter sets", () => {
+    const slice = nalu(NALU_TYPE_NON_IDR_SLICE, [0x10, 0x20]);
+    const r = extractParameterSetsAndChunk(avcc(slice));
+    expect(r.sps).toEqual([]);
+    expect(r.pps).toEqual([]);
+    expect(r.isKey).toBe(false);
+    expect(Array.from(r.chunk)).toEqual([
+      0,
+      0,
+      0,
+      slice.length,
+      ...Array.from(slice),
+    ]);
+  });
+
+  it("preserves picture-NALU order even if parameter sets are interleaved", () => {
+    const sei = nalu(NALU_TYPE_SEI, [0x99]);
+    const idr = nalu(NALU_TYPE_IDR_SLICE, [0xff, 0xff]);
+    const r = extractParameterSetsAndChunk(
+      avcc(sei, SPS_BYTES, PPS_BYTES, idr),
+    );
+    // Picture NALUs are SEI then IDR, in arrival order.
+    expect(r.isKey).toBe(true);
+    expect(Array.from(r.chunk)).toEqual([
+      0,
+      0,
+      0,
+      sei.length,
+      ...Array.from(sei),
+      0,
+      0,
+      0,
+      idr.length,
+      ...Array.from(idr),
+    ]);
+  });
+
+  it("returns an empty chunk for parameter-set-only payloads", () => {
+    const r = extractParameterSetsAndChunk(avcc(SPS_BYTES, PPS_BYTES));
+    expect(r.chunk).toHaveLength(0);
+    expect(r.isKey).toBe(false);
+  });
+});
+
+describe("buildAvcDecoderConfigDescription", () => {
+  it("produces a valid AVCDecoderConfigurationRecord for one SPS + one PPS", () => {
+    const out = buildAvcDecoderConfigDescription([SPS_BYTES], [PPS_BYTES]);
+    let off = 0;
+    expect(out[off++]).toBe(1); // configurationVersion
+    expect(out[off++]).toBe(SPS_BYTES[1]); // profile (0x42)
+    expect(out[off++]).toBe(SPS_BYTES[2]); // compat  (0xc0)
+    expect(out[off++]).toBe(SPS_BYTES[3]); // level   (0x1f)
+    expect(out[off++]).toBe(0xff); // reserved | lengthSizeMinusOne=3
+    expect(out[off++]).toBe(0xe1); // reserved | numOfSPS=1
+    expect((out[off] << 8) | out[off + 1]).toBe(SPS_BYTES.length);
+    off += 2;
+    expect(Array.from(out.slice(off, off + SPS_BYTES.length))).toEqual(
+      Array.from(SPS_BYTES),
+    );
+    off += SPS_BYTES.length;
+    expect(out[off++]).toBe(1); // numOfPPS
+    expect((out[off] << 8) | out[off + 1]).toBe(PPS_BYTES.length);
+    off += 2;
+    expect(Array.from(out.slice(off, off + PPS_BYTES.length))).toEqual(
+      Array.from(PPS_BYTES),
+    );
+    off += PPS_BYTES.length;
+    expect(off).toBe(out.length);
+  });
+
+  it("encodes multiple SPS and PPS in arrival order", () => {
+    const sps2 = nalu(NALU_TYPE_SPS, [0x4d, 0x40, 0x1e, 0x00]);
+    const pps2 = nalu(NALU_TYPE_PPS, [0xab]);
+    const out = buildAvcDecoderConfigDescription(
+      [SPS_BYTES, sps2],
+      [PPS_BYTES, pps2],
+    );
+    expect(out[5]).toBe(0xe2); // numOfSPS=2
+    // First SPS still drives profile/compat/level (the spec leaves the others
+    // for selection by the decoder).
+    expect(out[1]).toBe(SPS_BYTES[1]);
+  });
+
+  it("throws when SPS or PPS is missing", () => {
+    expect(() => buildAvcDecoderConfigDescription([], [PPS_BYTES])).toThrow(
+      AvcParseError,
+    );
+    expect(() => buildAvcDecoderConfigDescription([SPS_BYTES], [])).toThrow(
+      AvcParseError,
+    );
+  });
+
+  it("throws when the first SPS is too short to read profile/level", () => {
+    expect(() =>
+      buildAvcDecoderConfigDescription(
+        [new Uint8Array([0x67, 0x42])],
+        [PPS_BYTES],
+      ),
+    ).toThrow(AvcParseError);
+  });
+});

--- a/src/loc/avc.ts
+++ b/src/loc/avc.ts
@@ -1,0 +1,195 @@
+// AVC (H.264) helpers for the LOC payload path.
+//
+// LOC AVC objects are length-prefixed NALUs (4-byte big-endian length per
+// NALU). At IDR boundaries mlmpub prepends SPS+PPS NALUs to the payload, so
+// the player can build a fresh AVCDecoderConfigurationRecord on first
+// keyframe and re-validate on parameter-set changes.
+//
+// References:
+//   - ISO/IEC 14496-10 §7.4.1.2 (NAL unit syntax / nal_unit_type)
+//   - ISO/IEC 14496-15 §5.3.3.1 (AVCDecoderConfigurationRecord)
+//   - draft-mzanaty-moq-loc-05 §3 (length-prefixed NALU format)
+//   - moqlivemock/internal/sub/loc.go for the wire layout we consume
+
+export const NALU_TYPE_NON_IDR_SLICE = 1;
+export const NALU_TYPE_IDR_SLICE = 5;
+export const NALU_TYPE_SEI = 6;
+export const NALU_TYPE_SPS = 7;
+export const NALU_TYPE_PPS = 8;
+
+export interface NaluView {
+  /** nal_unit_type (5 LSBs of the first byte). */
+  type: number;
+  /** The NALU payload — the type byte plus all RBSP bytes. */
+  data: Uint8Array;
+}
+
+export class AvcParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AvcParseError";
+  }
+}
+
+/**
+ * Split a length-prefixed NALU stream into its NALUs. Each prefix is a 4-byte
+ * big-endian length. Empty payload yields an empty array.
+ */
+export function walkAvccNalus(payload: Uint8Array): NaluView[] {
+  const result: NaluView[] = [];
+  let offset = 0;
+  while (offset < payload.length) {
+    if (offset + 4 > payload.length) {
+      throw new AvcParseError(
+        `truncated NALU length prefix at offset ${offset} (have ${payload.length - offset} bytes)`,
+      );
+    }
+    const len =
+      (payload[offset] << 24) |
+      (payload[offset + 1] << 16) |
+      (payload[offset + 2] << 8) |
+      payload[offset + 3];
+    offset += 4;
+    if (len < 1) {
+      throw new AvcParseError(`zero-length NALU at offset ${offset}`);
+    }
+    if (offset + len > payload.length) {
+      throw new AvcParseError(
+        `NALU of length ${len} extends past end (offset ${offset}, payload ${payload.length})`,
+      );
+    }
+    const data = payload.subarray(offset, offset + len);
+    const type = data[0] & 0x1f;
+    result.push({ type, data });
+    offset += len;
+  }
+  return result;
+}
+
+/** True when any NALU in `payload` is an IDR slice. */
+export function payloadIsKey(payload: Uint8Array): boolean {
+  for (const nalu of walkAvccNalus(payload)) {
+    if (nalu.type === NALU_TYPE_IDR_SLICE) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export interface AvcSplitResult {
+  /** Parameter sets discovered in the payload, in arrival order. */
+  sps: Uint8Array[];
+  /** Picture parameter sets discovered in the payload, in arrival order. */
+  pps: Uint8Array[];
+  /**
+   * Length-prefixed picture NALUs (slice + SEI + AUD ...) suitable for
+   * EncodedVideoChunk.data. Empty when the object only carried parameter
+   * sets.
+   */
+  chunk: Uint8Array;
+  /** True when the picture NALUs include at least one IDR slice. */
+  isKey: boolean;
+}
+
+/**
+ * Walk an LOC AVC payload, peel off any leading/trailing SPS+PPS NALUs, and
+ * return the picture NALUs as a fresh length-prefixed buffer. Order is
+ * preserved among picture NALUs.
+ */
+export function extractParameterSetsAndChunk(
+  payload: Uint8Array,
+): AvcSplitResult {
+  const sps: Uint8Array[] = [];
+  const pps: Uint8Array[] = [];
+  const picture: Uint8Array[] = [];
+  let isKey = false;
+  for (const nalu of walkAvccNalus(payload)) {
+    if (nalu.type === NALU_TYPE_SPS) {
+      sps.push(copy(nalu.data));
+    } else if (nalu.type === NALU_TYPE_PPS) {
+      pps.push(copy(nalu.data));
+    } else {
+      picture.push(nalu.data);
+      if (nalu.type === NALU_TYPE_IDR_SLICE) {
+        isKey = true;
+      }
+    }
+  }
+  let chunkLength = 0;
+  for (const n of picture) {
+    chunkLength += 4 + n.length;
+  }
+  const chunk = new Uint8Array(chunkLength);
+  let offset = 0;
+  for (const n of picture) {
+    chunk[offset] = (n.length >>> 24) & 0xff;
+    chunk[offset + 1] = (n.length >>> 16) & 0xff;
+    chunk[offset + 2] = (n.length >>> 8) & 0xff;
+    chunk[offset + 3] = n.length & 0xff;
+    chunk.set(n, offset + 4);
+    offset += 4 + n.length;
+  }
+  return { sps, pps, chunk, isKey };
+}
+
+/**
+ * Build an AVCDecoderConfigurationRecord (the avcC box content, which is
+ * what WebCodecs expects in `VideoDecoderConfig.description`) from at least
+ * one SPS and one PPS. Length size is fixed at 4 bytes — matches the LOC
+ * wire format and what we re-emit in `chunk`.
+ */
+export function buildAvcDecoderConfigDescription(
+  sps: Uint8Array[],
+  pps: Uint8Array[],
+): Uint8Array {
+  if (sps.length === 0) {
+    throw new AvcParseError("at least one SPS is required");
+  }
+  if (pps.length === 0) {
+    throw new AvcParseError("at least one PPS is required");
+  }
+  if (sps.length > 31) {
+    throw new AvcParseError(`too many SPS (${sps.length}, max 31)`);
+  }
+  if (pps.length > 255) {
+    throw new AvcParseError(`too many PPS (${pps.length}, max 255)`);
+  }
+  const firstSps = sps[0];
+  if (firstSps.length < 4) {
+    throw new AvcParseError("SPS too short to read profile/level");
+  }
+  let size = 6; // header bytes through numOfSequenceParameterSets
+  for (const s of sps) {
+    size += 2 + s.length;
+  }
+  size += 1; // numOfPictureParameterSets
+  for (const p of pps) {
+    size += 2 + p.length;
+  }
+  const out = new Uint8Array(size);
+  let off = 0;
+  out[off++] = 1; // configurationVersion
+  out[off++] = firstSps[1]; // AVCProfileIndication
+  out[off++] = firstSps[2]; // profile_compatibility
+  out[off++] = firstSps[3]; // AVCLevelIndication
+  out[off++] = 0xfc | 3; // reserved 6 bits | lengthSizeMinusOne (3 = 4 bytes)
+  out[off++] = 0xe0 | sps.length; // reserved 3 bits | numOfSequenceParameterSets
+  for (const s of sps) {
+    out[off++] = (s.length >> 8) & 0xff;
+    out[off++] = s.length & 0xff;
+    out.set(s, off);
+    off += s.length;
+  }
+  out[off++] = pps.length;
+  for (const p of pps) {
+    out[off++] = (p.length >> 8) & 0xff;
+    out[off++] = p.length & 0xff;
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function copy(src: Uint8Array): Uint8Array {
+  return new Uint8Array(src);
+}

--- a/src/loc/extensions.test.ts
+++ b/src/loc/extensions.test.ts
@@ -1,0 +1,207 @@
+import {
+  LOC_EXT_TIMESTAMP,
+  LocExtensionParseError,
+  getLocCaptureTimestampUs,
+  parseMoqExtensions,
+  readQuicVarint,
+} from "./extensions";
+
+// Helper: build a QUIC varint of the smallest size that fits `value`.
+function quicVarint(value: bigint): Uint8Array {
+  if (value < 0n) {
+    throw new Error("negative varint");
+  }
+  if (value <= 0x3fn) {
+    return new Uint8Array([Number(value)]);
+  }
+  if (value <= 0x3fffn) {
+    const buf = new Uint8Array(2);
+    buf[0] = 0x40 | Number((value >> 8n) & 0x3fn);
+    buf[1] = Number(value & 0xffn);
+    return buf;
+  }
+  if (value <= 0x3fffffffn) {
+    const buf = new Uint8Array(4);
+    buf[0] = 0x80 | Number((value >> 24n) & 0x3fn);
+    buf[1] = Number((value >> 16n) & 0xffn);
+    buf[2] = Number((value >> 8n) & 0xffn);
+    buf[3] = Number(value & 0xffn);
+    return buf;
+  }
+  if (value <= 0x3fffffffffffffffn) {
+    const buf = new Uint8Array(8);
+    buf[0] = 0xc0 | Number((value >> 56n) & 0x3fn);
+    for (let i = 1; i < 8; i++) {
+      buf[i] = Number((value >> BigInt((7 - i) * 8)) & 0xffn);
+    }
+    return buf;
+  }
+  throw new Error("value too large for QUIC varint");
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+describe("readQuicVarint", () => {
+  it("reads a 1-byte varint", () => {
+    const r = readQuicVarint(new Uint8Array([0x06]), 0);
+    expect(r).toEqual({ value: 6n, bytesRead: 1 });
+  });
+
+  it("reads a 2-byte varint", () => {
+    // value 0x40 (= 64) requires the 2-byte form since it overflows 6 bits.
+    const r = readQuicVarint(quicVarint(64n), 0);
+    expect(r).toEqual({ value: 64n, bytesRead: 2 });
+  });
+
+  it("reads a 4-byte varint", () => {
+    const r = readQuicVarint(quicVarint(1_000_000n), 0);
+    expect(r).toEqual({ value: 1_000_000n, bytesRead: 4 });
+  });
+
+  it("reads an 8-byte varint", () => {
+    // 1_700_000_000_000_000 µs (~ 2023-11-14) overflows 30 bits → 8-byte form.
+    const ts = 1_700_000_000_000_000n;
+    const r = readQuicVarint(quicVarint(ts), 0);
+    expect(r).toEqual({ value: ts, bytesRead: 8 });
+  });
+
+  it("reads at a non-zero offset", () => {
+    const buf = concat(new Uint8Array([0xde, 0xad]), quicVarint(42n));
+    const r = readQuicVarint(buf, 2);
+    expect(r).toEqual({ value: 42n, bytesRead: 1 });
+  });
+
+  it("throws when the buffer is empty", () => {
+    expect(() => readQuicVarint(new Uint8Array(), 0)).toThrow(
+      LocExtensionParseError,
+    );
+  });
+
+  it("throws when a multi-byte varint runs past the end", () => {
+    // First byte signals 4-byte size but only 2 bytes are available.
+    expect(() => readQuicVarint(new Uint8Array([0x80, 0x00]), 0)).toThrow(
+      LocExtensionParseError,
+    );
+  });
+});
+
+describe("parseMoqExtensions", () => {
+  it("returns an empty list for undefined or empty input", () => {
+    expect(parseMoqExtensions(undefined)).toEqual([]);
+    expect(parseMoqExtensions(new Uint8Array())).toEqual([]);
+  });
+
+  it("parses a single even-typed (ValueVarInt) KVP", () => {
+    const blob = concat(quicVarint(LOC_EXT_TIMESTAMP), quicVarint(123_456n));
+    expect(parseMoqExtensions(blob)).toEqual([
+      { type: LOC_EXT_TIMESTAMP, valueVarInt: 123_456n },
+    ]);
+  });
+
+  it("parses a single odd-typed (ValueBytes) KVP", () => {
+    const payload = new Uint8Array([1, 2, 3, 4]);
+    const blob = concat(
+      quicVarint(0x07n),
+      quicVarint(BigInt(payload.length)),
+      payload,
+    );
+    const out = parseMoqExtensions(blob);
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe(0x07n);
+    const valueBytes = out[0].valueBytes;
+    expect(valueBytes).toBeDefined();
+    expect(Array.from(valueBytes as Uint8Array)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("parses a sequence of mixed-parity KVPs", () => {
+    const ts = 1_700_000_000_000_000n;
+    const bytes = new Uint8Array([0xaa, 0xbb]);
+    const blob = concat(
+      // even type 0x06 → varint
+      quicVarint(LOC_EXT_TIMESTAMP),
+      quicVarint(ts),
+      // odd type 0x07 → length-prefixed bytes
+      quicVarint(0x07n),
+      quicVarint(BigInt(bytes.length)),
+      bytes,
+      // even type 0x08 → varint
+      quicVarint(0x08n),
+      quicVarint(0n),
+    );
+    const out = parseMoqExtensions(blob);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({ type: LOC_EXT_TIMESTAMP, valueVarInt: ts });
+    expect(out[1].type).toBe(0x07n);
+    const valueBytes = out[1].valueBytes;
+    expect(valueBytes).toBeDefined();
+    expect(Array.from(valueBytes as Uint8Array)).toEqual([0xaa, 0xbb]);
+    expect(out[2]).toEqual({ type: 0x08n, valueVarInt: 0n });
+  });
+
+  it("throws when a length-prefixed value runs past the end", () => {
+    // type 0x07 (odd), claimed length 4, but only 2 bytes follow.
+    const blob = concat(
+      quicVarint(0x07n),
+      quicVarint(4n),
+      new Uint8Array([0x01, 0x02]),
+    );
+    expect(() => parseMoqExtensions(blob)).toThrow(LocExtensionParseError);
+  });
+});
+
+describe("getLocCaptureTimestampUs", () => {
+  it("returns null when no extensions are present", () => {
+    expect(getLocCaptureTimestampUs(undefined)).toBeNull();
+    expect(getLocCaptureTimestampUs(new Uint8Array())).toBeNull();
+  });
+
+  it("returns null when the timestamp KVP is absent", () => {
+    const blob = concat(quicVarint(0x08n), quicVarint(0n));
+    expect(getLocCaptureTimestampUs(blob)).toBeNull();
+  });
+
+  it("returns the timestamp from a single-KVP blob", () => {
+    const ts = 1_759_924_158_381_000n;
+    const blob = concat(quicVarint(LOC_EXT_TIMESTAMP), quicVarint(ts));
+    expect(getLocCaptureTimestampUs(blob)).toBe(ts);
+  });
+
+  it("returns the timestamp when other KVPs precede it", () => {
+    const ts = 1_700_000_000_000_001n;
+    const blob = concat(
+      quicVarint(0x08n),
+      quicVarint(99n),
+      quicVarint(LOC_EXT_TIMESTAMP),
+      quicVarint(ts),
+    );
+    expect(getLocCaptureTimestampUs(blob)).toBe(ts);
+  });
+
+  it("matches a hand-encoded blob equivalent to mlmpub output", () => {
+    // mlmpub writes a single KVP: type 0x06 (1 byte), value=µs (8-byte varint
+    // for any timestamp past Nov 2023). Verify the exact byte layout we expect
+    // to receive on the wire.
+    const ts = 1_759_924_158_381_000n;
+    const expected = new Uint8Array([
+      0x06,
+      0xc0 | Number((ts >> 56n) & 0x3fn),
+      Number((ts >> 48n) & 0xffn),
+      Number((ts >> 40n) & 0xffn),
+      Number((ts >> 32n) & 0xffn),
+      Number((ts >> 24n) & 0xffn),
+      Number((ts >> 16n) & 0xffn),
+      Number((ts >> 8n) & 0xffn),
+      Number(ts & 0xffn),
+    ]);
+    expect(getLocCaptureTimestampUs(expected)).toBe(ts);
+  });
+});

--- a/src/loc/extensions.ts
+++ b/src/loc/extensions.ts
@@ -1,0 +1,111 @@
+// LOC (Low Overhead Container) extension-header parsing.
+//
+// LOC objects carry metadata in MoQ Object extension headers, which are encoded
+// as a sequence of moqtransport KeyValuePairs concatenated without an outer
+// count or length. The extensions blob is what tracks.ts exposes on
+// MOQObject.extensions.
+//
+// moqtransport's KVP parity rule (see moqtransport/internal/wire/key_value_pair.go):
+//   type % 2 == 0  →  ValueVarInt (single varint, no length)
+//   type % 2 == 1  →  ValueBytes  (varint length followed by bytes)
+//
+// LOC property IDs used by mlmpub today (see moqlivemock/internal/sub/loc.go):
+//   0x06  Capture timestamp, microseconds since the Unix epoch (varint).
+
+export const LOC_EXT_TIMESTAMP = 0x06n;
+
+export interface LocKvp {
+  type: bigint;
+  /** Set for even-typed pairs (ValueVarInt). */
+  valueVarInt?: bigint;
+  /** Set for odd-typed pairs (ValueBytes). */
+  valueBytes?: Uint8Array;
+}
+
+export class LocExtensionParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocExtensionParseError";
+  }
+}
+
+/**
+ * Read a single QUIC variable-length integer from `buf` at `offset`.
+ * Returns the value and the number of bytes consumed.
+ */
+export function readQuicVarint(
+  buf: Uint8Array,
+  offset: number,
+): { value: bigint; bytesRead: number } {
+  if (offset >= buf.length) {
+    throw new LocExtensionParseError(
+      `varint read out of bounds at offset ${offset}`,
+    );
+  }
+  const first = buf[offset];
+  const sizeCode = (first & 0xc0) >> 6;
+  const length = 1 << sizeCode;
+  if (offset + length > buf.length) {
+    throw new LocExtensionParseError(
+      `varint of size ${length} extends past end (offset ${offset}, buf ${buf.length})`,
+    );
+  }
+  // Strip the size bits from the first byte and accumulate.
+  let value = BigInt(first & 0x3f);
+  for (let i = 1; i < length; i++) {
+    value = (value << 8n) | BigInt(buf[offset + i]);
+  }
+  return { value, bytesRead: length };
+}
+
+/**
+ * Parse a flat extension-headers blob into KVPs. Returns an empty list when
+ * `blob` is undefined or empty. Throws LocExtensionParseError on malformed input.
+ */
+export function parseMoqExtensions(blob: Uint8Array | undefined): LocKvp[] {
+  if (!blob || blob.length === 0) {
+    return [];
+  }
+  const result: LocKvp[] = [];
+  let offset = 0;
+  while (offset < blob.length) {
+    const typeRead = readQuicVarint(blob, offset);
+    offset += typeRead.bytesRead;
+    const type = typeRead.value;
+
+    if ((type & 1n) === 0n) {
+      const valueRead = readQuicVarint(blob, offset);
+      offset += valueRead.bytesRead;
+      result.push({ type, valueVarInt: valueRead.value });
+    } else {
+      const lenRead = readQuicVarint(blob, offset);
+      offset += lenRead.bytesRead;
+      const length = Number(lenRead.value);
+      if (offset + length > blob.length) {
+        throw new LocExtensionParseError(
+          `length-prefixed value of ${length} bytes extends past end ` +
+            `(offset ${offset}, buf ${blob.length})`,
+        );
+      }
+      const valueBytes = blob.slice(offset, offset + length);
+      offset += length;
+      result.push({ type, valueBytes });
+    }
+  }
+  return result;
+}
+
+/**
+ * Convenience: extract the LOC capture timestamp (microseconds since the Unix
+ * epoch) from an extension blob. Returns null when no timestamp KVP is present.
+ */
+export function getLocCaptureTimestampUs(
+  blob: Uint8Array | undefined,
+): bigint | null {
+  for (const kvp of parseMoqExtensions(blob)) {
+    if (kvp.type === LOC_EXT_TIMESTAMP && kvp.valueVarInt !== undefined) {
+      return kvp.valueVarInt;
+    }
+  }
+  return null;
+}

--- a/src/loc/hevc.test.ts
+++ b/src/loc/hevc.test.ts
@@ -1,0 +1,312 @@
+import {
+  HevcParseError,
+  NALU_TYPE_CRA_NUT,
+  NALU_TYPE_IDR_N_LP,
+  NALU_TYPE_IDR_W_RADL,
+  NALU_TYPE_PPS,
+  NALU_TYPE_PREFIX_SEI,
+  NALU_TYPE_SPS,
+  NALU_TYPE_VPS,
+  buildHevcDecoderConfigDescription,
+  extractParameterSetsAndChunk,
+  isIrapNaluType,
+  naluType,
+  payloadIsKey,
+  walkHvccNalus,
+} from "./hevc";
+
+// Build a length-prefixed NALU stream from raw NALU bodies.
+function hvcc(...nalus: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const n of nalus) {
+    total += 4 + n.length;
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const n of nalus) {
+    out[off++] = (n.length >>> 24) & 0xff;
+    out[off++] = (n.length >>> 16) & 0xff;
+    out[off++] = (n.length >>> 8) & 0xff;
+    out[off++] = n.length & 0xff;
+    out.set(n, off);
+    off += n.length;
+  }
+  return out;
+}
+
+// Construct a HEVC NALU with a given type and arbitrary RBSP body. The 2-byte
+// header carries nal_unit_type in bits 1-6 of the first byte; nuh_layer_id=0
+// and nuh_temporal_id_plus1=1 are the common defaults.
+function nalu(type: number, body: number[] = []): Uint8Array {
+  const first = (type & 0x3f) << 1;
+  const second = 0x01; // layer_id=0, temporal_id_plus1=1
+  return new Uint8Array([first, second, ...body]);
+}
+
+// Minimal SPS: 2-byte NAL header + 1 byte (vps_id|max_sub_layers|nested) +
+// 12 bytes of profile_tier_level. Values picked so the PTL extractor finds
+// recognisable bytes.
+const PTL_BYTES = [
+  0x21, // profile_space=0, tier_flag=1, profile_idc=1 (Main)
+  0x60,
+  0x00,
+  0x00,
+  0x00, // profile_compatibility_flags
+  0x90,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00, // constraint_indicator_flags
+  0x5d, // level_idc = 93 (level 3.1)
+];
+const SPS_BYTES = nalu(NALU_TYPE_SPS, [0x00, ...PTL_BYTES, 0xab, 0xcd]);
+const VPS_BYTES = nalu(NALU_TYPE_VPS, [0x0c, 0x01]);
+const PPS_BYTES = nalu(NALU_TYPE_PPS, [0xc1, 0x72]);
+
+describe("naluType / isIrapNaluType", () => {
+  it("decodes nal_unit_type from the first byte", () => {
+    expect(naluType(0x40)).toBe(32); // 0100 0000 → bits 1-6 = 100000 = 32 (VPS)
+    expect(naluType(0x42)).toBe(33); // SPS
+    expect(naluType(0x44)).toBe(34); // PPS
+    expect(naluType(0x28)).toBe(20); // IDR_N_LP
+  });
+
+  it("identifies IRAP types", () => {
+    expect(isIrapNaluType(NALU_TYPE_IDR_W_RADL)).toBe(true);
+    expect(isIrapNaluType(NALU_TYPE_IDR_N_LP)).toBe(true);
+    expect(isIrapNaluType(NALU_TYPE_CRA_NUT)).toBe(true);
+    expect(isIrapNaluType(15)).toBe(false);
+    expect(isIrapNaluType(24)).toBe(false);
+    expect(isIrapNaluType(NALU_TYPE_VPS)).toBe(false);
+  });
+});
+
+describe("walkHvccNalus", () => {
+  it("returns an empty list for an empty payload", () => {
+    expect(walkHvccNalus(new Uint8Array())).toEqual([]);
+  });
+
+  it("splits a stream of multiple NALUs preserving order", () => {
+    const out = walkHvccNalus(
+      hvcc(VPS_BYTES, SPS_BYTES, PPS_BYTES, nalu(NALU_TYPE_IDR_W_RADL, [0xff])),
+    );
+    expect(out.map((n) => n.type)).toEqual([
+      NALU_TYPE_VPS,
+      NALU_TYPE_SPS,
+      NALU_TYPE_PPS,
+      NALU_TYPE_IDR_W_RADL,
+    ]);
+  });
+
+  it("throws on a truncated length prefix", () => {
+    expect(() => walkHvccNalus(new Uint8Array([0x00, 0x00]))).toThrow(
+      HevcParseError,
+    );
+  });
+
+  it("throws when a NALU runs past the end", () => {
+    const bad = new Uint8Array([0x00, 0x00, 0x00, 0x0a, 0x40, 0x01]);
+    expect(() => walkHvccNalus(bad)).toThrow(HevcParseError);
+  });
+
+  it("throws on a too-small NALU length", () => {
+    const bad = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x40]);
+    expect(() => walkHvccNalus(bad)).toThrow(HevcParseError);
+  });
+});
+
+describe("payloadIsKey", () => {
+  it("returns true when an IRAP slice is present", () => {
+    expect(payloadIsKey(hvcc(nalu(NALU_TYPE_IDR_W_RADL, [0])))).toBe(true);
+    expect(payloadIsKey(hvcc(nalu(NALU_TYPE_CRA_NUT)))).toBe(true);
+    expect(
+      payloadIsKey(
+        hvcc(VPS_BYTES, SPS_BYTES, PPS_BYTES, nalu(NALU_TYPE_IDR_N_LP)),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for non-IRAP slices only", () => {
+    expect(payloadIsKey(hvcc(nalu(1, [0])))).toBe(false);
+    expect(payloadIsKey(hvcc(VPS_BYTES, SPS_BYTES, PPS_BYTES))).toBe(false);
+  });
+
+  it("returns false for empty payload", () => {
+    expect(payloadIsKey(new Uint8Array())).toBe(false);
+  });
+});
+
+describe("extractParameterSetsAndChunk", () => {
+  it("separates VPS+SPS+PPS at IRAP and rebuilds the chunk", () => {
+    const idr = nalu(NALU_TYPE_IDR_W_RADL, [0xa1, 0xa2, 0xa3]);
+    const r = extractParameterSetsAndChunk(
+      hvcc(VPS_BYTES, SPS_BYTES, PPS_BYTES, idr),
+    );
+    expect(r.vps).toHaveLength(1);
+    expect(Array.from(r.vps[0])).toEqual(Array.from(VPS_BYTES));
+    expect(r.sps).toHaveLength(1);
+    expect(Array.from(r.sps[0])).toEqual(Array.from(SPS_BYTES));
+    expect(r.pps).toHaveLength(1);
+    expect(Array.from(r.pps[0])).toEqual(Array.from(PPS_BYTES));
+    expect(r.isKey).toBe(true);
+    expect(Array.from(r.chunk)).toEqual([
+      0,
+      0,
+      0,
+      idr.length,
+      ...Array.from(idr),
+    ]);
+  });
+
+  it("passes through delta frames without parameter sets", () => {
+    const slice = nalu(1, [0x10, 0x20]);
+    const r = extractParameterSetsAndChunk(hvcc(slice));
+    expect(r.vps).toEqual([]);
+    expect(r.sps).toEqual([]);
+    expect(r.pps).toEqual([]);
+    expect(r.isKey).toBe(false);
+    expect(Array.from(r.chunk)).toEqual([
+      0,
+      0,
+      0,
+      slice.length,
+      ...Array.from(slice),
+    ]);
+  });
+
+  it("preserves picture-NALU order even if parameter sets are interleaved", () => {
+    const sei = nalu(NALU_TYPE_PREFIX_SEI, [0x99]);
+    const idr = nalu(NALU_TYPE_IDR_W_RADL, [0xff, 0xff]);
+    const r = extractParameterSetsAndChunk(
+      hvcc(sei, VPS_BYTES, SPS_BYTES, PPS_BYTES, idr),
+    );
+    expect(r.isKey).toBe(true);
+    expect(Array.from(r.chunk)).toEqual([
+      0,
+      0,
+      0,
+      sei.length,
+      ...Array.from(sei),
+      0,
+      0,
+      0,
+      idr.length,
+      ...Array.from(idr),
+    ]);
+  });
+
+  it("returns an empty chunk for parameter-set-only payloads", () => {
+    const r = extractParameterSetsAndChunk(
+      hvcc(VPS_BYTES, SPS_BYTES, PPS_BYTES),
+    );
+    expect(r.chunk).toHaveLength(0);
+    expect(r.isKey).toBe(false);
+  });
+});
+
+describe("buildHevcDecoderConfigDescription", () => {
+  it("produces a valid HEVCDecoderConfigurationRecord", () => {
+    const out = buildHevcDecoderConfigDescription(
+      [VPS_BYTES],
+      [SPS_BYTES],
+      [PPS_BYTES],
+    );
+    let off = 0;
+    expect(out[off++]).toBe(1); // configurationVersion
+    expect(out[off++]).toBe(PTL_BYTES[0]); // profile_space|tier|profile_idc
+    expect(Array.from(out.slice(off, off + 4))).toEqual(PTL_BYTES.slice(1, 5));
+    off += 4;
+    expect(Array.from(out.slice(off, off + 6))).toEqual(PTL_BYTES.slice(5, 11));
+    off += 6;
+    expect(out[off++]).toBe(PTL_BYTES[11]); // level_idc
+    expect(out[off++]).toBe(0xf0); // reserved | min_spatial_segmentation_idc high
+    expect(out[off++]).toBe(0x00); // min_spatial_segmentation_idc low
+    expect(out[off++]).toBe(0xfc); // reserved | parallelismType
+    expect(out[off++]).toBe(0xfd); // reserved | chromaFormat (4:2:0)
+    expect(out[off++]).toBe(0xf8); // reserved | bitDepthLumaMinus8
+    expect(out[off++]).toBe(0xf8); // reserved | bitDepthChromaMinus8
+    expect(out[off++]).toBe(0x00); // avgFrameRate hi
+    expect(out[off++]).toBe(0x00); // avgFrameRate lo
+    expect(out[off++]).toBe(0x0b); // constantFrameRate|numTemporalLayers|temporalIdNested|lengthSizeMinusOne
+    expect(out[off++]).toBe(3); // numOfArrays
+
+    // VPS array
+    expect(out[off++]).toBe(0x80 | NALU_TYPE_VPS);
+    expect((out[off] << 8) | out[off + 1]).toBe(1);
+    off += 2;
+    expect((out[off] << 8) | out[off + 1]).toBe(VPS_BYTES.length);
+    off += 2;
+    expect(Array.from(out.slice(off, off + VPS_BYTES.length))).toEqual(
+      Array.from(VPS_BYTES),
+    );
+    off += VPS_BYTES.length;
+
+    // SPS array
+    expect(out[off++]).toBe(0x80 | NALU_TYPE_SPS);
+    expect((out[off] << 8) | out[off + 1]).toBe(1);
+    off += 2;
+    expect((out[off] << 8) | out[off + 1]).toBe(SPS_BYTES.length);
+    off += 2;
+    expect(Array.from(out.slice(off, off + SPS_BYTES.length))).toEqual(
+      Array.from(SPS_BYTES),
+    );
+    off += SPS_BYTES.length;
+
+    // PPS array
+    expect(out[off++]).toBe(0x80 | NALU_TYPE_PPS);
+    expect((out[off] << 8) | out[off + 1]).toBe(1);
+    off += 2;
+    expect((out[off] << 8) | out[off + 1]).toBe(PPS_BYTES.length);
+    off += 2;
+    expect(Array.from(out.slice(off, off + PPS_BYTES.length))).toEqual(
+      Array.from(PPS_BYTES),
+    );
+    off += PPS_BYTES.length;
+
+    expect(off).toBe(out.length);
+  });
+
+  it("handles emulation-prevention bytes in the SPS PTL region", () => {
+    // PTL_BYTES has 00 00 90 at indices 3..5 (compat[2..3] + constraint[0]).
+    // In the bitstream that's escaped to 00 00 03 90 — the decoder must
+    // strip the 0x03 so the recovered PTL matches the original 12 bytes.
+    // PTL[3..4] sit at SPS indices 6..7; the 0x03 is inserted before SPS[8].
+    const sps = new Uint8Array([
+      ...SPS_BYTES.subarray(0, 8), // through PTL[4] = 0x00
+      0x03, // emulation prevention byte
+      ...SPS_BYTES.subarray(8), // PTL[5]=0x90 onwards
+    ]);
+    const out = buildHevcDecoderConfigDescription(
+      [VPS_BYTES],
+      [sps],
+      [PPS_BYTES],
+    );
+    expect(out[1]).toBe(PTL_BYTES[0]); // profile byte preserved
+    // profile_compatibility_flags (4 bytes after profile byte)
+    expect(Array.from(out.slice(2, 6))).toEqual(PTL_BYTES.slice(1, 5));
+    // constraint_indicator_flags (6 bytes) — first 3 of which include the
+    // stripped 0x00 0x00 (originally 0x00 0x00 03 90 in the bitstream).
+    expect(Array.from(out.slice(6, 12))).toEqual(PTL_BYTES.slice(5, 11));
+    expect(out[12]).toBe(PTL_BYTES[11]); // level_idc preserved
+  });
+
+  it("throws when a parameter-set list is empty", () => {
+    expect(() =>
+      buildHevcDecoderConfigDescription([], [SPS_BYTES], [PPS_BYTES]),
+    ).toThrow(HevcParseError);
+    expect(() =>
+      buildHevcDecoderConfigDescription([VPS_BYTES], [], [PPS_BYTES]),
+    ).toThrow(HevcParseError);
+    expect(() =>
+      buildHevcDecoderConfigDescription([VPS_BYTES], [SPS_BYTES], []),
+    ).toThrow(HevcParseError);
+  });
+
+  it("throws when the SPS is too short to read profile_tier_level", () => {
+    const shortSps = new Uint8Array([0x42, 0x01, 0x00, 0x00]);
+    expect(() =>
+      buildHevcDecoderConfigDescription([VPS_BYTES], [shortSps], [PPS_BYTES]),
+    ).toThrow(HevcParseError);
+  });
+});

--- a/src/loc/hevc.ts
+++ b/src/loc/hevc.ts
@@ -1,0 +1,316 @@
+// HEVC (H.265) helpers for the LOC payload path.
+//
+// LOC HEVC objects are length-prefixed NALUs (4-byte big-endian length per
+// NALU). At IRAP boundaries mlmpub prepends VPS+SPS+PPS NALUs to the payload,
+// so the player can build a fresh HEVCDecoderConfigurationRecord on first
+// keyframe and re-validate on parameter-set changes.
+//
+// References:
+//   - ISO/IEC 23008-2 §7.4.2.2 (NAL unit syntax / nal_unit_type)
+//   - ISO/IEC 14496-15 §8.3.3.1 (HEVCDecoderConfigurationRecord)
+//   - draft-ietf-moq-loc-02 §2.1 (length-prefixed NALU format)
+//   - moqlivemock/internal/media.go (HEVCData.GenLOCVideoConfig)
+
+// IRAP picture NAL unit types (ISO/IEC 23008-2 §7.4.2.2 Table 7-1).
+export const NALU_TYPE_BLA_W_LP = 16;
+export const NALU_TYPE_BLA_W_RADL = 17;
+export const NALU_TYPE_BLA_N_LP = 18;
+export const NALU_TYPE_IDR_W_RADL = 19;
+export const NALU_TYPE_IDR_N_LP = 20;
+export const NALU_TYPE_CRA_NUT = 21;
+
+// Parameter set NAL unit types.
+export const NALU_TYPE_VPS = 32;
+export const NALU_TYPE_SPS = 33;
+export const NALU_TYPE_PPS = 34;
+
+export const NALU_TYPE_AUD = 35;
+export const NALU_TYPE_PREFIX_SEI = 39;
+export const NALU_TYPE_SUFFIX_SEI = 40;
+
+export interface NaluView {
+  /** nal_unit_type (bits 1-6 of the first byte). */
+  type: number;
+  /** The NALU payload — the two header bytes plus all RBSP bytes. */
+  data: Uint8Array;
+}
+
+export class HevcParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HevcParseError";
+  }
+}
+
+/** True for IRAP NAL unit types (BLA / IDR / CRA). */
+export function isIrapNaluType(type: number): boolean {
+  return type >= NALU_TYPE_BLA_W_LP && type <= NALU_TYPE_CRA_NUT;
+}
+
+/** Read nal_unit_type from the first byte of a HEVC NALU. */
+export function naluType(firstByte: number): number {
+  return (firstByte >> 1) & 0x3f;
+}
+
+/**
+ * Split a length-prefixed NALU stream into its NALUs. Each prefix is a 4-byte
+ * big-endian length. Empty payload yields an empty array.
+ */
+export function walkHvccNalus(payload: Uint8Array): NaluView[] {
+  const result: NaluView[] = [];
+  let offset = 0;
+  while (offset < payload.length) {
+    if (offset + 4 > payload.length) {
+      throw new HevcParseError(
+        `truncated NALU length prefix at offset ${offset} (have ${payload.length - offset} bytes)`,
+      );
+    }
+    const len =
+      (payload[offset] << 24) |
+      (payload[offset + 1] << 16) |
+      (payload[offset + 2] << 8) |
+      payload[offset + 3];
+    offset += 4;
+    if (len < 2) {
+      throw new HevcParseError(
+        `NALU length ${len} too small at offset ${offset}`,
+      );
+    }
+    if (offset + len > payload.length) {
+      throw new HevcParseError(
+        `NALU of length ${len} extends past end (offset ${offset}, payload ${payload.length})`,
+      );
+    }
+    const data = payload.subarray(offset, offset + len);
+    result.push({ type: naluType(data[0]), data });
+    offset += len;
+  }
+  return result;
+}
+
+/** True when any NALU in `payload` is an IRAP slice. */
+export function payloadIsKey(payload: Uint8Array): boolean {
+  for (const n of walkHvccNalus(payload)) {
+    if (isIrapNaluType(n.type)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export interface HevcSplitResult {
+  /** Video parameter sets discovered in the payload, in arrival order. */
+  vps: Uint8Array[];
+  /** Sequence parameter sets discovered in the payload, in arrival order. */
+  sps: Uint8Array[];
+  /** Picture parameter sets discovered in the payload, in arrival order. */
+  pps: Uint8Array[];
+  /**
+   * Length-prefixed picture NALUs (slice + SEI + AUD ...) suitable for
+   * EncodedVideoChunk.data. Empty when the object only carried parameter sets.
+   */
+  chunk: Uint8Array;
+  /** True when the picture NALUs include at least one IRAP slice. */
+  isKey: boolean;
+}
+
+/**
+ * Walk an LOC HEVC payload, peel off any leading/trailing VPS+SPS+PPS NALUs,
+ * and return the picture NALUs as a fresh length-prefixed buffer. Order is
+ * preserved among picture NALUs.
+ */
+export function extractParameterSetsAndChunk(
+  payload: Uint8Array,
+): HevcSplitResult {
+  const vps: Uint8Array[] = [];
+  const sps: Uint8Array[] = [];
+  const pps: Uint8Array[] = [];
+  const picture: Uint8Array[] = [];
+  let isKey = false;
+  for (const n of walkHvccNalus(payload)) {
+    if (n.type === NALU_TYPE_VPS) {
+      vps.push(copy(n.data));
+    } else if (n.type === NALU_TYPE_SPS) {
+      sps.push(copy(n.data));
+    } else if (n.type === NALU_TYPE_PPS) {
+      pps.push(copy(n.data));
+    } else {
+      picture.push(n.data);
+      if (isIrapNaluType(n.type)) {
+        isKey = true;
+      }
+    }
+  }
+  let chunkLength = 0;
+  for (const p of picture) {
+    chunkLength += 4 + p.length;
+  }
+  const chunk = new Uint8Array(chunkLength);
+  let offset = 0;
+  for (const p of picture) {
+    chunk[offset] = (p.length >>> 24) & 0xff;
+    chunk[offset + 1] = (p.length >>> 16) & 0xff;
+    chunk[offset + 2] = (p.length >>> 8) & 0xff;
+    chunk[offset + 3] = p.length & 0xff;
+    chunk.set(p, offset + 4);
+    offset += 4 + p.length;
+  }
+  return { vps, sps, pps, chunk, isKey };
+}
+
+/**
+ * Strip emulation prevention bytes (0x000003 → 0x0000) from a NALU RBSP slice.
+ * HEVC, like AVC, escapes byte sequences that could be confused with start
+ * codes. We only need this for the 12-byte profile_tier_level region of the
+ * SPS — emulation-prevention bytes there are rare but legal.
+ */
+function stripEmulationPrevention(input: Uint8Array): Uint8Array {
+  const out = new Uint8Array(input.length);
+  let outLen = 0;
+  let zeroRun = 0;
+  for (let i = 0; i < input.length; i++) {
+    const b = input[i];
+    if (zeroRun >= 2 && b === 0x03) {
+      zeroRun = 0;
+      continue;
+    }
+    out[outLen++] = b;
+    zeroRun = b === 0 ? zeroRun + 1 : 0;
+  }
+  return out.subarray(0, outLen);
+}
+
+/**
+ * Profile/Tier/Level fields extracted from the first 12 bytes of an HEVC SPS
+ * profile_tier_level structure.
+ */
+interface ProfileTierLevel {
+  profileSpace: number; // 2 bits
+  tierFlag: number; // 1 bit
+  profileIdc: number; // 5 bits
+  profileCompatibilityFlags: Uint8Array; // 4 bytes
+  constraintIndicatorFlags: Uint8Array; // 6 bytes
+  levelIdc: number; // 8 bits
+}
+
+/**
+ * Pull the profile_tier_level prefix out of an SPS NALU.
+ *
+ * SPS layout (ISO/IEC 23008-2 §7.3.2.2):
+ *   bytes 0-1: NAL header (2 bytes)
+ *   byte 2:    sps_video_parameter_set_id(4) | sps_max_sub_layers_minus1(3)
+ *              | sps_temporal_id_nesting_flag(1)
+ *   bytes 3-14: profile_tier_level (12 bytes for the base layer prefix)
+ */
+function extractPtl(spsNalu: Uint8Array): ProfileTierLevel {
+  if (spsNalu.length < 15) {
+    throw new HevcParseError(
+      `SPS too short to read profile_tier_level (${spsNalu.length} bytes)`,
+    );
+  }
+  const stripped = stripEmulationPrevention(spsNalu);
+  if (stripped.length < 15) {
+    throw new HevcParseError(
+      `SPS too short after emulation strip (${stripped.length} bytes)`,
+    );
+  }
+  const ptl = stripped.subarray(3, 15);
+  return {
+    profileSpace: (ptl[0] >> 6) & 0x03,
+    tierFlag: (ptl[0] >> 5) & 0x01,
+    profileIdc: ptl[0] & 0x1f,
+    profileCompatibilityFlags: ptl.subarray(1, 5),
+    constraintIndicatorFlags: ptl.subarray(5, 11),
+    levelIdc: ptl[11],
+  };
+}
+
+/**
+ * Build an HEVCDecoderConfigurationRecord (the hvcC box content, which is
+ * what WebCodecs expects in `VideoDecoderConfig.description`) from VPS, SPS
+ * and PPS NALUs. Length size is fixed at 4 bytes — matches the LOC wire
+ * format and what we re-emit in `chunk`.
+ *
+ * Profile/tier/level is taken from the first SPS. Other fields (chroma
+ * format, bit depths, parallelism) are set to common 4:2:0 8-bit defaults
+ * — sufficient for the test content; would need SPS bitstream parsing to
+ * generalise.
+ */
+export function buildHevcDecoderConfigDescription(
+  vps: Uint8Array[],
+  sps: Uint8Array[],
+  pps: Uint8Array[],
+): Uint8Array {
+  if (vps.length === 0) {
+    throw new HevcParseError("at least one VPS is required");
+  }
+  if (sps.length === 0) {
+    throw new HevcParseError("at least one SPS is required");
+  }
+  if (pps.length === 0) {
+    throw new HevcParseError("at least one PPS is required");
+  }
+  const ptl = extractPtl(sps[0]);
+
+  const arrays: { type: number; nalus: Uint8Array[] }[] = [
+    { type: NALU_TYPE_VPS, nalus: vps },
+    { type: NALU_TYPE_SPS, nalus: sps },
+    { type: NALU_TYPE_PPS, nalus: pps },
+  ];
+
+  let size = 23; // fixed-length header
+  for (const arr of arrays) {
+    size += 3; // array header (1 byte type + 2 bytes numNalus)
+    for (const n of arr.nalus) {
+      size += 2 + n.length;
+    }
+  }
+
+  const out = new Uint8Array(size);
+  let off = 0;
+  out[off++] = 1; // configurationVersion
+  out[off++] =
+    ((ptl.profileSpace & 0x03) << 6) |
+    ((ptl.tierFlag & 0x01) << 5) |
+    (ptl.profileIdc & 0x1f);
+  out.set(ptl.profileCompatibilityFlags, off);
+  off += 4;
+  out.set(ptl.constraintIndicatorFlags, off);
+  off += 6;
+  out[off++] = ptl.levelIdc;
+  // reserved (4 bits, all 1s) | min_spatial_segmentation_idc (12 bits, 0)
+  out[off++] = 0xf0;
+  out[off++] = 0x00;
+  // reserved (6 bits, all 1s) | parallelismType (2 bits, 0 = mixed)
+  out[off++] = 0xfc;
+  // reserved (6 bits, all 1s) | chromaFormat (2 bits, 1 = 4:2:0)
+  out[off++] = 0xfc | 0x01;
+  // reserved (5 bits, all 1s) | bitDepthLumaMinus8 (3 bits, 0)
+  out[off++] = 0xf8;
+  // reserved (5 bits, all 1s) | bitDepthChromaMinus8 (3 bits, 0)
+  out[off++] = 0xf8;
+  // avgFrameRate (16 bits, 0 = unspecified)
+  out[off++] = 0x00;
+  out[off++] = 0x00;
+  // constantFrameRate (2) | numTemporalLayers (3) | temporalIdNested (1) | lengthSizeMinusOne (2)
+  // 0 | 1 | 0 | 3 → 0b00 001 0 11 = 0x0b
+  out[off++] = 0x0b;
+  out[off++] = arrays.length; // numOfArrays
+  for (const arr of arrays) {
+    // array_completeness=1 | reserved=0 | NAL_unit_type (6 bits)
+    out[off++] = 0x80 | (arr.type & 0x3f);
+    out[off++] = (arr.nalus.length >> 8) & 0xff;
+    out[off++] = arr.nalus.length & 0xff;
+    for (const n of arr.nalus) {
+      out[off++] = (n.length >> 8) & 0xff;
+      out[off++] = n.length & 0xff;
+      out.set(n, off);
+      off += n.length;
+    }
+  }
+  return out;
+}
+
+function copy(src: Uint8Array): Uint8Array {
+  return new Uint8Array(src);
+}

--- a/src/loc/opus.test.ts
+++ b/src/loc/opus.test.ts
@@ -1,0 +1,83 @@
+import {
+  OpusConfigError,
+  buildOpusHead,
+  buildOpusHeadFromCatalog,
+} from "./opus";
+
+describe("buildOpusHead", () => {
+  it("produces a 19-byte stereo OpusHead with sensible defaults", () => {
+    const head = buildOpusHead({ channels: 2, inputSampleRate: 48000 });
+    expect(head).toHaveLength(19);
+    // Magic "OpusHead"
+    expect(Array.from(head.slice(0, 8))).toEqual([
+      0x4f, 0x70, 0x75, 0x73, 0x48, 0x65, 0x61, 0x64,
+    ]);
+    expect(head[8]).toBe(1); // version
+    expect(head[9]).toBe(2); // channels
+    expect(head[10] | (head[11] << 8)).toBe(0); // pre-skip default
+    expect(
+      head[12] | (head[13] << 8) | (head[14] << 16) | (head[15] << 24),
+    ).toBe(48000);
+    expect(head[16] | (head[17] << 8)).toBe(0); // output gain default
+    expect(head[18]).toBe(0); // channel mapping family
+  });
+
+  it("encodes mono with the right channel count", () => {
+    const head = buildOpusHead({ channels: 1, inputSampleRate: 48000 });
+    expect(head[9]).toBe(1);
+  });
+
+  it("encodes pre-skip and output gain little-endian", () => {
+    const head = buildOpusHead({
+      channels: 2,
+      inputSampleRate: 48000,
+      preSkip: 312,
+      outputGain: -100,
+    });
+    expect(head[10] | (head[11] << 8)).toBe(312);
+    // -100 as int16 → 0xff9c.
+    expect(head[16] | (head[17] << 8)).toBe(0xff9c);
+  });
+
+  it("rejects channel counts that need a mapping table", () => {
+    expect(() =>
+      buildOpusHead({ channels: 0, inputSampleRate: 48000 }),
+    ).toThrow(OpusConfigError);
+    expect(() =>
+      buildOpusHead({ channels: 6, inputSampleRate: 48000 }),
+    ).toThrow(OpusConfigError);
+  });
+
+  it("rejects out-of-range pre-skip and gain", () => {
+    expect(() =>
+      buildOpusHead({ channels: 2, inputSampleRate: 48000, preSkip: 70_000 }),
+    ).toThrow(OpusConfigError);
+    expect(() =>
+      buildOpusHead({
+        channels: 2,
+        inputSampleRate: 48000,
+        outputGain: 40_000,
+      }),
+    ).toThrow(OpusConfigError);
+  });
+
+  it("rejects non-positive sample rates", () => {
+    expect(() => buildOpusHead({ channels: 2, inputSampleRate: 0 })).toThrow(
+      OpusConfigError,
+    );
+  });
+});
+
+describe("buildOpusHeadFromCatalog", () => {
+  it("matches buildOpusHead for the typical stereo case", () => {
+    const fromCatalog = buildOpusHeadFromCatalog(48000, "2");
+    const direct = buildOpusHead({ channels: 2, inputSampleRate: 48000 });
+    expect(Array.from(fromCatalog)).toEqual(Array.from(direct));
+  });
+
+  it("rejects non-numeric channelConfig", () => {
+    expect(() => buildOpusHeadFromCatalog(48000, "stereo")).toThrow(
+      OpusConfigError,
+    );
+  });
+});

--- a/src/loc/opus.ts
+++ b/src/loc/opus.ts
@@ -1,0 +1,111 @@
+// Opus helpers for the LOC payload path.
+//
+// LOC Opus objects are raw Opus packets without any container framing. To
+// set up a WebCodecs AudioDecoder we synthesize an Opus ID Header
+// ("OpusHead") from catalog metadata and pass it as
+// `AudioDecoderConfig.description`.
+//
+// References:
+//   - RFC 7845 §5.1 (Opus ID Header)
+//   - WebCodecs AudioDecoderConfig.description for the "opus" codec.
+//
+// All multi-byte fields in OpusHead are little-endian.
+
+export class OpusConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpusConfigError";
+  }
+}
+
+export interface OpusHeadOptions {
+  /** 1 or 2 — channel-mapping family 0 forbids more channels. */
+  channels: number;
+  /**
+   * Original input sample rate in Hz. Informational only — the Opus decoder
+   * always outputs at 48 kHz. Pass the catalog samplerate field through.
+   */
+  inputSampleRate: number;
+  /**
+   * Encoder pre-skip in 48 kHz samples. Catalogs for live content typically
+   * imply 0; this field accepts a non-default override.
+   */
+  preSkip?: number;
+  /** Output gain in Q7.8 fixed-point dB. 0 = unity. */
+  outputGain?: number;
+}
+
+const OPUS_HEAD_MAGIC = new Uint8Array([
+  0x4f,
+  0x70,
+  0x75,
+  0x73,
+  0x48,
+  0x65,
+  0x61,
+  0x64, // "OpusHead"
+]);
+
+/**
+ * Build an OpusHead suitable for `AudioDecoderConfig.description` when
+ * codec is "opus". Mapping family is fixed at 0 (mono / stereo, no mapping
+ * table) — mlmpub only emits stereo Opus today.
+ */
+export function buildOpusHead(options: OpusHeadOptions): Uint8Array {
+  const { channels, inputSampleRate } = options;
+  const preSkip = options.preSkip ?? 0;
+  const outputGain = options.outputGain ?? 0;
+  if (!Number.isInteger(channels) || channels < 1 || channels > 2) {
+    throw new OpusConfigError(
+      `mapping family 0 requires 1 or 2 channels, got ${channels}`,
+    );
+  }
+  if (
+    !Number.isInteger(inputSampleRate) ||
+    inputSampleRate <= 0 ||
+    inputSampleRate > 0xffffffff
+  ) {
+    throw new OpusConfigError(`invalid input sample rate ${inputSampleRate}`);
+  }
+  if (!Number.isInteger(preSkip) || preSkip < 0 || preSkip > 0xffff) {
+    throw new OpusConfigError(`pre-skip ${preSkip} outside [0, 65535]`);
+  }
+  if (
+    !Number.isInteger(outputGain) ||
+    outputGain < -32768 ||
+    outputGain > 32767
+  ) {
+    throw new OpusConfigError(`output gain ${outputGain} outside int16 range`);
+  }
+
+  const out = new Uint8Array(19);
+  out.set(OPUS_HEAD_MAGIC, 0);
+  out[8] = 1; // version
+  out[9] = channels;
+  out[10] = preSkip & 0xff;
+  out[11] = (preSkip >>> 8) & 0xff;
+  out[12] = inputSampleRate & 0xff;
+  out[13] = (inputSampleRate >>> 8) & 0xff;
+  out[14] = (inputSampleRate >>> 16) & 0xff;
+  out[15] = (inputSampleRate >>> 24) & 0xff;
+  // Output gain is signed 16-bit little-endian.
+  const gainU16 = outputGain & 0xffff;
+  out[16] = gainU16 & 0xff;
+  out[17] = (gainU16 >>> 8) & 0xff;
+  out[18] = 0; // channel mapping family
+  return out;
+}
+
+/** Convenience: build OpusHead from the catalog fields. */
+export function buildOpusHeadFromCatalog(
+  sampleRate: number,
+  channelConfig: string,
+): Uint8Array {
+  const channels = parseInt(channelConfig, 10);
+  if (!Number.isInteger(channels)) {
+    throw new OpusConfigError(
+      `channelConfig "${channelConfig}" is not a decimal integer`,
+    );
+  }
+  return buildOpusHead({ channels, inputSampleRate: sampleRate });
+}

--- a/src/pipeline/index.test.ts
+++ b/src/pipeline/index.test.ts
@@ -1,0 +1,138 @@
+import { WarpTrack } from "../warpcatalog";
+
+import {
+  defaultEngineForTracks,
+  engineCanPlayTracks,
+  engineSupports,
+  resolveEngine,
+  trackIsEncrypted,
+} from "./index";
+
+function track(
+  packaging: string | undefined,
+  options: { encrypted?: boolean } = {},
+): WarpTrack {
+  const t: WarpTrack = {
+    name: "test",
+    namespace: "test",
+    packaging,
+    isLive: true,
+  } as WarpTrack;
+  if (options.encrypted) {
+    t.contentProtectionRefIDs = ["cenc-ref-1"];
+  }
+  return t;
+}
+
+describe("trackIsEncrypted", () => {
+  it("treats missing or empty contentProtectionRefIDs as clear", () => {
+    expect(trackIsEncrypted(null)).toBe(false);
+    expect(trackIsEncrypted(undefined)).toBe(false);
+    expect(trackIsEncrypted(track("cmaf"))).toBe(false);
+  });
+
+  it("treats any non-empty contentProtectionRefIDs as encrypted", () => {
+    expect(trackIsEncrypted(track("cmaf", { encrypted: true }))).toBe(true);
+  });
+});
+
+describe("engineSupports", () => {
+  it("MSE handles cmaf in clear and encrypted forms", () => {
+    expect(engineSupports("mse", "cmaf", false)).toBe(true);
+    expect(engineSupports("mse", "cmaf", true)).toBe(true);
+  });
+
+  it("MSE does not yet handle loc or unknown packagings", () => {
+    // Reserve loc/locmaf reconstruction for a follow-up phase.
+    expect(engineSupports("mse", "loc", false)).toBe(false);
+    expect(engineSupports("mse", "locmaf", false)).toBe(false);
+    expect(engineSupports("mse", "moqmi", false)).toBe(false);
+  });
+
+  it("WebCodecs handles clear loc only", () => {
+    expect(engineSupports("webcodecs", "loc", false)).toBe(true);
+    expect(engineSupports("webcodecs", "loc", true)).toBe(false);
+    expect(engineSupports("webcodecs", "cmaf", false)).toBe(false);
+  });
+});
+
+describe("engineCanPlayTracks", () => {
+  it("returns true for an empty selection", () => {
+    expect(engineCanPlayTracks("mse", null, null)).toBe(true);
+    expect(engineCanPlayTracks("webcodecs", null, null)).toBe(true);
+  });
+
+  it("MSE accepts cmaf-only selections, including encrypted", () => {
+    expect(engineCanPlayTracks("mse", track("cmaf"), track("cmaf"))).toBe(true);
+    expect(
+      engineCanPlayTracks(
+        "mse",
+        track("cmaf", { encrypted: true }),
+        track("cmaf"),
+      ),
+    ).toBe(true);
+  });
+
+  it("WebCodecs accepts clear loc, rejects encrypted loc and cmaf", () => {
+    expect(engineCanPlayTracks("webcodecs", track("loc"), track("loc"))).toBe(
+      true,
+    );
+    expect(
+      engineCanPlayTracks(
+        "webcodecs",
+        track("loc", { encrypted: true }),
+        track("loc"),
+      ),
+    ).toBe(false);
+    expect(engineCanPlayTracks("webcodecs", track("cmaf"), null)).toBe(false);
+  });
+});
+
+describe("defaultEngineForTracks", () => {
+  it("falls back to mse when no tracks are present", () => {
+    expect(defaultEngineForTracks(null, null)).toBe("mse");
+  });
+
+  it("picks mse for cmaf", () => {
+    expect(defaultEngineForTracks(track("cmaf"), track("cmaf"))).toBe("mse");
+  });
+
+  it("picks webcodecs for clear loc", () => {
+    expect(defaultEngineForTracks(track("loc"), track("loc"))).toBe(
+      "webcodecs",
+    );
+  });
+
+  it("forces mse when any track is encrypted, even for loc", () => {
+    expect(
+      defaultEngineForTracks(track("loc", { encrypted: true }), track("loc")),
+    ).toBe("mse");
+  });
+
+  it("rejects mixed packagings", () => {
+    expect(() => defaultEngineForTracks(track("cmaf"), track("loc"))).toThrow(
+      /mixed packagings/i,
+    );
+  });
+});
+
+describe("resolveEngine", () => {
+  it("delegates to defaultEngineForTracks for auto", () => {
+    expect(resolveEngine("auto", track("cmaf"), null)).toBe("mse");
+    expect(resolveEngine("auto", track("loc"), null)).toBe("webcodecs");
+  });
+
+  it("respects explicit choices when compatible", () => {
+    expect(resolveEngine("mse", track("cmaf"), null)).toBe("mse");
+    expect(resolveEngine("webcodecs", track("loc"), null)).toBe("webcodecs");
+  });
+
+  it("rejects explicit choices that can't play the selection", () => {
+    expect(() => resolveEngine("webcodecs", track("cmaf"), null)).toThrow(
+      /cannot play/i,
+    );
+    expect(() =>
+      resolveEngine("webcodecs", track("loc", { encrypted: true }), null),
+    ).toThrow(/cannot play/i);
+  });
+});

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -1,0 +1,227 @@
+// Playback pipeline abstraction.
+//
+// The render path has two orthogonal axes:
+//
+//   1. Engine            — MSE (with optional EME) | WebCodecs
+//   2. Packaging         — cmaf | loc | locmaf | ... (per-track on the wire)
+//
+// Most engine/packaging combinations are valid; some require reconstruction.
+// Encrypted content can only flow through the MSE engine because production
+// browsers don't expose Encrypted WebCodecs.
+//
+//      capability matrix       cmaf      loc       locmaf
+//      ────────────────────    ────      ───       ──────
+//      mse (clear)              ✓        future    future
+//      mse (encrypted/EME)      ✓        n/a       future
+//      webcodecs (clear)        future   ✓ Phase3  future
+//      webcodecs (encrypted)    ✗        ✗         ✗
+//
+// `MsePipeline` owns MediaSource, SourceBuffer, and (eventually) MediaKeys/EME.
+// `WebCodecsLocPipeline` (Phase 3) will own VideoDecoder/AudioDecoder + canvas.
+// LOCMAF lands as additional packaging support: a payload adapter that
+// reconstructs CMAF for MSE and (clear-only) raw chunks for WebCodecs.
+
+import { ILogger } from "../logger";
+import { MOQObject } from "../transport/tracks";
+import { WarpTrack } from "../warpcatalog";
+
+/** Render engine identifiers. */
+export type Engine = "mse" | "webcodecs";
+
+/**
+ * User preference for engine selection. "auto" picks the best engine for the
+ * selected tracks; the explicit choices override and let the namespace UI
+ * filter to compatible namespaces only.
+ */
+export type EngineChoice = "auto" | "mse" | "webcodecs";
+
+/** Which media role a delivered MOQObject belongs to. */
+export type TrackRole = "video" | "audio";
+
+/** Buffer/latency knobs forwarded from the user-facing config. */
+export interface PipelineBufferConfig {
+  minimalBufferMs: number;
+  targetLatencyMs: number;
+}
+
+/** Snapshot read by the rate-control loop in player.ts. */
+export interface PipelineLatencySnapshot {
+  /**
+   * End-to-end latency in ms (wallclock now − presentation time of the frame
+   * currently on screen). null when no frame has been presented yet.
+   */
+  currentLatencyMs: number | null;
+  /** Buffered seconds ahead of the playhead in the video pipeline. */
+  videoBufferedAheadS: number;
+  /** Buffered seconds ahead of the playhead in the audio pipeline. */
+  audioBufferedAheadS: number;
+}
+
+/** What a pipeline needs to render into. Different pipelines use different parts. */
+export interface PipelineRenderTargets {
+  /** Used by MSE for both video and audio playback. */
+  videoElement: HTMLVideoElement;
+  /** Used by WebCodecs to draw decoded VideoFrames. May be hidden for MSE. */
+  canvasElement?: HTMLCanvasElement;
+}
+
+export interface PipelineSetupOptions {
+  videoTrack: WarpTrack | null;
+  audioTrack: WarpTrack | null;
+  targets: PipelineRenderTargets;
+  buffer: PipelineBufferConfig;
+  logger: ILogger;
+}
+
+/**
+ * A pipeline owns the render path from received MOQObjects to playback.
+ *
+ * Lifecycle: create → setup() → routeObject()* → dispose().
+ *
+ * Implementations must be idempotent under repeated dispose() and tolerate
+ * setup() being called only once per instance.
+ */
+export interface IPlaybackPipeline {
+  readonly engine: Engine;
+
+  /** Wire up decoders/source buffers and attach to the render targets. */
+  setup(options: PipelineSetupOptions): Promise<void>;
+
+  /** Hand off a freshly received object to the pipeline for the given role. */
+  routeObject(role: TrackRole, obj: MOQObject): void;
+
+  /** Snapshot for the rate-control loop. */
+  getLatencySnapshot(): PipelineLatencySnapshot;
+
+  /** Update the buffer/latency targets at runtime. */
+  setBufferConfig(config: PipelineBufferConfig): void;
+
+  /** Apply a playback-rate multiplier (1.0 = real-time). */
+  setPlaybackRate(rate: number): void;
+
+  /** Tear down decoders, source buffers, render scheduling. */
+  dispose(): Promise<void>;
+}
+
+/** Returns true when the track has any content protection (DRM/ECCP). */
+export function trackIsEncrypted(track: WarpTrack | null | undefined): boolean {
+  if (!track) {
+    return false;
+  }
+  return Boolean(
+    track.contentProtectionRefIDs && track.contentProtectionRefIDs.length > 0,
+  );
+}
+
+/**
+ * Capability table — kept as a function so it stays grep-able when LOCMAF or
+ * other packagings land. Returns true when the engine can play the
+ * (packaging, encrypted) combination today.
+ */
+export function engineSupports(
+  engine: Engine,
+  packaging: string | undefined,
+  encrypted: boolean,
+): boolean {
+  if (engine === "mse") {
+    // MSE handles CMAF natively today. LOC/LOCMAF reconstruction is future
+    // work but the encrypted path is reserved for MSE+EME regardless.
+    if (packaging === "cmaf") {
+      return true;
+    }
+    return false;
+  }
+  // webcodecs
+  if (encrypted) {
+    return false;
+  }
+  if (packaging === "loc") {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True when the engine can play every present track. Used by namespace
+ * filtering to highlight/enable only compatible namespaces once the user has
+ * picked an engine.
+ */
+export function engineCanPlayTracks(
+  engine: Engine,
+  videoTrack: WarpTrack | null,
+  audioTrack: WarpTrack | null,
+): boolean {
+  for (const track of [videoTrack, audioTrack]) {
+    if (!track) {
+      continue;
+    }
+    if (!engineSupports(engine, track.packaging, trackIsEncrypted(track))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Pick the engine that should play the given tracks when the user has not
+ * forced a choice. Prefers MSE for CMAF / encrypted content; prefers
+ * WebCodecs for clear LOC. Throws on mixed packagings.
+ */
+export function defaultEngineForTracks(
+  videoTrack: WarpTrack | null,
+  audioTrack: WarpTrack | null,
+): Engine {
+  const packagings = new Set<string>();
+  let anyEncrypted = false;
+  for (const track of [videoTrack, audioTrack]) {
+    if (!track) {
+      continue;
+    }
+    if (track.packaging) {
+      packagings.add(track.packaging);
+    }
+    if (trackIsEncrypted(track)) {
+      anyEncrypted = true;
+    }
+  }
+  if (packagings.size === 0) {
+    return "mse";
+  }
+  if (packagings.size > 1) {
+    throw new Error(
+      `Mixed packagings not supported: ${Array.from(packagings).join(", ")}`,
+    );
+  }
+  if (anyEncrypted) {
+    return "mse";
+  }
+  const [packaging] = packagings;
+  if (packaging === "loc") {
+    return "webcodecs";
+  }
+  if (packaging === "cmaf") {
+    return "mse";
+  }
+  throw new Error(`Unsupported track packaging: ${packaging}`);
+}
+
+/**
+ * Resolve the engine the player should actually use based on the user's
+ * choice and what the tracks support. Throws when the user forced an engine
+ * that can't play these tracks — the namespace UI is expected to prevent that.
+ */
+export function resolveEngine(
+  choice: EngineChoice,
+  videoTrack: WarpTrack | null,
+  audioTrack: WarpTrack | null,
+): Engine {
+  if (choice === "auto") {
+    return defaultEngineForTracks(videoTrack, audioTrack);
+  }
+  if (!engineCanPlayTracks(choice, videoTrack, audioTrack)) {
+    throw new Error(
+      `Engine "${choice}" cannot play the selected tracks (incompatible packaging or encryption)`,
+    );
+  }
+  return choice;
+}

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -102,6 +102,12 @@ export interface IPlaybackPipeline {
   /** Current playback-rate multiplier surfaced to the UI. */
   getPlaybackRate(): number;
 
+  /** Mute or unmute audio output. */
+  setMuted(muted: boolean): void;
+
+  /** True when audio output is muted. */
+  getMuted(): boolean;
+
   /** Tear down decoders, source buffers, render scheduling. */
   dispose(): Promise<void>;
 }

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -99,6 +99,9 @@ export interface IPlaybackPipeline {
   /** Apply a playback-rate multiplier (1.0 = real-time). */
   setPlaybackRate(rate: number): void;
 
+  /** Current playback-rate multiplier surfaced to the UI. */
+  getPlaybackRate(): number;
+
   /** Tear down decoders, source buffers, render scheduling. */
   dispose(): Promise<void>;
 }

--- a/src/pipeline/msePipeline.ts
+++ b/src/pipeline/msePipeline.ts
@@ -1,5 +1,14 @@
 import { MediaBuffer, MediaSegmentBuffer } from "../buffer";
 import { ILogger } from "../logger";
+import { MOQObject } from "../transport/tracks";
+
+import {
+  IPlaybackPipeline,
+  PipelineBufferConfig,
+  PipelineLatencySnapshot,
+  PipelineSetupOptions,
+  TrackRole,
+} from "./index";
 
 /**
  * Owns the MSE state for a single playback session: the shared MediaSource,
@@ -11,11 +20,21 @@ import { ILogger } from "../logger";
  * phases will route setup/teardown through the methods on this class and
  * tighten visibility once that's done.
  *
+ * Phase 4: MsePipeline now also implements IPlaybackPipeline, exposing
+ * getLatencySnapshot() and getPlaybackRate() so the metric panels can read
+ * MSE and WebCodecs sessions through one interface. setup() / routeObject()
+ * are no-ops on this pipeline today — the legacy player.ts flow continues
+ * to drive the MediaSource and SourceBuffers directly. They exist so the
+ * polymorphic surface compiles and to give us a hook for the future
+ * setup/teardown migration without breaking callers.
+ *
  * MediaKeys / EME setup will land here too — the (engine, packaging,
  * encryption) capability matrix in pipeline/index.ts assumes that encrypted
  * playback is owned by the MSE engine.
  */
-export class MsePipeline {
+export class MsePipeline implements IPlaybackPipeline {
+  readonly engine = "mse" as const;
+
   sharedMediaSource: MediaSource | ManagedMediaSource | null = null;
   usingManagedMediaSource = false;
   videoSourceBuffer: SourceBuffer | null = null;
@@ -24,6 +43,13 @@ export class MsePipeline {
   audioMediaSegmentBuffer: MediaSegmentBuffer | null = null;
   videoMediaBuffer: MediaBuffer | null = null;
   audioMediaBuffer: MediaBuffer | null = null;
+
+  /** Set by Player when MSE playback engages, cleared on dispose. */
+  private videoElement: HTMLVideoElement | null = null;
+  private bufferConfig: PipelineBufferConfig = {
+    minimalBufferMs: 200,
+    targetLatencyMs: 300,
+  };
 
   constructor(private readonly logger: ILogger) {}
 
@@ -81,11 +107,88 @@ export class MsePipeline {
     this.videoMediaBuffer = null;
   }
 
+  /**
+   * Attach the <video> element used by the legacy MSE flow. Stored so
+   * getLatencySnapshot() / getPlaybackRate() can read playback state without
+   * touching the DOM directly.
+   */
+  attachVideoElement(el: HTMLVideoElement | null): void {
+    this.videoElement = el;
+  }
+
+  /* --- IPlaybackPipeline ------------------------------------------------ */
+
+  /** No-op: MSE setup is currently inlined in Player.setupVideoPlayback. */
+  async setup(_options: PipelineSetupOptions): Promise<void> {
+    // Reserved for the future MSE setup migration; today the legacy flow
+    // owns the MediaSource lifecycle.
+    return;
+  }
+
+  /** No-op: MSE objects flow through the legacy buffer pipeline today. */
+  routeObject(_role: TrackRole, _obj: MOQObject): void {
+    // Reserved for the future routeObject migration.
+  }
+
+  getLatencySnapshot(): PipelineLatencySnapshot {
+    const videoEl = this.videoElement;
+    let videoBufferedAheadS = 0;
+    let audioBufferedAheadS = 0;
+    let currentLatencyMs: number | null = null;
+
+    if (videoEl) {
+      const t = videoEl.currentTime;
+      if (this.videoSourceBuffer) {
+        videoBufferedAheadS = bufferedAhead(this.videoSourceBuffer.buffered, t);
+      }
+      if (this.audioSourceBuffer) {
+        audioBufferedAheadS = bufferedAhead(this.audioSourceBuffer.buffered, t);
+      }
+      // Latency presumes the publisher's media time is wallclock-aligned
+      // (mlmpub anchors to UTC). Negative or wildly large values are
+      // surfaced as null so the UI shows N/A rather than nonsense.
+      const raw = Date.now() - t * 1000;
+      if (Number.isFinite(raw) && raw >= 0 && raw < 30_000) {
+        currentLatencyMs = raw;
+      }
+    }
+
+    return {
+      currentLatencyMs,
+      videoBufferedAheadS,
+      audioBufferedAheadS,
+    };
+  }
+
+  getPlaybackRate(): number {
+    return this.videoElement?.playbackRate ?? 1.0;
+  }
+
+  setBufferConfig(config: PipelineBufferConfig): void {
+    this.bufferConfig = config;
+  }
+
+  setPlaybackRate(rate: number): void {
+    if (this.videoElement) {
+      this.videoElement.playbackRate = rate;
+    }
+  }
+
   /** Drop all references — used during disconnect/reset. */
-  dispose(): void {
+  async dispose(): Promise<void> {
     this.clearVideo();
     this.clearAudio();
     this.sharedMediaSource = null;
     this.usingManagedMediaSource = false;
+    this.videoElement = null;
   }
+}
+
+function bufferedAhead(ranges: TimeRanges, currentTime: number): number {
+  for (let i = 0; i < ranges.length; i++) {
+    if (currentTime >= ranges.start(i) && currentTime < ranges.end(i)) {
+      return ranges.end(i) - currentTime;
+    }
+  }
+  return 0;
 }

--- a/src/pipeline/msePipeline.ts
+++ b/src/pipeline/msePipeline.ts
@@ -1,0 +1,91 @@
+import { MediaBuffer, MediaSegmentBuffer } from "../buffer";
+import { ILogger } from "../logger";
+
+/**
+ * Owns the MSE state for a single playback session: the shared MediaSource,
+ * the per-track SourceBuffers, and the segment + box parsers that feed them.
+ *
+ * State fields are public so the cutover from inlined state on Player can
+ * happen without touching every read-site. Player exposes private getter
+ * delegates that forward to these fields, which keeps the diff small. Future
+ * phases will route setup/teardown through the methods on this class and
+ * tighten visibility once that's done.
+ *
+ * MediaKeys / EME setup will land here too — the (engine, packaging,
+ * encryption) capability matrix in pipeline/index.ts assumes that encrypted
+ * playback is owned by the MSE engine.
+ */
+export class MsePipeline {
+  sharedMediaSource: MediaSource | ManagedMediaSource | null = null;
+  usingManagedMediaSource = false;
+  videoSourceBuffer: SourceBuffer | null = null;
+  audioSourceBuffer: SourceBuffer | null = null;
+  videoMediaSegmentBuffer: MediaSegmentBuffer | null = null;
+  audioMediaSegmentBuffer: MediaSegmentBuffer | null = null;
+  videoMediaBuffer: MediaBuffer | null = null;
+  audioMediaBuffer: MediaBuffer | null = null;
+
+  constructor(private readonly logger: ILogger) {}
+
+  generateVideoMimeType(codec?: string): string {
+    if (!codec) {
+      throw new Error("Video codec is required but was not provided");
+    }
+    return `video/mp4; codecs="${codec}"`;
+  }
+
+  generateAudioMimeType(codec?: string): string {
+    if (!codec) {
+      throw new Error("Audio codec is required but was not provided");
+    }
+    return `audio/mp4; codecs="${codec}"`;
+  }
+
+  /**
+   * Parse a CMAF init segment, attach the source buffer to the segment buffer,
+   * and append it. Used for both video and audio at setup time.
+   */
+  processInitSegment(
+    initData: ArrayBuffer,
+    mediaBuffer: MediaBuffer,
+    mediaSegmentBuffer: MediaSegmentBuffer,
+    sourceBuffer: SourceBuffer | ManagedSourceBuffer,
+    type: string,
+  ): void {
+    this.logger.info(`[${type}MediaBuffer] Processing init segment`);
+
+    const trackInfo = mediaBuffer.parseInitSegment(initData);
+    this.logger.info(
+      `[${type}MediaBuffer] Parsed init segment, timescale: ${trackInfo.timescale}`,
+    );
+    mediaSegmentBuffer.setSourceBuffer(sourceBuffer);
+    const initSegmentObj = mediaSegmentBuffer.addInitSegment(initData);
+    mediaSegmentBuffer.appendToSourceBuffer(initSegmentObj);
+
+    this.logger.info(
+      `[${type}MediaBuffer] Added CMAF init segment to MediaSegmentBuffer and SourceBuffer`,
+    );
+  }
+
+  /** Reset the audio half of the pipeline — used by the audio-fallback path. */
+  clearAudio(): void {
+    this.audioSourceBuffer = null;
+    this.audioMediaSegmentBuffer = null;
+    this.audioMediaBuffer = null;
+  }
+
+  /** Reset the video half of the pipeline — used by the video-fallback path. */
+  clearVideo(): void {
+    this.videoSourceBuffer = null;
+    this.videoMediaSegmentBuffer = null;
+    this.videoMediaBuffer = null;
+  }
+
+  /** Drop all references — used during disconnect/reset. */
+  dispose(): void {
+    this.clearVideo();
+    this.clearAudio();
+    this.sharedMediaSource = null;
+    this.usingManagedMediaSource = false;
+  }
+}

--- a/src/pipeline/msePipeline.ts
+++ b/src/pipeline/msePipeline.ts
@@ -174,6 +174,16 @@ export class MsePipeline implements IPlaybackPipeline {
     }
   }
 
+  setMuted(muted: boolean): void {
+    if (this.videoElement) {
+      this.videoElement.muted = muted;
+    }
+  }
+
+  getMuted(): boolean {
+    return this.videoElement?.muted ?? true;
+  }
+
   /** Drop all references — used during disconnect/reset. */
   async dispose(): Promise<void> {
     this.clearVideo();

--- a/src/pipeline/webcodecsLocPipeline.ts
+++ b/src/pipeline/webcodecsLocPipeline.ts
@@ -18,9 +18,13 @@
 import { buildAacConfigFromCatalog } from "../loc/aac";
 import {
   buildAvcDecoderConfigDescription,
-  extractParameterSetsAndChunk,
+  extractParameterSetsAndChunk as extractAvcParameterSetsAndChunk,
 } from "../loc/avc";
 import { getLocCaptureTimestampUs } from "../loc/extensions";
+import {
+  buildHevcDecoderConfigDescription,
+  extractParameterSetsAndChunk as extractHevcParameterSetsAndChunk,
+} from "../loc/hevc";
 import { buildOpusHeadFromCatalog } from "../loc/opus";
 import { ILogger } from "../logger";
 import { MOQObject } from "../transport/tracks";
@@ -52,7 +56,8 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
   private ctx: CanvasRenderingContext2D | null = null;
 
   private decoder: VideoDecoder | null = null;
-  /** Last SPS bytes used to configure the decoder, to detect parameter changes. */
+  /** Last parameter-set bytes used to configure the decoder, to detect parameter changes. */
+  private lastVps: Uint8Array | null = null;
   private lastSps: Uint8Array | null = null;
   private lastPps: Uint8Array | null = null;
 
@@ -266,8 +271,21 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
 
     const captureUsBig = getLocCaptureTimestampUs(obj.extensions);
     const captureUs = captureUsBig === null ? null : Number(captureUsBig);
+    const timestampUs = captureUs ?? this.deriveTimestampUs(obj);
 
-    const extracted = extractParameterSetsAndChunk(payload);
+    if (this.isHevcCodec()) {
+      this.routeHevcVideo(decoder, payload, timestampUs);
+    } else {
+      this.routeAvcVideo(decoder, payload, timestampUs);
+    }
+  }
+
+  private routeAvcVideo(
+    decoder: VideoDecoder,
+    payload: Uint8Array,
+    timestampUs: number,
+  ): void {
+    const extracted = extractAvcParameterSetsAndChunk(payload);
     const isKey = extracted.isKey;
 
     if (isKey) {
@@ -315,7 +333,6 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     }
 
     if (decoder.state !== "configured") {
-      // Still waiting for the first keyframe.
       return;
     }
 
@@ -328,7 +345,7 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
       decoder.decode(
         new EncodedVideoChunk({
           type: isKey ? "key" : "delta",
-          timestamp: captureUs ?? this.deriveTimestampUs(obj),
+          timestamp: timestampUs,
           data: chunkBytes,
         }),
       );
@@ -337,6 +354,96 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
         `[WebCodecsLoc] decode failed: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
+  }
+
+  private routeHevcVideo(
+    decoder: VideoDecoder,
+    payload: Uint8Array,
+    timestampUs: number,
+  ): void {
+    const extracted = extractHevcParameterSetsAndChunk(payload);
+    const isKey = extracted.isKey;
+
+    if (isKey) {
+      if (
+        extracted.vps.length === 0 ||
+        extracted.sps.length === 0 ||
+        extracted.pps.length === 0
+      ) {
+        this.logger.warn(
+          "[WebCodecsLoc] Keyframe missing VPS/SPS/PPS — dropping",
+        );
+        return;
+      }
+      const newVps = extracted.vps[0];
+      const newSps = extracted.sps[0];
+      const newPps = extracted.pps[0];
+      const needsConfigure =
+        decoder.state === "unconfigured" ||
+        !this.bytesEqual(this.lastVps, newVps) ||
+        !this.bytesEqual(this.lastSps, newSps) ||
+        !this.bytesEqual(this.lastPps, newPps);
+      if (needsConfigure) {
+        const description = buildHevcDecoderConfigDescription(
+          extracted.vps,
+          extracted.sps,
+          extracted.pps,
+        );
+        // Normalise hev1 -> hvc1 for WebCodecs. Both describe identical
+        // bitstreams; the difference is whether parameter sets travel in
+        // the sample stream (hev1) or in the hvcC box (hvc1). Since we
+        // feed VPS+SPS+PPS via `description` (the hvcC equivalent), hvc1
+        // is the correct label and broadly accepted across browsers.
+        const catalogCodec = this.videoTrack?.codec ?? "hvc1.1.6.L93.B0";
+        const codec = catalogCodec.replace(/^hev1\./i, "hvc1.");
+        const config: VideoDecoderConfig = {
+          codec,
+          codedWidth: this.videoTrack?.width,
+          codedHeight: this.videoTrack?.height,
+          description,
+          optimizeForLatency: true,
+        };
+        decoder.configure(config);
+        this.lastVps = newVps;
+        this.lastSps = newSps;
+        this.lastPps = newPps;
+        this.logger.info(
+          `[WebCodecsLoc] VideoDecoder configured (codec=${codec}` +
+            (catalogCodec !== codec
+              ? `, normalised from ${catalogCodec}`
+              : "") +
+            ")",
+        );
+      }
+    }
+
+    if (decoder.state !== "configured") {
+      return;
+    }
+
+    const chunkBytes = isKey ? extracted.chunk : payload;
+    if (chunkBytes.byteLength === 0) {
+      return;
+    }
+
+    try {
+      decoder.decode(
+        new EncodedVideoChunk({
+          type: isKey ? "key" : "delta",
+          timestamp: timestampUs,
+          data: chunkBytes,
+        }),
+      );
+    } catch (e) {
+      this.logger.error(
+        `[WebCodecsLoc] decode failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
+  private isHevcCodec(): boolean {
+    const codec = this.videoTrack?.codec?.toLowerCase() ?? "";
+    return codec.startsWith("hvc1") || codec.startsWith("hev1");
   }
 
   getLatencySnapshot(): PipelineLatencySnapshot {
@@ -462,6 +569,7 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     if (this.videoEl) {
       this.videoEl.style.display = "";
     }
+    this.lastVps = null;
     this.lastSps = null;
     this.lastPps = null;
     this.anchorWallMs = null;

--- a/src/pipeline/webcodecsLocPipeline.ts
+++ b/src/pipeline/webcodecsLocPipeline.ts
@@ -1,0 +1,684 @@
+// WebCodecs LOC playback pipeline.
+//
+// Phase 1: clear-AVC video.
+// Phase 2: clear-AAC and Opus audio, sharing the wallclock anchor with video.
+//
+// Render strategy: a canvas is overlaid on the existing <video> element
+// (the video element is hidden while this pipeline is active, then restored
+// on dispose). VideoFrames flow into a queue keyed by their capture
+// timestamp; a requestAnimationFrame loop draws frames whose timestamp is
+// at or before a wallclock-anchored playhead, then closes them.
+//
+// Audio strategy: a single AudioContext is created in setup(); the AAC/Opus
+// AudioDecoder is configured immediately from catalog metadata. Each decoded
+// AudioData is converted to an AudioBuffer and scheduled on a fresh
+// AudioBufferSourceNode at the AudioContext-time computed from the same
+// wallclock anchor used by the video render loop.
+
+import { buildAacConfigFromCatalog } from "../loc/aac";
+import {
+  buildAvcDecoderConfigDescription,
+  extractParameterSetsAndChunk,
+} from "../loc/avc";
+import { getLocCaptureTimestampUs } from "../loc/extensions";
+import { buildOpusHeadFromCatalog } from "../loc/opus";
+import { ILogger } from "../logger";
+import { MOQObject } from "../transport/tracks";
+import { WarpTrack } from "../warpcatalog";
+
+import {
+  IPlaybackPipeline,
+  PipelineBufferConfig,
+  PipelineLatencySnapshot,
+  PipelineSetupOptions,
+  TrackRole,
+} from "./index";
+
+/** A frame waiting to be drawn, keyed by its presentation time in ms. */
+interface QueuedFrame {
+  /** Presentation time in ms relative to the wallclock anchor. */
+  presentationMs: number;
+  frame: VideoFrame;
+}
+
+export class WebCodecsLocPipeline implements IPlaybackPipeline {
+  readonly engine = "webcodecs" as const;
+
+  private logger!: ILogger;
+  private videoTrack: WarpTrack | null = null;
+  private audioTrack: WarpTrack | null = null;
+  private videoEl!: HTMLVideoElement;
+  private canvas: HTMLCanvasElement | null = null;
+  private ctx: CanvasRenderingContext2D | null = null;
+
+  private decoder: VideoDecoder | null = null;
+  /** Last SPS bytes used to configure the decoder, to detect parameter changes. */
+  private lastSps: Uint8Array | null = null;
+  private lastPps: Uint8Array | null = null;
+
+  private audioDecoder: AudioDecoder | null = null;
+  private audioContext: AudioContext | null = null;
+  /**
+   * Wallclock ms at which AudioContext.currentTime was 0. Used to convert
+   * wallclock-anchored presentation times into AudioContext schedule times.
+   */
+  private audioCtxStartWallMs: number | null = null;
+  /**
+   * The latest AudioContext-time at which an audio chunk has been scheduled
+   * to *end*. Used to back-fill the schedule for chunks whose target time
+   * falls in the past so audio plays gap-free instead of being dropped.
+   */
+  private audioNextScheduleSec: number | null = null;
+  /** Newest scheduled audio presentation time in ms — for buffer-ahead. */
+  private audioNewestScheduledMs: number | null = null;
+
+  /** Wallclock ms at which presentationMs == anchorPresentationMs. */
+  private anchorWallMs: number | null = null;
+  private anchorPresentationMs = 0;
+  /** Playback-rate multiplier; 1.0 = real-time. */
+  private playbackRate = 1.0;
+
+  /** Queue of decoded frames, sorted by presentation time. */
+  private frameQueue: QueuedFrame[] = [];
+  private rafHandle: number | null = null;
+  private disposed = false;
+
+  /** Counters surfaced via getLatencySnapshot. */
+  private lastPresentedMs: number | null = null;
+
+  private bufferConfig: PipelineBufferConfig = {
+    minimalBufferMs: 200,
+    targetLatencyMs: 300,
+  };
+
+  async setup(options: PipelineSetupOptions): Promise<void> {
+    this.logger = options.logger;
+    this.videoTrack = options.videoTrack;
+    this.audioTrack = options.audioTrack;
+    this.videoEl = options.targets.videoElement;
+    this.bufferConfig = options.buffer;
+
+    if (!this.videoTrack) {
+      throw new Error("WebCodecsLocPipeline requires a video track");
+    }
+    if (typeof VideoDecoder === "undefined") {
+      throw new Error("VideoDecoder is not available in this browser");
+    }
+
+    const width = this.videoTrack.width ?? 1280;
+    const height = this.videoTrack.height ?? 720;
+
+    // Create a canvas the same size as the video container and overlay it
+    // on top of the <video> element. The video element is hidden while
+    // this pipeline runs.
+    const canvas =
+      options.targets.canvasElement ?? document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    canvas.id = canvas.id || "webcodecsCanvas";
+    canvas.style.width = "100%";
+    canvas.style.maxHeight = "100%";
+    canvas.style.background = "#000";
+    canvas.style.objectFit = "contain";
+
+    if (!canvas.isConnected) {
+      const parent = this.videoEl.parentElement;
+      if (!parent) {
+        throw new Error("Video element has no parent to host the canvas");
+      }
+      parent.insertBefore(canvas, this.videoEl);
+    }
+    this.videoEl.style.display = "none";
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      throw new Error("Could not get 2D context from canvas");
+    }
+    this.canvas = canvas;
+    this.ctx = ctx;
+
+    this.decoder = new VideoDecoder({
+      output: (frame) => this.onDecodedFrame(frame),
+      error: (e) => {
+        this.logger.error(`[WebCodecsLoc] VideoDecoder error: ${e.message}`);
+      },
+    });
+
+    this.startRenderLoop();
+
+    if (this.audioTrack) {
+      this.setupAudio();
+    }
+
+    this.logger.info(
+      `[WebCodecsLoc] setup complete; canvas ${width}x${height}, video codec=${this.videoTrack.codec}, audio codec=${this.audioTrack?.codec ?? "(none)"}`,
+    );
+  }
+
+  private setupAudio(): void {
+    const track = this.audioTrack;
+    if (!track) {
+      return;
+    }
+    if (typeof AudioDecoder === "undefined") {
+      this.logger.warn(
+        "[WebCodecsLoc] AudioDecoder not available; audio disabled",
+      );
+      return;
+    }
+    if (typeof AudioContext === "undefined") {
+      this.logger.warn(
+        "[WebCodecsLoc] AudioContext not available; audio disabled",
+      );
+      return;
+    }
+
+    const sampleRate = track.samplerate ?? 48000;
+    const channelConfig = track.channelConfig ?? "2";
+    const numberOfChannels = parseInt(channelConfig, 10);
+    if (!Number.isInteger(numberOfChannels) || numberOfChannels <= 0) {
+      this.logger.warn(
+        `[WebCodecsLoc] invalid channelConfig "${channelConfig}" — audio disabled`,
+      );
+      return;
+    }
+
+    const codec = track.codec ?? "";
+    let description: Uint8Array;
+    let configCodec: string;
+    let configSampleRate = sampleRate;
+    if (codec.startsWith("mp4a") || codec.startsWith("MP4A")) {
+      description = buildAacConfigFromCatalog(codec, sampleRate, channelConfig);
+      configCodec = codec;
+    } else if (codec.toLowerCase() === "opus") {
+      description = buildOpusHeadFromCatalog(sampleRate, channelConfig);
+      configCodec = "opus";
+      // Opus decoders always output at 48 kHz regardless of input sample rate.
+      configSampleRate = 48000;
+    } else {
+      this.logger.warn(
+        `[WebCodecsLoc] unsupported audio codec "${codec}" — audio disabled`,
+      );
+      return;
+    }
+
+    this.audioContext = new AudioContext({ sampleRate: configSampleRate });
+    if (this.audioContext.state === "suspended") {
+      this.audioContext.resume().catch(() => {
+        // Autoplay policy may block this; we'll retry on the first scheduled
+        // chunk where currentTime is captured.
+      });
+    }
+
+    this.audioDecoder = new AudioDecoder({
+      output: (data) => this.onDecodedAudio(data),
+      error: (e) => {
+        this.logger.error(`[WebCodecsLoc] AudioDecoder error: ${e.message}`);
+      },
+    });
+
+    this.audioDecoder.configure({
+      codec: configCodec,
+      sampleRate: configSampleRate,
+      numberOfChannels,
+      description,
+    });
+
+    this.logger.info(
+      `[WebCodecsLoc] AudioDecoder configured (codec=${configCodec}, sampleRate=${configSampleRate}, channels=${numberOfChannels})`,
+    );
+  }
+
+  routeObject(role: TrackRole, obj: MOQObject): void {
+    if (this.disposed) {
+      return;
+    }
+    if (role === "audio") {
+      this.routeAudio(obj);
+      return;
+    }
+    if (role !== "video") {
+      return;
+    }
+    const decoder = this.decoder;
+    if (!decoder) {
+      return;
+    }
+
+    const payload = this.toUint8(obj.data);
+    if (payload.byteLength === 0) {
+      return;
+    }
+
+    const captureUsBig = getLocCaptureTimestampUs(obj.extensions);
+    const captureUs = captureUsBig === null ? null : Number(captureUsBig);
+
+    const extracted = extractParameterSetsAndChunk(payload);
+    const isKey = extracted.isKey;
+
+    if (isKey) {
+      if (extracted.sps.length === 0 || extracted.pps.length === 0) {
+        this.logger.warn("[WebCodecsLoc] Keyframe missing SPS/PPS — dropping");
+        return;
+      }
+      const newSps = extracted.sps[0];
+      const newPps = extracted.pps[0];
+      const needsConfigure =
+        decoder.state === "unconfigured" ||
+        !this.bytesEqual(this.lastSps, newSps) ||
+        !this.bytesEqual(this.lastPps, newPps);
+      if (needsConfigure) {
+        const description = buildAvcDecoderConfigDescription(
+          extracted.sps,
+          extracted.pps,
+        );
+        // Normalise avc3 -> avc1 for WebCodecs. Both describe identical
+        // bitstreams; they differ only in whether parameter sets travel
+        // in the sample stream (avc3) or in the avcC box (avc1). Since
+        // we feed SPS+PPS via `description` (the avcC equivalent), avc1
+        // is the correct label and is the one Safari's WebCodecs accepts
+        // — Safari rejects avc3 codec strings as unsupported.
+        const catalogCodec = this.videoTrack?.codec ?? "avc1.4D401F";
+        const codec = catalogCodec.replace(/^avc3\./i, "avc1.");
+        const config: VideoDecoderConfig = {
+          codec,
+          codedWidth: this.videoTrack?.width,
+          codedHeight: this.videoTrack?.height,
+          description,
+          optimizeForLatency: true,
+        };
+        decoder.configure(config);
+        this.lastSps = newSps;
+        this.lastPps = newPps;
+        this.logger.info(
+          `[WebCodecsLoc] VideoDecoder configured (codec=${codec}` +
+            (catalogCodec !== codec
+              ? `, normalised from ${catalogCodec}`
+              : "") +
+            ")",
+        );
+      }
+    }
+
+    if (decoder.state !== "configured") {
+      // Still waiting for the first keyframe.
+      return;
+    }
+
+    const chunkBytes = isKey ? extracted.chunk : payload;
+    if (chunkBytes.byteLength === 0) {
+      return;
+    }
+
+    try {
+      decoder.decode(
+        new EncodedVideoChunk({
+          type: isKey ? "key" : "delta",
+          timestamp: captureUs ?? this.deriveTimestampUs(obj),
+          data: chunkBytes,
+        }),
+      );
+    } catch (e) {
+      this.logger.error(
+        `[WebCodecsLoc] decode failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
+  getLatencySnapshot(): PipelineLatencySnapshot {
+    const newest = this.frameQueue.length
+      ? this.frameQueue[this.frameQueue.length - 1].presentationMs
+      : this.lastPresentedMs;
+    const playheadMs = this.playheadMs();
+    let videoBufferedAheadS = 0;
+    if (newest !== null && playheadMs !== null) {
+      videoBufferedAheadS = Math.max(0, (newest - playheadMs) / 1000);
+    }
+
+    let audioBufferedAheadS = 0;
+    if (this.audioNewestScheduledMs !== null && playheadMs !== null) {
+      audioBufferedAheadS = Math.max(
+        0,
+        (this.audioNewestScheduledMs - playheadMs) / 1000,
+      );
+    }
+
+    let currentLatencyMs: number | null = null;
+    if (this.lastPresentedMs !== null) {
+      currentLatencyMs = Date.now() - this.lastPresentedMs;
+    }
+
+    return {
+      currentLatencyMs,
+      videoBufferedAheadS,
+      audioBufferedAheadS,
+    };
+  }
+
+  setBufferConfig(config: PipelineBufferConfig): void {
+    this.bufferConfig = config;
+  }
+
+  setPlaybackRate(rate: number): void {
+    if (!Number.isFinite(rate) || rate <= 0) {
+      this.logger?.warn(
+        `[WebCodecsLoc] ignoring invalid playback rate ${rate}`,
+      );
+      return;
+    }
+    // Re-anchor at the current playhead so the rate change takes effect
+    // smoothly without a jump.
+    const head = this.playheadMs();
+    if (head !== null) {
+      this.anchorWallMs = Date.now();
+      this.anchorPresentationMs = head;
+    }
+    this.playbackRate = rate;
+  }
+
+  getPlaybackRate(): number {
+    return this.playbackRate;
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    if (this.rafHandle !== null) {
+      cancelAnimationFrame(this.rafHandle);
+      this.rafHandle = null;
+    }
+    for (const q of this.frameQueue) {
+      q.frame.close();
+    }
+    this.frameQueue = [];
+
+    if (this.decoder && this.decoder.state !== "closed") {
+      try {
+        this.decoder.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.decoder = null;
+
+    if (this.audioDecoder && this.audioDecoder.state !== "closed") {
+      try {
+        this.audioDecoder.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.audioDecoder = null;
+
+    if (this.audioContext) {
+      try {
+        await this.audioContext.close();
+      } catch {
+        // ignore
+      }
+      this.audioContext = null;
+    }
+    this.audioCtxStartWallMs = null;
+    this.audioNextScheduleSec = null;
+    this.audioNewestScheduledMs = null;
+
+    if (this.canvas && this.canvas.parentElement) {
+      this.canvas.parentElement.removeChild(this.canvas);
+    }
+    this.canvas = null;
+    this.ctx = null;
+    if (this.videoEl) {
+      this.videoEl.style.display = "";
+    }
+    this.lastSps = null;
+    this.lastPps = null;
+    this.anchorWallMs = null;
+    this.lastPresentedMs = null;
+  }
+
+  /* -------------------------------------------------------------------- */
+
+  private onDecodedFrame(frame: VideoFrame): void {
+    if (this.disposed) {
+      frame.close();
+      return;
+    }
+    // VideoFrame.timestamp is microseconds.
+    const presentationMs = frame.timestamp / 1000;
+    this.ensureAnchor(presentationMs);
+    this.frameQueue.push({ presentationMs, frame });
+    // Keep the queue sorted in case decoder emits slightly out of order.
+    this.frameQueue.sort((a, b) => a.presentationMs - b.presentationMs);
+  }
+
+  /**
+   * Set the wallclock anchor on the very first sample seen (video or audio).
+   * The first sample is delayed by the configured minimal-buffer offset so
+   * the queue has a small head-start on the playhead.
+   */
+  private ensureAnchor(presentationMs: number): void {
+    if (this.anchorWallMs !== null) {
+      return;
+    }
+    this.anchorWallMs = Date.now() + this.bufferConfig.minimalBufferMs;
+    this.anchorPresentationMs = presentationMs;
+  }
+
+  private playheadMs(): number | null {
+    if (this.anchorWallMs === null) {
+      return null;
+    }
+    return (
+      this.anchorPresentationMs +
+      (Date.now() - this.anchorWallMs) * this.playbackRate
+    );
+  }
+
+  private startRenderLoop(): void {
+    const tick = () => {
+      if (this.disposed) {
+        return;
+      }
+      this.rafHandle = requestAnimationFrame(tick);
+      this.drawDueFrames();
+    };
+    this.rafHandle = requestAnimationFrame(tick);
+  }
+
+  private drawDueFrames(): void {
+    const playhead = this.playheadMs();
+    if (playhead === null || !this.ctx || !this.canvas) {
+      return;
+    }
+
+    let toDraw: QueuedFrame | null = null;
+    while (
+      this.frameQueue.length > 0 &&
+      this.frameQueue[0].presentationMs <= playhead
+    ) {
+      // If we're behind, the most recent due frame wins; close older ones.
+      if (toDraw) {
+        toDraw.frame.close();
+      }
+      const next = this.frameQueue.shift();
+      toDraw = next ?? toDraw;
+    }
+    if (!toDraw) {
+      return;
+    }
+    try {
+      this.ctx.drawImage(
+        toDraw.frame,
+        0,
+        0,
+        this.canvas.width,
+        this.canvas.height,
+      );
+      this.lastPresentedMs = toDraw.presentationMs;
+    } catch (e) {
+      this.logger.error(
+        `[WebCodecsLoc] drawImage failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    } finally {
+      toDraw.frame.close();
+    }
+  }
+
+  private routeAudio(obj: MOQObject): void {
+    const decoder = this.audioDecoder;
+    if (!decoder) {
+      return;
+    }
+    const payload = this.toUint8(obj.data);
+    if (payload.byteLength === 0) {
+      return;
+    }
+    const captureUsBig = getLocCaptureTimestampUs(obj.extensions);
+    const timestamp =
+      captureUsBig === null
+        ? this.deriveAudioTimestampUs(obj)
+        : Number(captureUsBig);
+
+    try {
+      decoder.decode(
+        new EncodedAudioChunk({
+          type: "key",
+          timestamp,
+          data: payload,
+        }),
+      );
+    } catch (e) {
+      this.logger.error(
+        `[WebCodecsLoc] audio decode failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
+  private onDecodedAudio(data: AudioData): void {
+    if (this.disposed || !this.audioContext) {
+      data.close();
+      return;
+    }
+    const audioCtx = this.audioContext;
+    if (audioCtx.state === "suspended") {
+      audioCtx.resume().catch(() => {
+        // ignore
+      });
+    }
+
+    // Capture timing fields before closing the AudioData.
+    const presentationMs = data.timestamp / 1000;
+    const numberOfChannels = data.numberOfChannels;
+    const numberOfFrames = data.numberOfFrames;
+    const sampleRate = data.sampleRate;
+
+    if (this.audioCtxStartWallMs === null) {
+      this.audioCtxStartWallMs = Date.now() - audioCtx.currentTime * 1000;
+    }
+    const audioCtxStartWallMs = this.audioCtxStartWallMs;
+    // Anchor on the first sample so audio-only sessions still play in
+    // real time.
+    this.ensureAnchor(presentationMs);
+    const anchorWallMs = this.anchorWallMs;
+    if (anchorWallMs === null) {
+      // ensureAnchor must have set this; defensive guard for TS narrowing.
+      data.close();
+      return;
+    }
+
+    const buffer = audioCtx.createBuffer(
+      numberOfChannels,
+      numberOfFrames,
+      sampleRate,
+    );
+    for (let ch = 0; ch < numberOfChannels; ch++) {
+      const channelData = new Float32Array(numberOfFrames);
+      data.copyTo(channelData, { planeIndex: ch, format: "f32-planar" });
+      buffer.copyToChannel(channelData, ch);
+    }
+    data.close();
+
+    // Wallclock at this chunk's presentation: 1 ms of media advances by
+    // 1/playbackRate ms of wallclock when rate ≠ 1.0. This mirrors the
+    // formula in playheadMs() so video and audio stay aligned under rate
+    // control.
+    const wallAtPresentation =
+      anchorWallMs +
+      (presentationMs - this.anchorPresentationMs) / this.playbackRate;
+    let when = (wallAtPresentation - audioCtxStartWallMs) / 1000;
+
+    // If the chunk's scheduled time has slipped into the past, queue it
+    // immediately after the previous chunk so audio stays gap-free.
+    const earliest = audioCtx.currentTime + 0.005;
+    if (when < earliest) {
+      when = Math.max(this.audioNextScheduleSec ?? earliest, earliest);
+    }
+
+    const source = audioCtx.createBufferSource();
+    source.buffer = buffer;
+    source.playbackRate.value = this.playbackRate;
+    source.connect(audioCtx.destination);
+    try {
+      source.start(when);
+    } catch (e) {
+      this.logger.warn(
+        `[WebCodecsLoc] audio start(${when.toFixed(3)}) failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      return;
+    }
+    // The source plays for buffer.duration / playbackRate seconds of
+    // wallclock, so the next back-to-back chunk should start there.
+    const wallDurationSec = buffer.duration / this.playbackRate;
+    this.audioNextScheduleSec = when + wallDurationSec;
+    this.audioNewestScheduledMs = presentationMs + buffer.duration * 1000;
+  }
+
+  private deriveAudioTimestampUs(obj: MOQObject): number {
+    // Fallback for audio when the publisher omits the LOC capture timestamp.
+    const sampleRate = this.audioTrack?.samplerate ?? 48000;
+    // AAC: 1024 samples/frame; Opus typical: 960 samples/frame at 48kHz.
+    // mlmpub's LOC path emits one frame per object, so just use object index.
+    const samplesPerFrame =
+      this.audioTrack?.codec?.toLowerCase() === "opus" ? 960 : 1024;
+    const groupId = Number(obj.location?.group ?? 0n);
+    const objectId = Number(obj.location?.object ?? 0n);
+    const frameIndex = groupId + objectId;
+    return Math.round((frameIndex * samplesPerFrame * 1_000_000) / sampleRate);
+  }
+
+  private deriveTimestampUs(obj: MOQObject): number {
+    // Fallback when the publisher didn't include a capture timestamp:
+    // derive from group/object id with the catalog framerate. This keeps
+    // the decoder happy even if it'll drift relative to wallclock.
+    const fps = this.videoTrack?.framerate ?? 25;
+    const objsPerGroup = 1; // one object per frame for AVC LOC video
+    const groupId = Number(obj.location?.group ?? 0n);
+    const objectId = Number(obj.location?.object ?? 0n);
+    const frameIndex = groupId * objsPerGroup + objectId;
+    return Math.round((frameIndex * 1_000_000) / fps);
+  }
+
+  private toUint8(data: Uint8Array | ArrayBuffer | undefined): Uint8Array {
+    if (!data) {
+      return new Uint8Array(0);
+    }
+    return data instanceof Uint8Array ? data : new Uint8Array(data);
+  }
+
+  private bytesEqual(
+    a: Uint8Array | null,
+    b: Uint8Array | null | undefined,
+  ): boolean {
+    if (!a || !b) {
+      return false;
+    }
+    if (a.byteLength !== b.byteLength) {
+      return false;
+    }
+    for (let i = 0; i < a.byteLength; i++) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/pipeline/webcodecsLocPipeline.ts
+++ b/src/pipeline/webcodecsLocPipeline.ts
@@ -59,6 +59,17 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
   private audioDecoder: AudioDecoder | null = null;
   private audioContext: AudioContext | null = null;
   /**
+   * GainNode sitting between every AudioBufferSourceNode and the
+   * destination. Driven by setMuted(): 1 when audible, 0 when muted.
+   */
+  private audioGain: GainNode | null = null;
+  /**
+   * Start muted to mirror the MSE path, where the <video muted> attribute
+   * makes the legacy session start silent until the user unmutes. Both
+   * engines keep the same Mute / Unmute UX this way.
+   */
+  private muted = true;
+  /**
    * Wallclock ms at which AudioContext.currentTime was 0. Used to convert
    * wallclock-anchored presentation times into AudioContext schedule times.
    */
@@ -209,6 +220,9 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
         // chunk where currentTime is captured.
       });
     }
+    this.audioGain = this.audioContext.createGain();
+    this.audioGain.gain.value = this.muted ? 0 : 1;
+    this.audioGain.connect(this.audioContext.destination);
 
     this.audioDecoder = new AudioDecoder({
       output: (data) => this.onDecodedAudio(data),
@@ -380,6 +394,17 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     return this.playbackRate;
   }
 
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+    if (this.audioGain) {
+      this.audioGain.gain.value = muted ? 0 : 1;
+    }
+  }
+
+  getMuted(): boolean {
+    return this.muted;
+  }
+
   async dispose(): Promise<void> {
     this.disposed = true;
     if (this.rafHandle !== null) {
@@ -409,6 +434,14 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     }
     this.audioDecoder = null;
 
+    if (this.audioGain) {
+      try {
+        this.audioGain.disconnect();
+      } catch {
+        // ignore
+      }
+      this.audioGain = null;
+    }
     if (this.audioContext) {
       try {
         await this.audioContext.close();
@@ -616,7 +649,7 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     const source = audioCtx.createBufferSource();
     source.buffer = buffer;
     source.playbackRate.value = this.playbackRate;
-    source.connect(audioCtx.destination);
+    source.connect(this.audioGain ?? audioCtx.destination);
     try {
       source.start(when);
     } catch (e) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -103,6 +103,12 @@ export class Player {
 
   /** Active WebCodecs pipeline when LOC playback is engaged. */
   private webcodecsPipeline: WebCodecsLocPipeline | null = null;
+  /**
+   * Display label for the DRM system negotiated for the current playback.
+   * One of "Widevine" | "PlayReady" | "FairPlay" | "ClearKey", or null when
+   * the session is clear. Surfaced in the engine-legend overlay.
+   */
+  private activeDrmLabel: string | null = null;
   /** Timer feeding the metric panels while the WebCodecs pipeline is active. */
   private webcodecsMetricsTimer: ReturnType<typeof setInterval> | null = null;
   /**
@@ -112,6 +118,15 @@ export class Player {
    * engine-agnostic.
    */
   private currentPipeline: IPlaybackPipeline | null = null;
+
+  /**
+   * Re-render the Mute/Unmute button label from currentPipeline.getMuted().
+   * Assigned by wireMuteButton(); call after every currentPipeline change so
+   * the label reflects the active engine, not the previous one. Null until
+   * the button has been wired (the user can change currentPipeline before
+   * the tracks UI is built, e.g. on disconnect, so callers must guard).
+   */
+  private refreshMuteLabel: (() => void) | null = null;
 
   // Synchronization state
   private videoBufferReady = false;
@@ -198,6 +213,59 @@ export class Player {
 
     // Create published namespaces section
     this.createPublishedNamespacesSection();
+
+    // When the user changes the render-engine choice, re-render the
+    // namespace picker so incompatible namespaces dim out.
+    const engineSelect = document.getElementById(
+      "engineChoice",
+    ) as HTMLSelectElement | null;
+    if (engineSelect) {
+      engineSelect.addEventListener("change", () => {
+        this.renderNamespaceSelector();
+        this.ensureSelectableNamespace();
+      });
+    }
+  }
+
+  /**
+   * After an engine-choice change, if the currently selected namespace is
+   * no longer selectable, switch to the first one that is. Keeps the
+   * current selection when it remains compatible.
+   */
+  private ensureSelectableNamespace(): void {
+    const choice = this.currentEngineChoice();
+    if (
+      this.selectedNamespace &&
+      this.isNamespaceSelectable(this.selectedNamespace, choice)
+    ) {
+      return;
+    }
+    const next = this.publishedNamespaces.find((ns) =>
+      this.isNamespaceSelectable(ns, choice),
+    );
+    if (next) {
+      this.selectNamespace(next);
+    }
+  }
+
+  /**
+   * True when a namespace is a media namespace, the user's render-engine
+   * choice can play it, and (if it's a ClearKey/ECCP namespace) the
+   * browser actually supports ClearKey. Used by both the namespace
+   * selector renderer and the auto-select-on-engine-change logic.
+   */
+  private isNamespaceSelectable(
+    namespace: string[],
+    engineChoice: EngineChoice,
+  ): boolean {
+    if (this.isNonMediaNamespace(namespace)) {
+      return false;
+    }
+    const joined = namespace.join("/");
+    if (joined.includes("/eccp-") && !this.clearKeySupported) {
+      return false;
+    }
+    return this.namespaceMatchesEngineChoice(namespace, engineChoice);
   }
 
   /**
@@ -465,12 +533,59 @@ export class Player {
     }
   }
 
-  /** Known non-media namespace prefixes (e.g. interop test namespaces) */
-  private static readonly NON_MEDIA_PREFIXES = ["moq-test"];
+  /**
+   * Known non-media namespace prefixes. These are surfaced in the namespace
+   * picker as inert labels rather than selectable buttons because warp-player
+   * has no playback path for them today: `moq-test` is the interop test
+   * namespace, `moq-mi/*` carries moq-mi packaging which doesn't have a
+   * pipeline implementation yet.
+   */
+  private static readonly NON_MEDIA_PREFIXES = ["moq-test", "moq-mi"];
+
+  /** Read the current value of the render-engine dropdown, default "auto". */
+  private currentEngineChoice(): EngineChoice {
+    const sel = document.getElementById(
+      "engineChoice",
+    ) as HTMLSelectElement | null;
+    const v = sel?.value ?? "auto";
+    return v === "mse" || v === "webcodecs" ? v : "auto";
+  }
+
+  /**
+   * Decide whether a published namespace is compatible with the user's
+   * render-engine choice. mlmpub's namespace prefix encodes the packaging:
+   *   cmsf/* -> CMAF (MSE)
+   *   msf/*  -> LOC (WebCodecs)
+   * For Auto we accept everything; for unknown prefixes we accept too,
+   * since the wire doesn't otherwise tell us packaging until we subscribe
+   * to the catalog.
+   */
+  private namespaceMatchesEngineChoice(
+    namespace: string[],
+    engineChoice: EngineChoice,
+  ): boolean {
+    if (engineChoice === "auto") {
+      return true;
+    }
+    const joined = namespace.join("/");
+    if (joined.startsWith("cmsf/")) {
+      return engineChoice === "mse";
+    }
+    if (joined.startsWith("msf/")) {
+      return engineChoice === "webcodecs";
+    }
+    return true;
+  }
 
   private isNonMediaNamespace(namespace: string[]): boolean {
+    // Namespaces arrive on the wire either as a real multi-element tuple
+    // (e.g. ["moq-test", "interop"]) or as a single tuple element that
+    // already contains slashes (e.g. ["moq-mi/clear"], the form mlmpub
+    // emits for its content namespaces). Compare against the slash-joined
+    // form so both shapes are recognised.
+    const joined = namespace.join("/");
     return Player.NON_MEDIA_PREFIXES.some(
-      (prefix) => namespace.length > 0 && namespace[0] === prefix,
+      (prefix) => joined === prefix || joined.startsWith(prefix + "/"),
     );
   }
 
@@ -823,6 +938,8 @@ export class Player {
       this.isNonMediaNamespace(ns),
     );
 
+    const engineChoice = this.currentEngineChoice();
+
     // Media namespace buttons on the left
     const mediaGroup = document.createElement("div");
     mediaGroup.style.cssText = "display: flex; gap: 0.5rem; flex-wrap: wrap;";
@@ -830,7 +947,11 @@ export class Player {
     for (const ns of mediaNs) {
       const nsStr = ns.join("/");
       const isEccp = nsStr.includes("/eccp-");
-      const disabled = isEccp && !this.clearKeySupported;
+      const engineCompatible = this.namespaceMatchesEngineChoice(
+        ns,
+        engineChoice,
+      );
+      const disabled = (isEccp && !this.clearKeySupported) || !engineCompatible;
 
       const btn = document.createElement("button");
       btn.className =
@@ -838,6 +959,11 @@ export class Player {
         (nsStr === selectedStr ? " selected" : "") +
         (disabled ? " disabled" : "");
       btn.textContent = nsStr;
+      if (!engineCompatible) {
+        btn.title = `${engineChoice === "mse" ? "MSE" : "WebCodecs"} engine cannot play this namespace`;
+      } else if (disabled) {
+        btn.title = "ClearKey not supported in this browser";
+      }
 
       if (!disabled) {
         btn.addEventListener("click", () => {
@@ -1009,6 +1135,49 @@ export class Player {
       };
       stopBtn.style.display = "";
     }
+
+    this.wireMuteButton();
+  }
+
+  /**
+   * Activate and wire up the Mute / Unmute toggle. Routed through the
+   * active pipeline so it works regardless of engine: MsePipeline forwards
+   * to videoElement.muted, WebCodecsLocPipeline drives a GainNode between
+   * each AudioBufferSourceNode and the AudioContext destination. We need
+   * a custom button because (a) Safari's native video controls don't
+   * expose a mute toggle the same way Chrome's do, and (b) the WebCodecs
+   * path hides the <video> entirely.
+   */
+  private wireMuteButton(): void {
+    const muteBtn = document.getElementById(
+      "muteBtn",
+    ) as HTMLButtonElement | null;
+    if (!muteBtn) {
+      return;
+    }
+    this.refreshMuteLabel = () => {
+      const muted = this.currentPipeline?.getMuted() ?? true;
+      // 🔇 = speaker with cancellation stroke (muted state, click to unmute)
+      // 🔊 = speaker with three sound waves (audible state, click to mute)
+      const icon = document.createElement("span");
+      icon.setAttribute("aria-hidden", "true");
+      icon.textContent = muted ? "🔇" : "🔊";
+      muteBtn.replaceChildren(
+        icon,
+        document.createTextNode(muted ? " Unmute" : " Mute"),
+      );
+    };
+    muteBtn.disabled = false;
+    this.refreshMuteLabel();
+    muteBtn.onclick = () => {
+      const pipeline = this.currentPipeline;
+      if (!pipeline) {
+        return;
+      }
+      const next = !pipeline.getMuted();
+      pipeline.setMuted(next);
+      this.refreshMuteLabel?.();
+    };
   }
 
   // Track subscriptions are managed through the trackSubscriptions map
@@ -1157,6 +1326,9 @@ export class Player {
     // to await it here — the legacy MSE flow tears down synchronously.
     void this.msePipeline.dispose();
     this.currentPipeline = null;
+    this.refreshMuteLabel?.();
+    this.activeDrmLabel = null;
+    this.updateEngineLegend();
 
     // Reset error handling state
     this.recoveryInProgress = false;
@@ -2295,7 +2467,9 @@ export class Player {
 
     this.webcodecsPipeline = pipeline;
     this.currentPipeline = pipeline;
+    this.refreshMuteLabel?.();
     this.playbackStarted = true;
+    this.updateEngineLegend();
 
     // The hidden <video> element doesn't fire timeupdate while WebCodecs is
     // active, so drive the metric-panel refresh ourselves.
@@ -2510,6 +2684,7 @@ export class Player {
             selectedSystemID = candidate.drmSystem.systemID;
             selectedDrmSystem = candidate.drmSystem;
             selectedInitDataType = attempt.initDataType;
+            this.activeDrmLabel = this.drmDisplayLabel(selectedSystemID);
             const resolvedConfig = access.getConfiguration();
             this.logger.info(
               `DRM accepted: keySystem=${attempt.keySystem}, initDataType=${attempt.initDataType}, resolvedConfig=${JSON.stringify(resolvedConfig)}`,
@@ -2853,6 +3028,8 @@ export class Player {
     // hand it the <video> element so it can read currentTime / playbackRate.
     this.msePipeline.attachVideoElement(videoEl);
     this.currentPipeline = this.msePipeline;
+    this.refreshMuteLabel?.();
+    this.updateEngineLegend();
 
     // Reset previous source if any
     videoEl.pause();
@@ -4236,6 +4413,68 @@ export class Player {
         rateEl.style.color = "#ef4444";
       }
     }
+  }
+
+  /** Map a DRM system UUID to a human-readable label for the legend overlay. */
+  private drmDisplayLabel(systemId: string): string {
+    switch (systemId) {
+      case this.widevine:
+        return "Widevine";
+      case this.playready:
+        return "PlayReady";
+      case this.fairplay:
+        return "FairPlay";
+      case this.clearkey:
+        return "ClearKey";
+      default:
+        return systemId;
+    }
+  }
+
+  /**
+   * Refresh the top-right overlay listing the active engine, DRM, and the
+   * selected video / audio track names. Hidden when no playback is active.
+   */
+  private updateEngineLegend(): void {
+    const el = document.getElementById("engineLegend");
+    if (!el) {
+      return;
+    }
+    if (!this.currentPipeline) {
+      el.classList.remove("active");
+      el.replaceChildren();
+      return;
+    }
+
+    const engineLabel =
+      this.currentPipeline.engine === "webcodecs" ? "WebCodecs" : "MSE";
+    const rows: Array<[string, string]> = [];
+    if (this.selectedNamespace && this.selectedNamespace.length > 0) {
+      rows.push(["Namespace", this.selectedNamespace.join("/")]);
+    }
+    rows.push(["Engine", engineLabel]);
+    rows.push(["DRM", this.activeDrmLabel ?? "None"]);
+    if (this.videoTrack?.name) {
+      rows.push(["Video", this.videoTrack.name]);
+    }
+    if (this.audioTrack?.name) {
+      rows.push(["Audio", this.audioTrack.name]);
+    }
+
+    el.replaceChildren();
+    for (const [key, val] of rows) {
+      const row = document.createElement("div");
+      row.className = "row";
+      const k = document.createElement("span");
+      k.className = "key";
+      k.textContent = `${key}:`;
+      const v = document.createElement("span");
+      v.className = "val";
+      v.textContent = val;
+      row.append(k, v);
+      el.appendChild(row);
+    }
+    el.classList.add("active");
   }
 
   /**

--- a/src/player.ts
+++ b/src/player.ts
@@ -537,7 +537,7 @@ export class Player {
             const text = new TextDecoder().decode(obj.data);
             const catalog = JSON.parse(text); // If using CBOR, replace this with CBOR decoding
             // Use the catalog manager to handle the catalog data
-            this.catalogManager.handleCatalogData(catalog);
+            this.catalogManager.handleCatalogData(catalog, namespaceStr);
           } catch (e) {
             this.logger.error(
               `Failed to decode catalog data: ${
@@ -607,7 +607,7 @@ export class Player {
           try {
             const text = new TextDecoder().decode(obj.data);
             const catalog = JSON.parse(text);
-            this.catalogManager.handleCatalogData(catalog);
+            this.catalogManager.handleCatalogData(catalog, namespaceStr);
           } catch (e) {
             this.logger.error(
               `Failed to decode fetched catalog data: ${

--- a/src/player.ts
+++ b/src/player.ts
@@ -6,7 +6,9 @@ import {
 
 import { MediaBuffer, MediaSegmentBuffer } from "./buffer";
 import { ILogger, LoggerFactory } from "./logger";
+import { EngineChoice, IPlaybackPipeline, resolveEngine } from "./pipeline";
 import { MsePipeline } from "./pipeline/msePipeline";
+import { WebCodecsLocPipeline } from "./pipeline/webcodecsLocPipeline";
 import { Client, DraftVersion } from "./transport/client";
 import { MOQObject } from "./transport/tracks";
 import {
@@ -98,6 +100,18 @@ export class Player {
 
   private videoTrack: WarpTrack | null = null;
   private audioTrack: WarpTrack | null = null;
+
+  /** Active WebCodecs pipeline when LOC playback is engaged. */
+  private webcodecsPipeline: WebCodecsLocPipeline | null = null;
+  /** Timer feeding the metric panels while the WebCodecs pipeline is active. */
+  private webcodecsMetricsTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Pipeline currently driving the metric panels — points at msePipeline for
+   * MSE/CMAF sessions and webcodecsPipeline for LOC sessions. Both implement
+   * IPlaybackPipeline.getLatencySnapshot()/getPlaybackRate(), so the UI is
+   * engine-agnostic.
+   */
+  private currentPipeline: IPlaybackPipeline | null = null;
 
   // Synchronization state
   private videoBufferReady = false;
@@ -1071,6 +1085,22 @@ export class Player {
       }
     }
 
+    // Tear down the WebCodecs pipeline if active.
+    if (this.webcodecsMetricsTimer !== null) {
+      clearInterval(this.webcodecsMetricsTimer);
+      this.webcodecsMetricsTimer = null;
+    }
+    if (this.webcodecsPipeline) {
+      try {
+        await this.webcodecsPipeline.dispose();
+      } catch (e) {
+        this.logger.warn(
+          `Error disposing WebCodecsLoc pipeline: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+      this.webcodecsPipeline = null;
+    }
+
     // Reset video element
     const videoEl = document.getElementById("videoPlayer") as HTMLVideoElement;
     if (videoEl) {
@@ -1123,8 +1153,10 @@ export class Player {
     this.videoObjectsReceived = 0;
     this.audioObjectsReceived = 0;
 
-    // Reset buffer variables
-    this.msePipeline.dispose();
+    // Reset buffer variables. dispose() returns a promise but we don't need
+    // to await it here — the legacy MSE flow tears down synchronously.
+    void this.msePipeline.dispose();
+    this.currentPipeline = null;
 
     // Reset error handling state
     this.recoveryInProgress = false;
@@ -2171,12 +2203,146 @@ export class Player {
       this.logger.info("DRM information not found, skipping DRM setup");
     }
 
+    // Pick the render engine. The dropdown lets the user force MSE or
+    // WebCodecs; "auto" falls back to packaging-based selection.
+    const engineSelect = document.getElementById(
+      "engineChoice",
+    ) as HTMLSelectElement | null;
+    const engineChoice = (engineSelect?.value ?? "auto") as EngineChoice;
+    let engine: "mse" | "webcodecs";
+    try {
+      engine = resolveEngine(
+        engineChoice,
+        videoTrack ?? null,
+        audioTrack ?? null,
+      );
+    } catch (e) {
+      this.logger.error(
+        `Engine choice "${engineChoice}" cannot play the selected tracks: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      return;
+    }
+
+    if (engine === "webcodecs") {
+      if (!videoTrack) {
+        this.logger.error(
+          "WebCodecs engine requires a video track; aborting Start",
+        );
+        return;
+      }
+      const locAudio =
+        audioTrack && audioTrack.packaging === "loc" ? audioTrack : null;
+      await this.setupLocPlayback(videoTrack, locAudio);
+      return;
+    }
+
     // Setup MediaSource and SourceBuffer for audio and video
     if (audioTrack) {
       this.setupAudioPlayback(audioTrack);
     }
     if (videoTrack) {
       this.setupVideoPlayback(videoTrack);
+    }
+  }
+
+  /**
+   * WebCodecs LOC playback entry point. Subscribes to the LOC video and (if
+   * present) LOC audio track and routes objects into the pipeline.
+   */
+  private async setupLocPlayback(
+    videoTrack: WarpTrack,
+    audioTrack: WarpTrack | null,
+  ): Promise<void> {
+    this.logger.info(
+      `[WebCodecsLoc] Setting up LOC playback for ${videoTrack.namespace}/${videoTrack.name}` +
+        (audioTrack ? ` + ${audioTrack.namespace}/${audioTrack.name}` : ""),
+    );
+    this.videoTrack = videoTrack;
+    if (audioTrack) {
+      this.audioTrack = audioTrack;
+    }
+
+    const videoEl = document.getElementById("videoPlayer") as HTMLVideoElement;
+    if (!videoEl) {
+      this.logger.error("Video element not found");
+      return;
+    }
+    // Stop and detach the legacy MSE element so its decoder doesn't fight
+    // with the canvas overlay.
+    videoEl.pause();
+    videoEl.removeAttribute("src");
+    videoEl.srcObject = null;
+    videoEl.load();
+
+    const pipeline = new WebCodecsLocPipeline();
+    try {
+      await pipeline.setup({
+        videoTrack,
+        audioTrack,
+        targets: { videoElement: videoEl },
+        buffer: {
+          minimalBufferMs: this.minimalBufferMs,
+          targetLatencyMs: this.targetLatencyMs,
+        },
+        logger: this.logger,
+      });
+    } catch (e) {
+      this.logger.error(
+        `[WebCodecsLoc] setup failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      return;
+    }
+
+    this.webcodecsPipeline = pipeline;
+    this.currentPipeline = pipeline;
+    this.playbackStarted = true;
+
+    // The hidden <video> element doesn't fire timeupdate while WebCodecs is
+    // active, so drive the metric-panel refresh ourselves.
+    this.webcodecsMetricsTimer = setInterval(() => {
+      this.updateBufferLevelUI();
+    }, 250);
+
+    await this.subscribeToVideoTrack(videoTrack, (obj) => {
+      pipeline.routeObject("video", obj as unknown as MOQObject);
+    });
+    if (audioTrack) {
+      await this.subscribeLocAudioTrack(audioTrack, (obj) => {
+        pipeline.routeObject("audio", obj);
+      });
+    }
+  }
+
+  /**
+   * Subscribe to a LOC audio track and route MOQObjects into the pipeline.
+   * The legacy MSE-aware subscribeToAudioTrack assumes a SourceBuffer pipeline
+   * and pre-existing MediaSegmentBuffer state, neither of which apply to
+   * WebCodecs LOC.
+   */
+  private async subscribeLocAudioTrack(
+    track: WarpTrack,
+    onObject: (obj: MOQObject) => void,
+  ): Promise<void> {
+    if (!this.client) {
+      this.logger.error("Client not initialized");
+      return;
+    }
+    const namespace = track.namespace || "";
+    const trackKey = `${namespace}/${track.name}`;
+    this.logger.info(`Subscribing to LOC audio track: ${trackKey}`);
+    try {
+      const trackAlias = await this.client.subscribeTrack(
+        namespace,
+        track.name,
+        onObject,
+      );
+      this.trackSubscriptions.set(trackKey, trackAlias);
+    } catch (error) {
+      this.logger.error(
+        `Error subscribing to LOC audio track ${trackKey}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
 
@@ -2682,6 +2848,11 @@ export class Player {
       this.logger.error("Video element not found");
       return;
     }
+
+    // The MsePipeline now drives the metric panels through getLatencySnapshot();
+    // hand it the <video> element so it can read currentTime / playbackRate.
+    this.msePipeline.attachVideoElement(videoEl);
+    this.currentPipeline = this.msePipeline;
 
     // Reset previous source if any
     videoEl.pause();
@@ -3981,7 +4152,166 @@ export class Player {
   private lastUpdateTime: number = 0;
 
   /**
-   * Update the buffer level and playback latency UI elements
+   * Paint the Playback-Information cards (Video Buffer, Audio Buffer,
+   * Latency, Playback Rate) from a pipeline-supplied snapshot. Used by the
+   * WebCodecs LOC path; the MSE path still reads from <video>/SourceBuffer
+   * directly further below.
+   */
+  private renderMetricPanelsFromSnapshot(
+    snapshot: {
+      currentLatencyMs: number | null;
+      videoBufferedAheadS: number;
+      audioBufferedAheadS: number;
+    },
+    playbackRate: number,
+  ): void {
+    const minimalBufferMs = this.minimalBufferMs;
+    const paintBuffer = (
+      el: HTMLElement | null,
+      ms: number,
+      hasTrack: boolean,
+    ) => {
+      if (!el) {
+        return;
+      }
+      el.textContent = hasTrack ? `${Math.round(ms)} ms` : "N/A";
+      if (!hasTrack) {
+        el.style.color = "#6b7280";
+        if (el.parentElement) {
+          el.parentElement.style.backgroundColor = "";
+        }
+        return;
+      }
+      if (ms < minimalBufferMs) {
+        el.style.color = "#ef4444";
+        if (el.parentElement) {
+          el.parentElement.style.backgroundColor = "#fee2e2";
+        }
+      } else if (ms < minimalBufferMs + 50) {
+        el.style.color = "#f59e0b";
+        if (el.parentElement) {
+          el.parentElement.style.backgroundColor = "#fef3c7";
+        }
+      } else {
+        el.style.color = "";
+        if (el.parentElement) {
+          el.parentElement.style.backgroundColor = "";
+        }
+      }
+    };
+
+    paintBuffer(
+      document.getElementById("videoBufferLevel"),
+      snapshot.videoBufferedAheadS * 1000,
+      this.videoTrack !== null,
+    );
+    paintBuffer(
+      document.getElementById("audioBufferLevel"),
+      snapshot.audioBufferedAheadS * 1000,
+      this.audioTrack !== null,
+    );
+
+    const latencyEl = document.getElementById("playbackLatency");
+    if (latencyEl) {
+      if (snapshot.currentLatencyMs === null) {
+        latencyEl.textContent = "N/A";
+        latencyEl.style.color = "#6b7280";
+      } else {
+        latencyEl.textContent = `${Math.round(snapshot.currentLatencyMs)} ms`;
+        latencyEl.style.color = "";
+      }
+    }
+
+    const rateEl = document.getElementById("playbackRate");
+    if (rateEl) {
+      rateEl.textContent = `${playbackRate.toFixed(3)}x`;
+      // Tri-state coloring matches the legacy MSE indicator so MSE and
+      // WebCodecs sessions render identically.
+      const delta = Math.abs(playbackRate - 1.0);
+      if (delta < 0.005) {
+        rateEl.style.color = "#10b981";
+      } else if (delta < 0.02) {
+        rateEl.style.color = "#f59e0b";
+      } else {
+        rateEl.style.color = "#ef4444";
+      }
+    }
+  }
+
+  /**
+   * Buffer-health rate controller for the WebCodecs pipeline. Mirrors the
+   * latency-targeting branches of checkBufferHealth(), but reads/writes
+   * through IPlaybackPipeline instead of <video>. No stall-recovery branch:
+   * WebCodecs has no native "stalled" state — the decoder just empties.
+   */
+  private adjustWebCodecsRate(
+    pipeline: IPlaybackPipeline,
+    snap: {
+      currentLatencyMs: number | null;
+      videoBufferedAheadS: number;
+      audioBufferedAheadS: number;
+    },
+    currentRate: number,
+  ): void {
+    if (snap.currentLatencyMs === null) {
+      return;
+    }
+
+    const minimalBufferSec = this.minimalBufferMs / 1000;
+    const targetLatencyMs = this.targetLatencyMs;
+    const currentLatencyMs = snap.currentLatencyMs;
+
+    // Use the lower of the two buffers when audio is present, otherwise just
+    // video — matches the legacy controller's effectiveMinBuffer semantics.
+    const effectiveMinBuffer = this.audioTrack
+      ? Math.min(snap.videoBufferedAheadS, snap.audioBufferedAheadS)
+      : snap.videoBufferedAheadS;
+    const belowMinimalBuffer = effectiveMinBuffer < minimalBufferSec;
+    const aboveTargetLatency = currentLatencyMs > targetLatencyMs;
+    const belowTargetLatency = currentLatencyMs < targetLatencyMs;
+
+    let newRate: number | null = null;
+    if (belowMinimalBuffer) {
+      // Buffer underrun risk — slow down to let it grow.
+      newRate = 0.97;
+    } else if (aboveTargetLatency) {
+      // Above target latency — speed up modestly, capped at 1.02.
+      const latencyError =
+        (currentLatencyMs - targetLatencyMs) / targetLatencyMs;
+      const baseGain = 0.03;
+      const gainReduction = Math.exp(-Math.abs(latencyError) * 10);
+      const effectiveGain = baseGain * (1 - gainReduction * 0.8);
+      newRate = Math.min(1.02, 1.0 + latencyError * effectiveGain);
+    } else if (belowTargetLatency) {
+      // Below target latency — slow down modestly, floored at 0.95.
+      const latencyError =
+        (targetLatencyMs - currentLatencyMs) / targetLatencyMs;
+      const baseGain = 0.05;
+      const gainReduction = Math.exp(-Math.abs(latencyError) * 15);
+      const effectiveGain = baseGain * (1 - gainReduction * 0.9);
+      newRate = Math.max(0.95, 1.0 - latencyError * effectiveGain);
+    }
+
+    if (newRate === null) {
+      return;
+    }
+    if (Math.abs(currentRate - newRate) < 0.001) {
+      return;
+    }
+    pipeline.setPlaybackRate(newRate);
+    if (Math.random() < 0.1) {
+      this.logger.debug(
+        `[BufferHealth] WebCodecs rate ${currentRate.toFixed(3)}→${newRate.toFixed(3)}` +
+          ` (latency ${currentLatencyMs.toFixed(0)}ms target ${targetLatencyMs}ms,` +
+          ` minBuf ${(effectiveMinBuffer * 1000).toFixed(0)}ms)`,
+      );
+    }
+  }
+
+  /**
+   * Update the buffer level and playback latency UI elements through the
+   * active pipeline's snapshot. Both MsePipeline and WebCodecsLocPipeline
+   * implement IPlaybackPipeline, so the UI is engine-agnostic.
    */
   private updateBufferLevelUI(): void {
     const now = Date.now();
@@ -3993,170 +4323,41 @@ export class Player {
 
     this.lastUpdateTime = now;
 
-    // Get video element
-    const videoEl = document.getElementById("videoPlayer") as HTMLVideoElement;
-    if (!videoEl) {
+    const pipeline = this.currentPipeline;
+    if (pipeline && this.playbackStarted) {
+      try {
+        const snap = pipeline.getLatencySnapshot();
+        const rate = pipeline.getPlaybackRate();
+        this.renderMetricPanelsFromSnapshot(snap, rate);
+        // The legacy MSE controller in checkBufferHealth() runs from
+        // monitorSync (timeupdate-driven) and writes videoEl.playbackRate
+        // directly. With WebCodecs the <video> never advances, so route the
+        // pipeline through a snapshot-based equivalent.
+        if (pipeline.engine === "webcodecs") {
+          this.adjustWebCodecsRate(pipeline, snap, rate);
+        }
+      } catch (e) {
+        this.logger.error(`[UI] Error updating buffer level UI: ${e}`);
+      }
       return;
     }
 
-    try {
-      // Get buffer parameters for UI display
-      const minimalBufferMs = this.minimalBufferMs;
-      const targetLatencyMs = this.targetLatencyMs;
-
-      // Debug log occasionally
-      if (Math.random() < 0.02) {
-        this.logger.debug(
-          `[UI] Minimal buffer: ${minimalBufferMs}ms, Target latency: ${targetLatencyMs}ms`,
-        );
+    // No active pipeline yet — show inactive placeholders.
+    const inactive = (id: string) => {
+      const el = document.getElementById(id);
+      if (!el) {
+        return;
       }
-
-      // Calculate current buffer levels
-      const currentTime = videoEl.currentTime;
-      let videoBufferAhead = 0;
-      let audioBufferAhead = 0;
-
-      // Find how much buffer we have ahead of the current position
-      if (this.videoSourceBuffer) {
-        for (let i = 0; i < this.videoSourceBuffer.buffered.length; i++) {
-          if (
-            currentTime >= this.videoSourceBuffer.buffered.start(i) &&
-            currentTime < this.videoSourceBuffer.buffered.end(i)
-          ) {
-            videoBufferAhead =
-              this.videoSourceBuffer.buffered.end(i) - currentTime;
-            break;
-          }
-        }
+      el.textContent = "N/A";
+      el.style.color = "#6b7280";
+      if (el.parentElement) {
+        el.parentElement.style.backgroundColor = "";
       }
-
-      if (this.audioSourceBuffer) {
-        for (let i = 0; i < this.audioSourceBuffer.buffered.length; i++) {
-          if (
-            currentTime >= this.audioSourceBuffer.buffered.start(i) &&
-            currentTime < this.audioSourceBuffer.buffered.end(i)
-          ) {
-            audioBufferAhead =
-              this.audioSourceBuffer.buffered.end(i) - currentTime;
-            break;
-          }
-        }
-      }
-
-      // Update stored values for other uses
-      this.lastVideoBufferAhead = videoBufferAhead;
-      this.lastAudioBufferAhead = audioBufferAhead;
-
-      // Update video buffer level display
-      const videoBufferEl = document.getElementById("videoBufferLevel");
-      if (videoBufferEl) {
-        const videoBufferMs = Math.round(videoBufferAhead * 1000);
-        videoBufferEl.textContent = this.videoSourceBuffer
-          ? `${videoBufferMs} ms`
-          : "N/A";
-
-        // Add color coding based on comparison to minimal buffer
-        // Red if below minimal buffer, orange if close (within 50ms)
-        if (this.videoSourceBuffer) {
-          if (videoBufferMs < minimalBufferMs) {
-            videoBufferEl.style.color = "#ef4444"; // Red for below minimal
-            if (videoBufferEl.parentElement) {
-              videoBufferEl.parentElement.style.backgroundColor = "#fee2e2"; // Light red background
-            }
-          } else if (videoBufferMs < minimalBufferMs + 50) {
-            videoBufferEl.style.color = "#f59e0b"; // Orange for close to minimal
-            if (videoBufferEl.parentElement) {
-              videoBufferEl.parentElement.style.backgroundColor = "#fef3c7"; // Light orange background
-            }
-          } else {
-            videoBufferEl.style.color = ""; // Reset to CSS default
-            if (videoBufferEl.parentElement) {
-              videoBufferEl.parentElement.style.backgroundColor = ""; // Reset background
-            }
-          }
-        } else {
-          videoBufferEl.style.color = "#6b7280"; // Gray for inactive
-        }
-      }
-
-      // Update audio buffer level display
-      const audioBufferEl = document.getElementById("audioBufferLevel");
-      if (audioBufferEl) {
-        const audioBufferMs = Math.round(audioBufferAhead * 1000);
-        audioBufferEl.textContent = this.audioSourceBuffer
-          ? `${audioBufferMs} ms`
-          : "N/A";
-
-        // Add color coding based on comparison to minimal buffer
-        // Red if below minimal buffer, orange if close (within 50ms)
-        if (this.audioSourceBuffer) {
-          if (audioBufferMs < minimalBufferMs) {
-            audioBufferEl.style.color = "#ef4444"; // Red for below minimal
-            if (audioBufferEl.parentElement) {
-              audioBufferEl.parentElement.style.backgroundColor = "#fee2e2"; // Light red background
-            }
-          } else if (audioBufferMs < minimalBufferMs + 50) {
-            audioBufferEl.style.color = "#f59e0b"; // Orange for close to minimal
-            if (audioBufferEl.parentElement) {
-              audioBufferEl.parentElement.style.backgroundColor = "#fef3c7"; // Light orange background
-            }
-          } else {
-            audioBufferEl.style.color = ""; // Reset to CSS default
-            if (audioBufferEl.parentElement) {
-              audioBufferEl.parentElement.style.backgroundColor = ""; // Reset background
-            }
-          }
-        } else {
-          audioBufferEl.style.color = "#6b7280"; // Gray for inactive
-        }
-      }
-
-      // Calculate and update playback latency
-      const playbackLatencyEl = document.getElementById("playbackLatency");
-      if (playbackLatencyEl) {
-        if (this.playbackStarted) {
-          // Calculate playback latency (now - videoEl.currentTime)
-          // Latency is the difference between wall clock time and playback time
-          // This is always positive in our real-time streaming scenario
-          if (videoEl) {
-            // Calculate estimated latency in milliseconds given that the media time
-            // is synchronized with UTC time
-            const latencyMs = Math.round(now - videoEl.currentTime * 1000);
-            playbackLatencyEl.textContent = `${latencyMs} ms`;
-
-            // Keep default orange color from CSS
-            playbackLatencyEl.style.color = ""; // Use CSS default
-          }
-        } else {
-          playbackLatencyEl.textContent = "N/A";
-          playbackLatencyEl.style.color = "#6b7280"; // Gray for inactive
-        }
-      }
-
-      // Update playback rate display
-      const playbackRateEl = document.getElementById("playbackRate");
-      if (playbackRateEl) {
-        if (videoEl && this.playbackStarted) {
-          const rate = videoEl.playbackRate;
-          playbackRateEl.textContent = `${rate.toFixed(3)}x`; // Show 3 decimal places
-
-          // Color coding based on playback rate
-          // Green for very close to normal, orange for minor adjustments, red for significant adjustments
-          if (Math.abs(rate - 1.0) < 0.005) {
-            playbackRateEl.style.color = "#10b981"; // Green for very close to normal
-          } else if (Math.abs(rate - 1.0) < 0.02) {
-            playbackRateEl.style.color = "#f59e0b"; // Orange for minor adjustment
-          } else {
-            playbackRateEl.style.color = "#ef4444"; // Red for significant adjustment
-          }
-        } else {
-          playbackRateEl.textContent = "N/A";
-          playbackRateEl.style.color = "#6b7280"; // Gray for inactive
-        }
-      }
-    } catch (e) {
-      this.logger.error(`[UI] Error updating buffer level UI: ${e}`);
-    }
+    };
+    inactive("videoBufferLevel");
+    inactive("audioBufferLevel");
+    inactive("playbackLatency");
+    inactive("playbackRate");
   }
 
   /**

--- a/src/player.ts
+++ b/src/player.ts
@@ -6,6 +6,7 @@ import {
 
 import { MediaBuffer, MediaSegmentBuffer } from "./buffer";
 import { ILogger, LoggerFactory } from "./logger";
+import { MsePipeline } from "./pipeline/msePipeline";
 import { Client, DraftVersion } from "./transport/client";
 import { MOQObject } from "./transport/tracks";
 import {
@@ -40,15 +41,61 @@ export class Player {
   private onConnectionStateChange: ((connected: boolean) => void) | null = null;
   private draftVersion: DraftVersion = "auto";
 
-  // Shared media elements for synchronized playback
-  private sharedMediaSource: MediaSource | ManagedMediaSource | null = null;
-  private usingManagedMediaSource = false;
-  private videoSourceBuffer: SourceBuffer | null = null;
-  private audioSourceBuffer: SourceBuffer | null = null;
-  private videoMediaSegmentBuffer: MediaSegmentBuffer | null = null;
-  private audioMediaSegmentBuffer: MediaSegmentBuffer | null = null;
-  private videoMediaBuffer: MediaBuffer | null = null;
-  private audioMediaBuffer: MediaBuffer | null = null;
+  // MSE state lives on MsePipeline; the getters/setters below keep
+  // existing call-sites in this file unchanged while the source of truth
+  // moves out. Future phases will replace direct delegate access with
+  // explicit MsePipeline method calls (attachToVideoElement, etc.).
+  private msePipeline!: MsePipeline;
+
+  private get sharedMediaSource(): MediaSource | ManagedMediaSource | null {
+    return this.msePipeline.sharedMediaSource;
+  }
+  private set sharedMediaSource(v: MediaSource | ManagedMediaSource | null) {
+    this.msePipeline.sharedMediaSource = v;
+  }
+  private get usingManagedMediaSource(): boolean {
+    return this.msePipeline.usingManagedMediaSource;
+  }
+  private set usingManagedMediaSource(v: boolean) {
+    this.msePipeline.usingManagedMediaSource = v;
+  }
+  private get videoSourceBuffer(): SourceBuffer | null {
+    return this.msePipeline.videoSourceBuffer;
+  }
+  private set videoSourceBuffer(v: SourceBuffer | null) {
+    this.msePipeline.videoSourceBuffer = v;
+  }
+  private get audioSourceBuffer(): SourceBuffer | null {
+    return this.msePipeline.audioSourceBuffer;
+  }
+  private set audioSourceBuffer(v: SourceBuffer | null) {
+    this.msePipeline.audioSourceBuffer = v;
+  }
+  private get videoMediaSegmentBuffer(): MediaSegmentBuffer | null {
+    return this.msePipeline.videoMediaSegmentBuffer;
+  }
+  private set videoMediaSegmentBuffer(v: MediaSegmentBuffer | null) {
+    this.msePipeline.videoMediaSegmentBuffer = v;
+  }
+  private get audioMediaSegmentBuffer(): MediaSegmentBuffer | null {
+    return this.msePipeline.audioMediaSegmentBuffer;
+  }
+  private set audioMediaSegmentBuffer(v: MediaSegmentBuffer | null) {
+    this.msePipeline.audioMediaSegmentBuffer = v;
+  }
+  private get videoMediaBuffer(): MediaBuffer | null {
+    return this.msePipeline.videoMediaBuffer;
+  }
+  private set videoMediaBuffer(v: MediaBuffer | null) {
+    this.msePipeline.videoMediaBuffer = v;
+  }
+  private get audioMediaBuffer(): MediaBuffer | null {
+    return this.msePipeline.audioMediaBuffer;
+  }
+  private set audioMediaBuffer(v: MediaBuffer | null) {
+    this.msePipeline.audioMediaBuffer = v;
+  }
+
   private videoTrack: WarpTrack | null = null;
   private audioTrack: WarpTrack | null = null;
 
@@ -119,6 +166,10 @@ export class Player {
     this.statusEl = statusEl;
     // Get logger for Player component
     this.logger = LoggerFactory.getInstance().getLogger("Player");
+
+    // MSE state owner. Created up front so getter delegates always have a
+    // target; dispose() returns it to a clean state on disconnect.
+    this.msePipeline = new MsePipeline(this.logger);
 
     // Log initialization
     this.logger.info("Player initialized");
@@ -1073,14 +1124,7 @@ export class Player {
     this.audioObjectsReceived = 0;
 
     // Reset buffer variables
-    this.videoSourceBuffer = null;
-    this.audioSourceBuffer = null;
-    this.videoMediaSegmentBuffer = null;
-    this.audioMediaSegmentBuffer = null;
-    this.videoMediaBuffer = null;
-    this.audioMediaBuffer = null;
-    this.sharedMediaSource = null;
-    this.usingManagedMediaSource = false;
+    this.msePipeline.dispose();
 
     // Reset error handling state
     this.recoveryInProgress = false;
@@ -1469,9 +1513,7 @@ export class Player {
     this.logger.error("Falling back to video-only playback");
 
     // Clear audio state
-    this.audioSourceBuffer = null;
-    this.audioMediaSegmentBuffer = null;
-    this.audioMediaBuffer = null;
+    this.msePipeline.clearAudio();
     this.audioTrack = null;
     this.audioBufferReady = false;
     this.audioObjectsReceived = 0;
@@ -1502,9 +1544,7 @@ export class Player {
     this.logger.error("Falling back to audio-only playback");
 
     // Clear video state
-    this.videoSourceBuffer = null;
-    this.videoMediaSegmentBuffer = null;
-    this.videoMediaBuffer = null;
+    this.msePipeline.clearVideo();
     this.videoTrack = null;
     this.videoBufferReady = false;
     this.videoObjectsReceived = 0;
@@ -2152,17 +2192,6 @@ export class Player {
   }
 
   /**
-   * @param codec Codec found in track
-   * @return A full video mime type.
-   */
-  private generateVideoMimeType(codec?: string): string {
-    if (!codec) {
-      throw new Error("Video codec is required but was not provided");
-    }
-    return `video/mp4; codecs="${codec}"`;
-  }
-
-  /**
    * @param tracks A list containing at most a video and audio warp track. The tracks are required to be protected.
    * @returns
    */
@@ -2177,9 +2206,9 @@ export class Player {
           continue;
         }
         if (track.role === "video") {
-          videoMimeType = this.generateVideoMimeType(track.codec);
+          videoMimeType = this.msePipeline.generateVideoMimeType(track.codec);
         } else if (track.role === "audio") {
-          audioMimeType = this.generateAudioMimeType(track.codec);
+          audioMimeType = this.msePipeline.generateAudioMimeType(track.codec);
         }
 
         candidates = this.selectContentProtections(refIDs); //If several protected tracks exist, the last's DRM systems are chosen
@@ -2639,47 +2668,6 @@ export class Player {
   }
 
   /**
-   * @param codec Codec found in track
-   * @return A full audio mime type.
-   */
-  private generateAudioMimeType(codec?: string): string {
-    if (!codec) {
-      throw new Error("Audio codec is required but was not provided");
-    }
-    return `audio/mp4; codecs="${codec}"`;
-  }
-
-  /**
-   * Process a media init segment (video, audio, etc.)
-   * @param initData The raw init segment data
-   * @param mediaBuffer The media buffer to use for parsing
-   * @param mediaSegmentBuffer The media segment buffer to use for buffering
-   * @param sourceBuffer The source buffer to use for playback
-   * @param type The type of media (e.g., 'Video', 'Audio')
-   */
-  private processInitSegment(
-    initData: ArrayBuffer,
-    mediaBuffer: MediaBuffer,
-    mediaSegmentBuffer: MediaSegmentBuffer,
-    sourceBuffer: SourceBuffer | ManagedSourceBuffer,
-    type: string,
-  ): void {
-    this.logger.info(`[${type}MediaBuffer] Processing init segment`);
-
-    const trackInfo = mediaBuffer.parseInitSegment(initData);
-    this.logger.info(
-      `[${type}MediaBuffer] Parsed init segment, timescale: ${trackInfo.timescale}`,
-    );
-    mediaSegmentBuffer.setSourceBuffer(sourceBuffer);
-    const initSegmentObj = mediaSegmentBuffer.addInitSegment(initData);
-    mediaSegmentBuffer.appendToSourceBuffer(initSegmentObj);
-
-    this.logger.info(
-      `[${type}MediaBuffer] Added CMAF init segment to MediaSegmentBuffer and SourceBuffer`,
-    );
-  }
-
-  /**
    * Setup MediaSource and SourceBuffer for video playback
    * This will initialize shared resources for both audio and video
    */
@@ -2749,7 +2737,9 @@ export class Player {
         }
 
         // Create video source buffer
-        const videoMimeType = this.generateVideoMimeType(track.codec);
+        const videoMimeType = this.msePipeline.generateVideoMimeType(
+          track.codec,
+        );
         this.logger.debug(
           `[SharedMediaSource] Using video mimeType: ${videoMimeType}`,
         );
@@ -2831,7 +2821,7 @@ export class Player {
           return;
         }
 
-        this.processInitSegment(
+        this.msePipeline.processInitSegment(
           videoInitSegment,
           this.videoMediaBuffer,
           this.videoMediaSegmentBuffer,
@@ -3326,7 +3316,9 @@ export class Player {
 
     try {
       // Create audio source buffer
-      const audioMimeType = this.generateAudioMimeType(this.audioTrack.codec);
+      const audioMimeType = this.msePipeline.generateAudioMimeType(
+        this.audioTrack.codec,
+      );
       this.logger.info(
         `[AudioSourceBuffer] Using audio mimeType: ${audioMimeType}`,
       );
@@ -3419,7 +3411,7 @@ export class Player {
         return;
       }
 
-      this.processInitSegment(
+      this.msePipeline.processInitSegment(
         audioInitSegment,
         this.audioMediaBuffer,
         this.audioMediaSegmentBuffer,

--- a/src/transport/client.ts
+++ b/src/transport/client.ts
@@ -104,6 +104,14 @@ export class Client {
 
     this.logger.info(`Connecting to ${this.config.url}...`);
     const wt = new WebTransport(this.config.url, options);
+    // Attach a handler to wt.closed up front. When the handshake fails (e.g.
+    // self-signed cert with no fingerprint to pin against), Safari rejects
+    // both wt.ready and wt.closed; without a handler on closed, Safari
+    // surfaces an "Unhandled Promise Rejection: WebTransportError". The
+    // rejection is also seen later by Connection.closed() — promises stay
+    // rejected, so multiple handlers each see the same value.
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    wt.closed.catch(() => {});
     await wt.ready;
     this.logger.info("WebTransport connection established");
 

--- a/src/transport/tracks.ts
+++ b/src/transport/tracks.ts
@@ -40,6 +40,12 @@ export interface MOQObject {
   trackAlias: bigint;
   location: Location;
   data: Uint8Array;
+  // Raw extension-headers blob: a sequence of moqtransport KVPs concatenated
+  // (no count or length prefix between pairs). Present only when the object's
+  // stream-type flag indicates extensions. Parse with parseMoqExtensions().
+  extensions?: Uint8Array;
+  // Object status varint, set when payloadLength == 0 (e.g. END_OF_GROUP).
+  status?: bigint;
 }
 
 // Callback for receiving objects

--- a/src/warpcatalog.ts
+++ b/src/warpcatalog.ts
@@ -143,8 +143,14 @@ export class WarpCatalogManager {
   /**
    * Handle received catalog data
    * @param data The catalog data received from the server
+   * @param announceNamespace The namespace under which the catalog track was
+   *   announced. Per draft-ietf-moq-msf-00 §5.1.10, tracks without an explicit
+   *   namespace inherit it from the catalog track.
    */
-  public handleCatalogData(data: WarpCatalog): void {
+  public handleCatalogData(
+    data: WarpCatalog,
+    announceNamespace?: string,
+  ): void {
     try {
       this.logger.info("Received catalog data");
 
@@ -152,6 +158,20 @@ export class WarpCatalogManager {
       if (!data || typeof data !== "object" || !Array.isArray(data.tracks)) {
         this.logger.error("Invalid catalog data format");
         return;
+      }
+
+      if (announceNamespace) {
+        const inherit = (tracks?: WarpTrack[]) => {
+          tracks?.forEach((t) => {
+            if (!t.namespace) {
+              t.namespace = announceNamespace;
+            }
+          });
+        };
+        inherit(data.tracks);
+        inherit(data.addTracks);
+        inherit(data.removeTracks);
+        inherit(data.cloneTracks);
       }
 
       // Store the catalog data


### PR DESCRIPTION
## Summary

Adds a WebCodecs-based render engine for LOC streams as a sibling to the existing MSE pipeline, with a render-engine selector so the user can pick (or be forced onto) one or the other. Most non-foundation work centres on `src/pipeline/webcodecsLocPipeline.ts` and the UI changes that wrap it.

## What's new

- **Pipeline abstraction.** New `IPlaybackPipeline` interface; the existing MSE handling moves into `MsePipeline` so a second engine can plug in cleanly. Shared metric panels are unified through a pipeline snapshot, so MSE and WebCodecs render identical UI.
- **LOC building blocks.** A MoQ LOC extension parser and decoder-config helpers for AVC, HEVC, AAC, and Opus (SPS/PPS extraction for AVC, VPS/SPS/PPS extraction and HEVCDecoderConfigurationRecord synthesis for HEVC, AudioSpecificConfig parsing, Opus identification header construction), all with unit tests.
- **WebCodecs LOC pipeline.** Decodes AVC and HEVC video via `VideoDecoder` to a canvas; decodes AAC and Opus through `AudioDecoder`, scheduling `AudioBufferSourceNode`s against an `AudioContext` anchored to wallclock. Drives `playbackRate` from a latency target so the engine tracks the live edge.
- **Engine-aware UI.** Render-engine selector placed next to Protocol Version, on-video legend showing engine/DRM/track/namespace, custom Mute/Unmute toggle that works for both engines (Safari has no standalone mute control and the WebCodecs path hides the underlying `<video>`), namespace buttons filtered by the forced engine, and auto-selection of the first compatible namespace on engine switch.
- **Fixes.** MSF/CMSF catalog tracks without an explicit namespace now inherit the announcing namespace. `moq-mi/*` is treated as a non-content namespace. `avc3.*` codec strings are normalised to `avc1.*` because Safari's WebCodecs rejects `avc3` even though the bitstream is identical (SPS+PPS already travel via `VideoDecoderConfig.description`); `hev1.*` is similarly normalised to `hvc1.*` for HEVC.

## Commits

1. `feat(loc): add LOC parser, decoder helpers, and pipeline abstraction`
2. `fix(catalog): inherit announce namespace for MSF/CMSF tracks`
3. `feat(loc): add WebCodecs LOC playback pipeline`
4. `feat(ui): add engine legend, mute toggle, and namespace filtering`
5. `fix(transport): handle wt.closed rejection so Safari doesn't flag it`
6. `feat(loc): add HEVC support to WebCodecs LOC pipeline`

## Test plan

- [x] `npm run typecheck && npm run lint && npm test` pass (121 tests, including 18 new HEVC tests)
- [x] Connect to `mlmpub` and verify both MSE and WebCodecs engines play AVC video + AAC and Opus audio
- [x] HEVC LOC playback: subscribe to `msf/clear/video_*kbps_hevc`, decode `hev1.* → hvc1.*` via WebCodecs (requires [Eyevinn/moqlivemock#76](https://github.com/Eyevinn/moqlivemock/pull/76))
- [x] Toggle render-engine selector mid-session; namespace list filters and auto-selects correctly
- [x] Mute/Unmute button toggles audio on both engines
- [x] Engine legend stays visible (no native fullscreen)
- [x] Verify against Safari (avc3 → avc1 / hev1 → hvc1 normalisation path)