### PR TITLE
chore: prepare v0.9.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ logs
 # Local Claude configuration
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Playwright MCP scratch dir
+.playwright-mcp/
+
+# Local screenshots and release-tarball scratch artifacts
+*.png
+dist-*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-17
+
+LOCMAF (compressed CMAF) packaging support, decoded into CMAF and played
+through the MSE pipeline.
+
+### Added
+
+- LOCMAF packaging support for tracks advertising `packaging: "locmaf"`
+  in the CMSF catalog
+  - New `src/locmaf/` module parses LOCMAF init, full `moof`, and delta
+    `moof` objects per the v0.1 wire format and reconstructs standard
+    CMAF init / media segments for the MSE pipeline
+  - Header type values `LOCMAF_HEADER_MOOV` (21), `LOCMAF_HEADER_MOOF`
+    (23), and `LOCMAF_HEADER_MOOF_DELTA` (25), with QUIC varint encoding
+    for length fields
+  - `baseMediaDecodeTime` is derived in delta `moof` headers; sample
+    sizes are inferred when only one sample is sent per CMAF chunk
+  - Receiver gated on `locmafVersion` from the catalog Track
+    (`LOCMAF_SUPPORTED_VERSION = "0.1"`)
+  - Engine capability matrix updated so `locmaf` routes through MSE
+    alongside `cmaf`
+- Test fixtures and unit tests under `test/locmaf-test-files/` and
+  `src/locmaf/locmaf.test.ts`
+
+### Changed
+
+- MSE pipeline avoids double parsing of LOCMAF/CMAF chunks
+- Test media moved to `test/media-files/`
+- Bumped development dependencies (TypeScript 5.9 → 6.0,
+  `@commitlint/cli` 20 → 21, `@commitlint/config-conventional`)
+- Bumped production dependencies (5-update group)
+- Bumped `actions/dependency-review-action` GitHub Action from 4 to 5
+
 ## [0.8.0] - 2026-05-05
 
 WebCodecs LOC playback engine alongside the existing MSE/CMAF engine.
@@ -190,12 +223,16 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 - Support for video and audio track selection
 - Real-time playback metrics (buffer levels, latency, playback rate)
 
-[Unreleased]: https://github.com/Eyevinn/warp-player/releases/tag/v0.6.0...HEAD
-[0.6.0]: https://github.com/Eyevinn/warp-player/releases/tag/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/Eyevinn/warp-player/releases/tag/v0.4.1...v0.5.0
-[0.4.1]: https://github.com/Eyevinn/warp-player/releases/tag/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/Eyevinn/warp-player/releases/tag/v0.2.0...v0.4.0
-[0.2.0]: https://github.com/Eyevinn/warp-player/releases/tag/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/Eyevinn/warp-player/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Eyevinn/warp-player/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/Eyevinn/warp-player/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/Eyevinn/warp-player/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/Eyevinn/warp-player/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/Eyevinn/warp-player/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/Eyevinn/warp-player/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/Eyevinn/warp-player/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/Eyevinn/warp-player/compare/v0.2.0...v0.4.0
+[0.2.0]: https://github.com/Eyevinn/warp-player/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Eyevinn/warp-player/releases/tag/v0.1.0
 [moqt-d11]: https://datatracker.ietf.org/doc/draft-ietf-moq-transport/11/
 [moqt-d14]: https://datatracker.ietf.org/doc/draft-ietf-moq-transport/14/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,10 @@ from the UI) and uses the MSF/CMSF catalog format
 Playback runs through one of two interchangeable render pipelines selected
 per session:
 
-- **MSE / CMAF** for `packaging: "cmaf"` tracks, with optional EME for
-  encrypted content (Widevine, PlayReady, FairPlay, ClearKey).
+- **MSE / CMAF** for `packaging: "cmaf"` and `packaging: "locmaf"` tracks,
+  with optional EME for encrypted content (Widevine, PlayReady, FairPlay,
+  ClearKey). LOCMAF objects are decompressed into standard CMAF before
+  being appended to the `SourceBuffer`.
 - **WebCodecs / LOC** for `packaging: "loc"` tracks (draft-mzanaty-moq-loc),
   clear content only, supporting AVC and HEVC video plus AAC and Opus audio.
 
@@ -94,6 +96,8 @@ warp-player/
 │   │   ├── aac.ts        # AAC AudioSpecificConfig from catalog metadata
 │   │   ├── opus.ts       # Opus ID-header (OpusHead) builder
 │   │   └── extensions.ts # LOC extension-header parsing (capture timestamps)
+│   ├── locmaf/           # LOCMAF (compressed CMAF) helpers for MSE pipeline
+│   │   └── locmaf.ts     # Parse LOCMAF init/moof/delta-moof, rebuild CMAF
 │   ├── pipeline/         # Pluggable render pipelines
 │   │   ├── index.ts                # IPlaybackPipeline + capability matrix
 │   │   ├── msePipeline.ts          # MSE/CMAF pipeline (with optional EME)
@@ -237,12 +241,23 @@ The codebase is organized into several key modules:
       and read LOC property `0x06` (capture timestamp in microseconds
       since the Unix epoch)
 
+11. **LOCMAF helpers** (`src/locmaf/locmaf.ts`):
+    - Parses LOCMAF (compressed CMAF) objects per the v0.1 wire format:
+      `LOCMAF_HEADER_MOOV` (21), `LOCMAF_HEADER_MOOF` (23), and
+      `LOCMAF_HEADER_MOOF_DELTA` (25), with QUIC varint length fields
+    - Reconstructs standard CMAF init segments and `moof+mdat` media
+      segments so the existing MSE pipeline can consume them unchanged
+    - Derives `baseMediaDecodeTime` for delta `moof` objects and infers
+      sample sizes when only one sample is sent per CMAF chunk
+    - Gated on `LOCMAF_SUPPORTED_VERSION` (`"0.1"`) advertised via the
+      CMSF Track's `locmafVersion` field
+
 ## Technical Notes
 
 1. The implementation supports MOQ Transport draft-14 and draft-16, with the MSF/CMSF catalog format (draft-ietf-moq-msf-00 / draft-ietf-moq-cmsf-00) and LOC packaging (draft-mzanaty-moq-loc).
 2. WebTransport is available in Chrome 87+, Edge 87+, Firefox, and Safari 26.4+. The WebCodecs render engine additionally requires WebCodecs (Chrome 94+, Edge 94+, Safari 16.4+, Firefox 130+).
 3. The client uses MSB (Most Significant Byte) 16-bit length fields for control messages.
-4. Media data is delivered either as CMAF (ISO BMFF) for the MSE pipeline or as raw codec payloads (length-prefixed AVC/HEVC NALUs, raw AAC access units, raw Opus packets) for the WebCodecs pipeline.
+4. Media data is delivered either as CMAF (ISO BMFF) — including the LOCMAF compressed variant, which is decompressed back into CMAF before MSE append — for the MSE pipeline, or as raw codec payloads (length-prefixed AVC/HEVC NALUs, raw AAC access units, raw Opus packets) for the WebCodecs pipeline.
 5. The client includes proper handling of bidirectional control streams for subscribing to content.
 6. The player should work fine towards https://github.com/Eyevinn/moqlivemock/cmd/mlmpub as a source.
 7. Encrypted content always flows through the MSE engine; production browsers do not expose Encrypted WebCodecs.
@@ -259,7 +274,8 @@ The codebase is organized into several key modules:
 - Catalog parsing follows draft-ietf-moq-msf-00 with CMSF
   (draft-ietf-moq-cmsf-00) for CMAF packaging
 - Tracks identify their payload format via the `packaging` field
-  (`"cmaf"`, `"loc"`, ...)
+  (`"cmaf"`, `"locmaf"`, `"loc"`, ...). LOCMAF tracks additionally
+  advertise `locmafVersion`, which the receiver gates on.
 - Tracks that omit `namespace` inherit it from the announce namespace of
   the catalog track they were delivered on (see
   `WarpCatalogManager.processCatalog`)
@@ -268,6 +284,24 @@ The codebase is organized into several key modules:
 - Content protection is signaled through the `contentProtections` array
   at the catalog root and referenced by `contentProtectionRefIDs` on
   individual tracks (CMSF ContentProtection signaling)
+
+### LOCMAF Packaging
+
+LOCMAF is a compressed CMAF wire format used by mlmpub to cut bytes on
+the wire while staying compatible with the MSE pipeline:
+
+- Parsed by `src/locmaf/locmaf.ts` and routed through the MSE engine
+  (LOCMAF is unsupported on the WebCodecs engine — see the capability
+  matrix in `src/pipeline/index.ts`)
+- Three object kinds with QUIC varint length fields:
+  - `LOCMAF_HEADER_MOOV` (21) — init segment
+  - `LOCMAF_HEADER_MOOF` (23) — full media segment
+  - `LOCMAF_HEADER_MOOF_DELTA` (25) — delta media segment, with
+    `baseMediaDecodeTime` derived from prior state
+- Receivers gate on the CMSF Track's `locmafVersion`. The current
+  supported version constant is `LOCMAF_SUPPORTED_VERSION = "0.1"`
+- The pipeline reconstructs a standard CMAF `moof+mdat` so the existing
+  MSE `MediaBuffer` / `MediaSegmentBuffer` code path is reused unchanged
 
 ### WebCodecs LOC Pipeline
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eyevinn/warp-player",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@eyevinn/is-drm-supported": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Version bump to **0.9.0** in `package.json` / `package-lock.json`.
- New `[0.9.0] - 2026-05-17` `CHANGELOG.md` entry covering **LOCMAF (compressed CMAF) packaging support** — new `src/locmaf/` module that parses LOCMAF init / `moof` / delta-`moof` objects per v0.1 with QUIC varints and derived `baseMediaDecodeTime`, routed through the MSE pipeline; gated on the catalog's `locmafVersion` field. Also notes TypeScript 6 and other dep bumps.
- CHANGELOG link footer rewritten — old `…/releases/tag/A...B` URLs were broken; now uses GitHub's `…/compare/A...B` form and covers 0.7.0, 0.7.1, 0.8.0, 0.9.0.
- `CLAUDE.md` updated: LOCMAF added to pipeline blurb, project-structure tree, key-components list, `packaging` enumeration, and a new `### LOCMAF Packaging` Recent Features subsection.
- `.gitignore` excludes local screenshots (`*.png`), dev tarballs (`dist-*.tgz`), and `.playwright-mcp/`.
- `fix(ts6)`: `ignoreDeprecations` value `"6.0"` is not accepted by TypeScript 6 — switched to `"5.0"` so `npm run typecheck` passes.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 141 tests pass
- [ ] Manual smoke test against `moqlivemock` for both CMAF and LOCMAF tracks
- [ ] Tag `v0.9.0` after merge