### PR TITLE
feat(locmaf): v0.2 decoder with version dispatch and shared senc helpers (v0.10.0 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-02
+
+LOCMAF v0.2 wire-format support, decoded alongside v0.1 and played through
+the MSE pipeline.
+
+### Added
+
+- LOCMAF v0.2 decoder under `src/locmaf/v02/`, selected per track via the
+  catalog `locmafVersion` field
+  - Version dispatch in `src/locmaf/locmaf.ts`: `LOCMAF_SUPPORTED_VERSIONS`
+    now accepts both `"0.1"` and `"0.2"`, routing v0.2 tracks to the new
+    decoder while v0.1 continues through the existing path
+  - Shared `senc` (sample encryption) helpers in `src/locmaf/senc.ts`
+    reused across versions
+  - Unit tests and a test encoder for the v0.2 wire format
+
+### Fixed
+
+- v0.2 `moof` `track_ID` is derived from the init segment's `tkhd`,
+  falling back to `trex`
+
 ## [0.9.0] - 2026-05-17
 
 LOCMAF (compressed CMAF) packaging support, decoded into CMAF and played
@@ -223,7 +244,8 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 - Support for video and audio track selection
 - Real-time playback metrics (buffer levels, latency, playback rate)
 
-[Unreleased]: https://github.com/Eyevinn/warp-player/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/warp-player/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/Eyevinn/warp-player/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Eyevinn/warp-player/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Eyevinn/warp-player/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Eyevinn/warp-player/compare/v0.7.0...v0.7.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,16 +241,24 @@ The codebase is organized into several key modules:
       and read LOC property `0x06` (capture timestamp in microseconds
       since the Unix epoch)
 
-11. **LOCMAF helpers** (`src/locmaf/locmaf.ts`):
-    - Parses LOCMAF (compressed CMAF) objects per the v0.1 wire format:
-      `LOCMAF_HEADER_MOOV` (21), `LOCMAF_HEADER_MOOF` (23), and
-      `LOCMAF_HEADER_MOOF_DELTA` (25), with QUIC varint length fields
-    - Reconstructs standard CMAF init segments and `moof+mdat` media
-      segments so the existing MSE pipeline can consume them unchanged
-    - Derives `baseMediaDecodeTime` for delta `moof` objects and infers
-      sample sizes when only one sample is sent per CMAF chunk
-    - Gated on `LOCMAF_SUPPORTED_VERSION` (`"0.1"`) advertised via the
-      CMSF Track's `locmafVersion` field
+11. **LOCMAF helpers** (`src/locmaf/locmaf.ts`, `src/locmaf/v02/`):
+    - Two independent decoders selected by the CMSF Track's
+      `locmafVersion`; `LOCMAF_SUPPORTED_VERSIONS` is `{"0.1", "0.2"}`
+      (an absent value assumes `LOCMAF_SUPPORTED_VERSION = "0.1"`)
+    - **v0.1** (`locmaf.ts`): parses `LOCMAF_HEADER_MOOV` (21),
+      `LOCMAF_HEADER_MOOF` (23), and `LOCMAF_HEADER_MOOF_DELTA` (25);
+      reconstructs both the CMAF init segment and `moof+mdat`
+    - **v0.2** (`v02/decoder.ts`): the normative spec is the IETF draft
+      [draft-einarsson-moq-locmaf](https://datatracker.ietf.org/doc/draft-einarsson-moq-locmaf/).
+      Init data is raw CMAF (no LOCMAF wrapping); only the `moof` is
+      coded, as Full (23) / Delta (25) property blocks of (field_id,
+      value) pairs (even IDs = scalar varints, odd IDs = length-prefixed).
+      Reconstructs `senc`/`saio`/`saiz` for ClearKey/ECCP, derives the
+      moof `track_ID` from `tkhd` (fallback `trex`), and unpacks the
+      5-bit `sample_flags` and zigzag composition-time offsets
+    - Both reconstruct standard CMAF so the existing MSE pipeline consumes
+      them unchanged; delta `moof` objects derive `baseMediaDecodeTime`
+      from prior in-group state
 
 ## Technical Notes
 
@@ -288,20 +296,29 @@ The codebase is organized into several key modules:
 ### LOCMAF Packaging
 
 LOCMAF is a compressed CMAF wire format used by mlmpub to cut bytes on
-the wire while staying compatible with the MSE pipeline:
+the wire while staying compatible with the MSE pipeline. The player
+supports two versions side-by-side, selected per track by the CMSF
+Track's `locmafVersion` (`LOCMAF_SUPPORTED_VERSIONS = {"0.1", "0.2"}`):
 
-- Parsed by `src/locmaf/locmaf.ts` and routed through the MSE engine
-  (LOCMAF is unsupported on the WebCodecs engine — see the capability
-  matrix in `src/pipeline/index.ts`)
-- Three object kinds with QUIC varint length fields:
+- Routed through the MSE engine only (LOCMAF is unsupported on the
+  WebCodecs engine — see the capability matrix in `src/pipeline/index.ts`)
+- **v0.1** (`src/locmaf/locmaf.ts`) — three object kinds with QUIC varint
+  length fields, including a LOCMAF-coded init segment:
   - `LOCMAF_HEADER_MOOV` (21) — init segment
   - `LOCMAF_HEADER_MOOF` (23) — full media segment
   - `LOCMAF_HEADER_MOOF_DELTA` (25) — delta media segment, with
     `baseMediaDecodeTime` derived from prior state
-- Receivers gate on the CMSF Track's `locmafVersion`. The current
-  supported version constant is `LOCMAF_SUPPORTED_VERSION = "0.1"`
-- The pipeline reconstructs a standard CMAF `moof+mdat` so the existing
-  MSE `MediaBuffer` / `MediaSegmentBuffer` code path is reused unchanged
+- **v0.2** (`src/locmaf/v02/decoder.ts`) — specified by the IETF draft
+  [draft-einarsson-moq-locmaf](https://datatracker.ietf.org/doc/draft-einarsson-moq-locmaf/).
+  Init data is raw CMAF (handed to MSE unchanged); only the `moof` is
+  coded, as Full (23) / Delta (25) property blocks of (field_id, value)
+  pairs under the even-scalar / odd-length-prefixed parity rule.
+  Supports `senc`/`saio`/`saiz` reconstruction (ClearKey/ECCP), the 5-bit
+  `sample_flags` packing, and zigzag-coded signed composition-time
+  offsets. The reconstructed moof `track_ID` comes from `tkhd` (fallback
+  `trex`)
+- Both reconstruct a standard CMAF `moof+mdat` so the existing MSE
+  `MediaBuffer` / `MediaSegmentBuffer` code path is reused unchanged
 
 ### WebCodecs LOC Pipeline
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -109,6 +109,7 @@ export default typescriptEslint.config(
     rules: {
       // Relaxed rules for test files
       "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
       "no-console": "off",
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eyevinn/warp-player",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@eyevinn/is-drm-supported": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {

--- a/src/locmaf/locmaf.test.ts
+++ b/src/locmaf/locmaf.test.ts
@@ -723,10 +723,10 @@ describe("locmaf reconstruction", () => {
   it("rejects a track that advertises an unsupported locmafVersion", async () => {
     const locmafInit = await loadLocmafInitObject();
     const referenceInit = await loadReferenceInit();
-    const track = { ...buildTrack(referenceInit), locmafVersion: "0.2" };
+    const track = { ...buildTrack(referenceInit), locmafVersion: "9.9" };
 
     expect(() => initializeLocmafTrack(track, locmafInit)).toThrow(
-      /unsupported locmafVersion "0\.2"/,
+      /unsupported locmafVersion "9\.9"/,
     );
   });
 

--- a/src/locmaf/locmaf.ts
+++ b/src/locmaf/locmaf.ts
@@ -25,7 +25,6 @@ import type {
   MovieHeaderBox,
   ParsedIsoBox,
   ProtectionSchemeInformationBox,
-  SampleEncryptionBox,
   SampleDescriptionBox,
   SampleTableBox,
   SoundMediaHeaderBox,
@@ -45,16 +44,35 @@ import type {
 import type { MediaTrackInfo } from "../buffer/mediaBuffer";
 import type { WarpTrack } from "../warpcatalog";
 
+import {
+  SENC_USE_SUBSAMPLE_ENCRYPTION,
+  writeSenc,
+  type ExtendedSampleEncryptionBox,
+  type SampleEncryptionEntry,
+} from "./senc";
+import {
+  decompressMoofV02WithTrackInfo,
+  initializeLocmafV02Track,
+  type LocmafV02TrackState,
+} from "./v02/decoder";
+
 const LOCMAF_HEADER_MOOV = 21;
 const LOCMAF_HEADER_MOOF = 23;
 const LOCMAF_HEADER_MOOF_DELTA = 25;
 
-// Highest LOCMAF wire-format version this decoder understands. The CMSF
-// catalog Track advertises `locmafVersion` whenever packaging == "locmaf".
-// New top-level object kinds are forward-compatible via skip-unknown, but
-// behavioural changes inside existing kinds (e.g. the absolute BMDT
-// override in delta moof) require receivers to gate on this string.
+// LOCMAF wire-format versions this decoder understands. The CMSF catalog
+// Track advertises `locmafVersion` whenever packaging == "locmaf". The
+// version selects which sub-decoder runs: v0.1 (legacy wire format) is in
+// this file, v0.2 (current IETF draft) lives in ./v02/decoder.
+//
+// New top-level object kinds inside a given version are forward-compatible
+// via skip-unknown, but behavioural differences between major versions
+// require receivers to gate on this string.
 export const LOCMAF_SUPPORTED_VERSION = "0.1";
+export const LOCMAF_SUPPORTED_VERSIONS: ReadonlySet<string> = new Set([
+  "0.1",
+  "0.2",
+]);
 
 const DEFAULT_TRACK_ID = 1;
 const DEFAULT_MOVIE_BRANDS = ["iso6", "cmfc", "mp41"];
@@ -73,7 +91,6 @@ const TRUN_SAMPLE_DURATION_PRESENT = 0x000100;
 const TRUN_SAMPLE_SIZE_PRESENT = 0x000200;
 const TRUN_SAMPLE_FLAGS_PRESENT = 0x000400;
 const TRUN_SAMPLE_COMPOSITION_TIME_OFFSET_PRESENT = 0x000800;
-const SENC_USE_SUBSAMPLE_ENCRYPTION = 0x000002;
 
 const audioSampleEntryTypes = [
   "Opus",
@@ -126,19 +143,6 @@ type ExtendedTrackEncryptionBox = TrackEncryptionBox & {
   defaultCryptByteBlock?: number;
   defaultSkipByteBlock?: number;
   defaultConstantIv?: Uint8Array;
-};
-
-type SampleEncryptionEntry = {
-  initializationVector?: Uint8Array;
-  subsampleEncryption?: Array<{
-    bytesOfClearData: number;
-    bytesOfProtectedData: number;
-  }>;
-};
-
-type ExtendedSampleEncryptionBox = SampleEncryptionBox & {
-  type: "senc";
-  samples: SampleEncryptionEntry[];
 };
 
 type LocmafBox =
@@ -226,9 +230,14 @@ export interface LocmafMoofDecompressionResult {
 }
 
 export interface LocmafTrackState {
+  /** Wire-format version this state belongs to. */
+  version: string;
   initContext: LocmafInitContext;
   initSegment: Uint8Array;
-  moofDecoder: LocmafMoofDeltaDecoder;
+  /** v0.1 moof decoder; populated only when version === "0.1". */
+  moofDecoder?: LocmafMoofDeltaDecoder;
+  /** v0.2 state; populated only when version === "0.2". */
+  v02?: LocmafV02TrackState;
 }
 
 export interface InitializedLocmafTrack {
@@ -1526,37 +1535,6 @@ function readSampleEntryMetadata(initSegment: Uint8Array): LocmafTrackMetadata {
   };
 }
 
-function writeSenc(box: ExtendedSampleEncryptionBox): IsoBoxWriteView {
-  let size = 8 + 4 + 4;
-  for (const sample of box.samples) {
-    size += sample.initializationVector?.byteLength ?? 0;
-    if (box.flags & SENC_USE_SUBSAMPLE_ENCRYPTION) {
-      size += 2;
-      size += (sample.subsampleEncryption?.length ?? 0) * 6;
-    }
-  }
-
-  const writer = new IsoBoxWriteView("senc", size);
-  writer.writeFullBox(box.version, box.flags);
-  writer.writeUint(box.sampleCount, 4);
-
-  for (const sample of box.samples) {
-    if (sample.initializationVector) {
-      writer.writeBytes(sample.initializationVector);
-    }
-    if (box.flags & SENC_USE_SUBSAMPLE_ENCRYPTION) {
-      const subsamples = sample.subsampleEncryption ?? [];
-      writer.writeUint(subsamples.length, 2);
-      for (const subsample of subsamples) {
-        writer.writeUint(subsample.bytesOfClearData, 2);
-        writer.writeUint(subsample.bytesOfProtectedData, 4);
-      }
-    }
-  }
-
-  return writer;
-}
-
 function writeTenc(box: ExtendedTrackEncryptionBox): IsoBoxWriteView {
   let size = 8 + 4 + 1 + 1 + 1 + 1 + 16;
   if (box.defaultIsEncrypted !== 0 && box.defaultIvSize === 0) {
@@ -1831,25 +1809,51 @@ export function isLocmafTrack(track: Pick<WarpTrack, "packaging">): boolean {
 
 function assertLocmafVersion(
   track: Pick<WarpTrack, "name" | "locmafVersion">,
-): void {
+): string {
   const version = track.locmafVersion;
   if (version === undefined) {
     console.warn(
       `[locmaf] track ${track.name ?? "<unnamed>"} has packaging=locmaf but no locmafVersion; assuming ${LOCMAF_SUPPORTED_VERSION}`,
     );
-    return;
+    return LOCMAF_SUPPORTED_VERSION;
   }
-  if (version !== LOCMAF_SUPPORTED_VERSION) {
+  if (!LOCMAF_SUPPORTED_VERSIONS.has(version)) {
+    const supported = Array.from(LOCMAF_SUPPORTED_VERSIONS)
+      .map((v) => `"${v}"`)
+      .join(", ");
     throw new Error(
-      `unsupported locmafVersion "${version}" on track ${track.name ?? "<unnamed>"}; this decoder supports "${LOCMAF_SUPPORTED_VERSION}"`,
+      `unsupported locmafVersion "${version}" on track ${track.name ?? "<unnamed>"}; this decoder supports ${supported}`,
     );
   }
+  return version;
 }
 
 export function createLocmafTrackState(
   track: WarpTrack,
   locmafInitSegment: Uint8Array | ArrayBuffer,
 ): LocmafTrackState {
+  const version = track.locmafVersion ?? LOCMAF_SUPPORTED_VERSION;
+  if (version === "0.2") {
+    const initialized = initializeLocmafV02Track(locmafInitSegment);
+    return {
+      version,
+      initContext: {
+        trackId: initialized.state.initContext.trackId,
+        timescale: initialized.state.initContext.timescale,
+        defaultSampleDescriptionIndex:
+          initialized.state.initContext.defaultSampleDescriptionIndex,
+        defaultSampleDuration:
+          initialized.state.initContext.defaultSampleDuration,
+        defaultSampleSize: initialized.state.initContext.defaultSampleSize,
+        defaultSampleFlags: initialized.state.initContext.defaultSampleFlags,
+        defaultPerSampleIVSize:
+          initialized.state.initContext.defaultPerSampleIVSize,
+      },
+      initSegment: initialized.state.initSegment,
+      v02: initialized.state,
+    };
+  }
+
   const headers = getLocmafHeaderConstants();
   let locPayload = ensureUint8Array(locmafInitSegment);
   const parsedInit = maybeParseLocmafInit(locmafInitSegment);
@@ -1863,6 +1867,7 @@ export function createLocmafTrackState(
   );
 
   return {
+    version,
     initContext: reconstructedInit.context,
     initSegment: reconstructedInit.bytes,
     moofDecoder: new LocmafMoofDeltaDecoder(),
@@ -1873,8 +1878,17 @@ export function initializeLocmafTrack(
   track: WarpTrack,
   initSegment: Uint8Array | ArrayBuffer,
 ): InitializedLocmafTrack {
-  assertLocmafVersion(track);
+  const version = assertLocmafVersion(track);
   const initBytes = ensureUint8Array(initSegment);
+
+  if (version === "0.2") {
+    // v0.2 init is raw CMAF — hand it back unchanged for MSE.
+    return {
+      state: createLocmafTrackState(track, initBytes),
+      initWasReconstructed: false,
+    };
+  }
+
   const parsedInit = maybeParseLocmafInit(initBytes);
 
   if (parsedInit?.headerId === getLocmafHeaderConstants().moov) {
@@ -1888,6 +1902,7 @@ export function initializeLocmafTrack(
   if (initContext) {
     return {
       state: {
+        version,
         initContext,
         initSegment: initBytes,
         moofDecoder: new LocmafMoofDeltaDecoder(),
@@ -1915,6 +1930,15 @@ export function decompressMoofWithTrackInfo(
   sequenceNumber: number,
   state: LocmafTrackState,
 ): { bytes: Uint8Array; trackInfo: MediaTrackInfo } | undefined {
+  if (state.version === "0.2") {
+    if (!state.v02) {
+      throw new Error("locmaf v0.2 track state is missing v02 substate");
+    }
+    return decompressMoofV02WithTrackInfo(payload, sequenceNumber, state.v02);
+  }
+  if (!state.moofDecoder) {
+    throw new Error("locmaf v0.1 track state is missing moofDecoder");
+  }
   const { headerId, locPayload, mdatPayload } = parseLocmafObject(payload);
   const headers = getLocmafHeaderConstants();
 

--- a/src/locmaf/senc.ts
+++ b/src/locmaf/senc.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared SampleEncryptionBox helpers for the LOCMAF decoders.
+ *
+ * `@svta/cml-iso-bmff` has native readers for `senc` but no
+ * writer, so both LOCMAF v0.1 and v0.2 reconstruct the box in
+ * memory and serialize it themselves. The serializer lives here so
+ * the two versioned decoders can use it without one depending on
+ * the other.
+ */
+import { IsoBoxWriteView, type SampleEncryptionBox } from "@svta/cml-iso-bmff";
+
+/** `flags & 0x02 = 1` means each sample carries a subsample map. */
+export const SENC_USE_SUBSAMPLE_ENCRYPTION = 0x000002;
+
+export type SampleEncryptionEntry = {
+  initializationVector?: Uint8Array;
+  subsampleEncryption?: Array<{
+    bytesOfClearData: number;
+    bytesOfProtectedData: number;
+  }>;
+};
+
+export type ExtendedSampleEncryptionBox = SampleEncryptionBox & {
+  type: "senc";
+  samples: SampleEncryptionEntry[];
+};
+
+/** Serialize an `ExtendedSampleEncryptionBox` into a write view. */
+export function writeSenc(box: ExtendedSampleEncryptionBox): IsoBoxWriteView {
+  let size = 8 + 4 + 4;
+  for (const sample of box.samples) {
+    size += sample.initializationVector?.byteLength ?? 0;
+    if (box.flags & SENC_USE_SUBSAMPLE_ENCRYPTION) {
+      size += 2;
+      size += (sample.subsampleEncryption?.length ?? 0) * 6;
+    }
+  }
+
+  const writer = new IsoBoxWriteView("senc", size);
+  writer.writeFullBox(box.version, box.flags);
+  writer.writeUint(box.sampleCount, 4);
+
+  for (const sample of box.samples) {
+    if (sample.initializationVector) {
+      writer.writeBytes(sample.initializationVector);
+    }
+    if (box.flags & SENC_USE_SUBSAMPLE_ENCRYPTION) {
+      const subsamples = sample.subsampleEncryption ?? [];
+      writer.writeUint(subsamples.length, 2);
+      for (const subsample of subsamples) {
+        writer.writeUint(subsample.bytesOfClearData, 2);
+        writer.writeUint(subsample.bytesOfProtectedData, 4);
+      }
+    }
+  }
+
+  return writer;
+}

--- a/src/locmaf/v02/decoder.test.ts
+++ b/src/locmaf/v02/decoder.test.ts
@@ -1,0 +1,481 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { jest } from "@jest/globals";
+import { defaultReaderConfig, readIsoBoxes } from "@svta/cml-iso-bmff";
+
+import type { WarpTrack } from "../../warpcatalog";
+import {
+  createLocmafTrackState,
+  decompressMoofWithTrackInfo,
+  initializeLocmafTrack,
+} from "../locmaf";
+
+import {
+  auxV02IDs,
+  decompressMoofV02WithTrackInfo,
+  initializeLocmafV02Track,
+  LOCMAF_V02_DELTA,
+  LOCMAF_V02_FULL,
+  fieldV02IDs,
+} from "./decoder";
+import {
+  buildLocmafV02Object,
+  buildProperties,
+  encodeVarint,
+  packSampleFlags,
+  zigzag,
+} from "./testEncoder";
+
+const CMAF_INIT_FIXTURE = "init.cmaf.mp4";
+
+async function loadInitCmaf(): Promise<Uint8Array> {
+  const fixturePath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../test/locmaf-test-files",
+    CMAF_INIT_FIXTURE,
+  );
+  return new Uint8Array(await readFile(fixturePath));
+}
+
+function findBox(boxes: any[], type: string): any | undefined {
+  for (const box of boxes) {
+    if (box.type === type) {
+      return box;
+    }
+    if (box.boxes) {
+      const nested = findBox(box.boxes, type);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return undefined;
+}
+
+function summarize(bytes: Uint8Array) {
+  const boxes = readIsoBoxes(bytes, defaultReaderConfig());
+  const moof = boxes.find((b: any) => b.type === "moof") as any;
+  const mdat = boxes.find((b: any) => b.type === "mdat") as any;
+  const prft = boxes.find((b: any) => b.type === "prft") as any;
+  const tfhd = findBox(moof.boxes, "tfhd");
+  const tfdt = findBox(moof.boxes, "tfdt");
+  const trun = findBox(moof.boxes, "trun");
+  return {
+    boxOrder: boxes.map((b: any) => b.type),
+    sequenceNumber: findBox(moof.boxes, "mfhd")?.sequenceNumber,
+    trackId: tfhd?.trackId,
+    bmdt: tfdt?.baseMediaDecodeTime,
+    sampleCount: trun?.sampleCount,
+    samples: trun?.samples,
+    firstSampleFlags: trun?.firstSampleFlags,
+    mdatLen: mdat?.data?.byteLength,
+    prft,
+  };
+}
+
+describe("locmaf v0.2 decoder", () => {
+  describe("initialization", () => {
+    it("uses raw CMAF init bytes unchanged and extracts trex/mdhd context", async () => {
+      const init = await loadInitCmaf();
+      const initialized = initializeLocmafV02Track(init);
+      expect(initialized.initWasReconstructed).toBe(false);
+      expect(initialized.state.initSegment).toEqual(init);
+      expect(initialized.state.initContext.trackId).toBe(1);
+      expect(initialized.state.initContext.timescale).toBe(12800);
+      expect(initialized.state.initContext.defaultSampleSize).toBe(0);
+    });
+
+    it("dispatches to v0.2 path via initializeLocmafTrack when locmafVersion=0.2", async () => {
+      const init = await loadInitCmaf();
+      const track: WarpTrack = {
+        name: "video",
+        packaging: "locmaf",
+        locmafVersion: "0.2",
+      };
+      const initialized = initializeLocmafTrack(track, init);
+      expect(initialized.initWasReconstructed).toBe(false);
+      expect(initialized.state.version).toBe("0.2");
+      expect(initialized.state.initSegment).toEqual(init);
+    });
+  });
+
+  describe("Full chunk round-trip", () => {
+    it("decodes a representative LocmafFullHeader into a CMAF moof+mdat", async () => {
+      const init = await loadInitCmaf();
+      const state = initializeLocmafV02Track(init).state;
+
+      // Three video samples: 4-byte mdat segments (toy), durations & sizes
+      // explicit, sample_flags showing sync + depended-on for sample 0,
+      // non-sync for samples 1 and 2.
+      const sampleSizes = [10n, 12n, 8n];
+      const sampleDurations = [512n, 512n, 512n];
+      const sampleFlags = [
+        packSampleFlags(0, 2, 1), // sync, depends_on=2 ("none"), is_depended_on=1
+        packSampleFlags(1, 1, 0),
+        packSampleFlags(1, 1, 0),
+      ];
+      const bmdt = 1024n;
+      const mdatPayload = new Uint8Array(
+        sampleSizes.reduce((s, v) => s + Number(v), 0),
+      );
+      for (let i = 0; i < mdatPayload.length; i++) {
+        mdatPayload[i] = i & 0xff;
+      }
+
+      const properties = buildProperties([
+        // ID 10 baseMediaDecodeTime (even, absolute in Full)
+        { fieldId: fieldV02IDs.tfdtBaseMediaDecodeTime, scalar: bmdt },
+        // ID 14 sampleCount (even, absolute)
+        {
+          fieldId: fieldV02IDs.trunSampleCount,
+          scalar: BigInt(sampleSizes.length),
+        },
+        // ID 1 sampleSizes per §15.1: n−1 entries; last sample size is
+        // derived by the receiver from the mdat payload length.
+        {
+          fieldId: fieldV02IDs.trunSampleSizes,
+          list: sampleSizes.slice(0, -1),
+        },
+        // ID 3 sampleDurations
+        { fieldId: fieldV02IDs.trunSampleDurations, list: sampleDurations },
+        // ID 7 sampleFlags (5-bit packed, list)
+        { fieldId: fieldV02IDs.trunSampleFlags, list: sampleFlags },
+      ]);
+
+      const wire = buildLocmafV02Object(
+        LOCMAF_V02_FULL,
+        properties,
+        mdatPayload,
+      );
+      const result = decompressMoofV02WithTrackInfo(wire, 7, state);
+      expect(result).toBeDefined();
+      const s = summarize(result!.bytes);
+      expect(s.boxOrder).toEqual(["moof", "mdat"]);
+      expect(s.sequenceNumber).toBe(7);
+      expect(s.trackId).toBe(1);
+      expect(s.bmdt).toBe(Number(bmdt));
+      expect(s.sampleCount).toBe(3);
+      expect(s.samples?.map((x: any) => x.sampleSize)).toEqual([10, 12, 8]);
+      expect(s.samples?.map((x: any) => x.sampleDuration)).toEqual([
+        512, 512, 512,
+      ]);
+      expect(s.mdatLen).toBe(mdatPayload.byteLength);
+      expect(result!.trackInfo.timescale).toBe(12800);
+      expect(result!.trackInfo.duration).toBe(1536);
+    });
+
+    it("decodes zigzag-signed composition time offsets (ID 5) in a Full chunk", async () => {
+      const init = await loadInitCmaf();
+      const state = initializeLocmafV02Track(init).state;
+
+      // Composition offsets are signed in trun v1 — the common CMAF case with
+      // B-frames. In a Full chunk they are still zigzag-encoded (unlike the
+      // other odd-ID lists, which are plain unsigned varints).
+      const sampleSizes = [10n, 12n, 8n];
+      const compositionOffsets = [0n, -512n, 256n];
+      const mdat = new Uint8Array(
+        sampleSizes.reduce((s, v) => s + Number(v), 0),
+      );
+
+      const properties = buildProperties([
+        { fieldId: fieldV02IDs.tfdtBaseMediaDecodeTime, scalar: 0n },
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: 3n },
+        {
+          fieldId: fieldV02IDs.trunSampleSizes,
+          list: sampleSizes.slice(0, -1),
+        },
+        {
+          fieldId: fieldV02IDs.trunSampleDurations,
+          list: [512n, 512n, 512n],
+        },
+        // ID 5: zigzag-encoded even in a Full chunk.
+        {
+          fieldId: fieldV02IDs.trunSampleCompositionTimeOffsets,
+          list: compositionOffsets.map(zigzag),
+        },
+      ]);
+
+      const wire = buildLocmafV02Object(LOCMAF_V02_FULL, properties, mdat);
+      const result = decompressMoofV02WithTrackInfo(wire, 3, state);
+      expect(result).toBeDefined();
+      const s = summarize(result!.bytes);
+      expect(s.samples?.map((x: any) => x.sampleCompositionTimeOffset)).toEqual(
+        [0, -512, 256],
+      );
+      // A negative offset forces trun version 1 (signed composition offsets).
+      const moofBox = readIsoBoxes(result!.bytes, defaultReaderConfig()).find(
+        (b: any) => b.type === "moof",
+      ) as any;
+      const trun = findBox(moofBox.boxes, "trun");
+      expect(trun.version).toBe(1);
+    });
+  });
+
+  describe("sample_flags 5-bit unpacking", () => {
+    it("expands the packed transport into the correct 32-bit sample_flags", async () => {
+      const init = await loadInitCmaf();
+      const state = initializeLocmafV02Track(init).state;
+
+      // Build a single-sample Full chunk with sample_flags expressing
+      // non_sync=1, depends_on=2, is_depended_on=3. Expected 32-bit value:
+      //   (is_depended_on << 22) | (depends_on << 24) | (non_sync << 16)
+      // = (3 << 22) | (2 << 24) | (1 << 16) = 0x02C10000
+      const packed = packSampleFlags(1, 2, 3);
+      const expected32 = (3 << 22) | (2 << 24) | (1 << 16);
+
+      const mdat = new Uint8Array([1, 2, 3, 4]);
+      // Single-sample chunk: omit sampleSizes (ID 1) and defaultSampleSize (ID 6).
+      const properties = buildProperties([
+        { fieldId: fieldV02IDs.tfdtBaseMediaDecodeTime, scalar: 0n },
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: 1n },
+        { fieldId: fieldV02IDs.trunSampleDurations, list: [256n] },
+        { fieldId: fieldV02IDs.trunSampleFlags, list: [packed] },
+      ]);
+      const wire = buildLocmafV02Object(LOCMAF_V02_FULL, properties, mdat);
+
+      const result = decompressMoofV02WithTrackInfo(wire, 1, state);
+      const s = summarize(result!.bytes);
+      expect(s.sampleCount).toBe(1);
+      expect(s.samples?.[0].sampleSize).toBe(4); // derived from mdat length
+      expect(s.samples?.[0].sampleFlags).toBe(expected32);
+    });
+
+    it("expands defaultSampleFlags scalar from the packed 5-bit value", async () => {
+      const init = await loadInitCmaf();
+      const state = initializeLocmafV02Track(init).state;
+
+      const packed = packSampleFlags(0, 2, 1); // non_sync=0, depends_on=2, is_depended_on=1
+      const expected32 = (1 << 22) | (2 << 24);
+
+      const mdat = new Uint8Array(10);
+      const properties = buildProperties([
+        // defaultSampleFlags (8) is the 5-bit packed value.
+        { fieldId: fieldV02IDs.tfhdDefaultSampleFlags, scalar: packed },
+        { fieldId: fieldV02IDs.tfdtBaseMediaDecodeTime, scalar: 0n },
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: 1n },
+        { fieldId: fieldV02IDs.trunSampleDurations, list: [256n] },
+      ]);
+      const wire = buildLocmafV02Object(LOCMAF_V02_FULL, properties, mdat);
+      const result = decompressMoofV02WithTrackInfo(wire, 1, state);
+      const s = summarize(result!.bytes);
+      // tfhd.defaultSampleFlags should hold the expanded 32-bit value, AND
+      // each sample inherits it (we copied the default into the per-sample
+      // list during reconstruction).
+      const moofBox = readIsoBoxes(result!.bytes, defaultReaderConfig()).find(
+        (b: any) => b.type === "moof",
+      ) as any;
+      const tfhd = findBox(moofBox.boxes, "tfhd");
+      expect(tfhd.defaultSampleFlags).toBe(expected32);
+      expect(s.samples?.[0].sampleFlags).toBe(expected32);
+    });
+  });
+
+  describe("Delta chunk sequence", () => {
+    it("decodes Full + several Deltas with BMDT derivation, list-length changes, and deletion marker", async () => {
+      const init = await loadInitCmaf();
+      const state = initializeLocmafV02Track(init).state;
+
+      const dur = 512n;
+
+      // ---- Chunk 1: Full, 3 samples, SAP-1 (firstSampleFlags present) ----
+      const sizes1 = [10n, 12n, 8n];
+      const flags1 = [packSampleFlags(0, 2, 1)]; // sync sample 0 (will use as firstSampleFlags)
+      const mdat1 = new Uint8Array(30); // sum of [10, 12, 8]
+      const props1 = buildProperties([
+        { fieldId: fieldV02IDs.tfdtBaseMediaDecodeTime, scalar: 0n },
+        { fieldId: fieldV02IDs.trunFirstSampleFlags, scalar: flags1[0] },
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: 3n },
+        // §15.1: n−1 entries; last is derived from mdat length (= 8).
+        { fieldId: fieldV02IDs.trunSampleSizes, list: sizes1.slice(0, -1) },
+        { fieldId: fieldV02IDs.trunSampleDurations, list: [dur, dur, dur] },
+      ]);
+      const wire1 = buildLocmafV02Object(LOCMAF_V02_FULL, props1, mdat1);
+      const r1 = decompressMoofV02WithTrackInfo(wire1, 1, state);
+      const s1 = summarize(r1!.bytes);
+      expect(s1.sampleCount).toBe(3);
+      expect(s1.bmdt).toBe(0);
+      // §15: with firstSampleFlags present, trun encodes the first sample's
+      // flags via that scalar and uses a placeholder for the per-sample list
+      // (the receiver gives sample 0 the firstSampleFlags value).
+      expect(s1.firstSampleFlags).toBe(
+        (1 << 22) | (2 << 24), // expanded from packed(0,2,1)
+      );
+
+      // ---- Chunk 2: Delta. Same sample_count(=3), all sizes shrink by 2
+      //      (zigzag(-2) = 3), drop firstSampleFlags via deletion marker. ----
+      const mdat2 = new Uint8Array(24); // sum of [8, 10, 6]
+      const props2 = buildProperties([
+        // deletion marker first — receiver applies before deltas
+        {
+          fieldId: auxV02IDs.deltaDeletedLocmafIDs,
+          list: [BigInt(fieldV02IDs.trunFirstSampleFlags)],
+        },
+        // sampleCount unchanged → zigzag(0) = 0
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: zigzag(0n) },
+        // BMDT delta = +sum(prev_durations) = +1536 — but BMDT is also normally
+        // derived. To test derivation, omit ID 10 entirely; the decoder will
+        // compute bmdt = 0 + 1536 = 1536.
+        // sampleSizes: n−1 = 2 wire entries (sizes 0 and 1). Each shrinks
+        // by 2 → zigzag(-2)=3. Sample 2's size (6) is derived from mdat.
+        {
+          fieldId: fieldV02IDs.trunSampleSizes,
+          list: [zigzag(-2n), zigzag(-2n)],
+        },
+      ]);
+      const wire2 = buildLocmafV02Object(LOCMAF_V02_DELTA, props2, mdat2);
+      const r2 = decompressMoofV02WithTrackInfo(wire2, 2, state);
+      const s2 = summarize(r2!.bytes);
+      expect(s2.bmdt).toBe(1536);
+      expect(s2.sampleCount).toBe(3);
+      expect(s2.samples?.map((x: any) => x.sampleSize)).toEqual([8, 10, 6]);
+      // firstSampleFlags was deleted, so the trun should not carry it.
+      expect(s2.firstSampleFlags).toBeUndefined();
+
+      // ---- Chunk 3: Delta. sample_count grows from 3 → 4. New sample's
+      //      previous size is treated as 0; wire carries absolute size for it. ----
+      const mdat3 = new Uint8Array(28); // sum of [8, 10, 6, 4]
+      const props3 = buildProperties([
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: zigzag(1n) },
+        // sampleSizes per §15.1: n_curr−1 = 3 wire entries (sizes 0..2).
+        // Previous wire list (from chunk 2) was [8, 10] (n_prev−1 = 2).
+        // Current wire list = [8, 10, 6]. Deltas: [zigzag(0), zigzag(0),
+        // zigzag(6)] (last is absolute since prev[2] doesn't exist).
+        // Sample 3's size (4) is derived from mdat: 28 − 8 − 10 − 6 = 4.
+        {
+          fieldId: fieldV02IDs.trunSampleSizes,
+          list: [zigzag(0n), zigzag(0n), zigzag(6n)],
+        },
+        {
+          fieldId: fieldV02IDs.trunSampleDurations,
+          list: [zigzag(0n), zigzag(0n), zigzag(0n), zigzag(dur)],
+        },
+      ]);
+      const wire3 = buildLocmafV02Object(LOCMAF_V02_DELTA, props3, mdat3);
+      const r3 = decompressMoofV02WithTrackInfo(wire3, 3, state);
+      const s3 = summarize(r3!.bytes);
+      // BMDT derived = previous bmdt (1536) + sum(prev durations) (3*512=1536) = 3072.
+      expect(s3.bmdt).toBe(3072);
+      expect(s3.sampleCount).toBe(4);
+      expect(s3.samples?.map((x: any) => x.sampleSize)).toEqual([8, 10, 6, 4]);
+
+      // ---- Chunk 4: Delta. sample_count shrinks from 4 → 2 (truncate). ----
+      const mdat4 = new Uint8Array(18);
+      const props4 = buildProperties([
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: zigzag(-2n) },
+        // No size delta — implicitly truncate previous sizes to [8, 10].
+      ]);
+      const wire4 = buildLocmafV02Object(LOCMAF_V02_DELTA, props4, mdat4);
+      const r4 = decompressMoofV02WithTrackInfo(wire4, 4, state);
+      const s4 = summarize(r4!.bytes);
+      // BMDT derived = 3072 + sum([512]*4) = 3072 + 2048 = 5120.
+      expect(s4.bmdt).toBe(5120);
+      expect(s4.sampleCount).toBe(2);
+      expect(s4.samples?.map((x: any) => x.sampleSize)).toEqual([8, 10]);
+
+      // ---- Chunk 5: Delta with explicit absolute BMDT override (re-anchor). ----
+      const mdat5 = new Uint8Array(18);
+      const props5 = buildProperties([
+        // Absolute BMDT (NOT zigzag delta) per §16.2.
+        { fieldId: fieldV02IDs.tfdtBaseMediaDecodeTime, scalar: 99999n },
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: zigzag(0n) },
+      ]);
+      const wire5 = buildLocmafV02Object(LOCMAF_V02_DELTA, props5, mdat5);
+      const r5 = decompressMoofV02WithTrackInfo(wire5, 5, state);
+      const s5 = summarize(r5!.bytes);
+      expect(s5.bmdt).toBe(99999);
+      expect(s5.sampleCount).toBe(2);
+    });
+  });
+
+  describe("unknown top-level header_id", () => {
+    it("returns undefined with a warning", async () => {
+      const init = await loadInitCmaf();
+      const state = initializeLocmafV02Track(init).state;
+      const wire = buildLocmafV02Object(99, new Uint8Array(), new Uint8Array());
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {
+        /* expected */
+      });
+      try {
+        expect(decompressMoofV02WithTrackInfo(wire, 1, state)).toBeUndefined();
+        expect(warn).toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe("dispatch through src/locmaf.ts", () => {
+    it("decompressMoofWithTrackInfo routes to v0.2 when track.locmafVersion=0.2", async () => {
+      const init = await loadInitCmaf();
+      const track: WarpTrack = {
+        name: "video",
+        packaging: "locmaf",
+        locmafVersion: "0.2",
+      };
+      const state = createLocmafTrackState(track, init);
+      expect(state.version).toBe("0.2");
+
+      const mdat = new Uint8Array([1, 2, 3, 4]);
+      const properties = buildProperties([
+        { fieldId: fieldV02IDs.tfdtBaseMediaDecodeTime, scalar: 0n },
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: 1n },
+        { fieldId: fieldV02IDs.trunSampleDurations, list: [256n] },
+      ]);
+      const wire = buildLocmafV02Object(LOCMAF_V02_FULL, properties, mdat);
+
+      const result = decompressMoofWithTrackInfo(wire, 42, state);
+      expect(result).toBeDefined();
+      const s = summarize(result!.bytes);
+      expect(s.sequenceNumber).toBe(42);
+      expect(s.sampleCount).toBe(1);
+      expect(s.samples?.[0].sampleSize).toBe(4);
+    });
+  });
+
+  describe("cross-decoder smoke test", () => {
+    it("v0.1 and v0.2 produce sample-equivalent moof for the same logical content", async () => {
+      // We build the same logical 1-sample chunk in v0.2 wire and compare
+      // against the v0.1 test fixture's decode for sample-level equivalence.
+      // The byte-level output is expected to differ; we assert on sample
+      // structure only (sample count, sizes, durations, BMDT direction).
+      const init = await loadInitCmaf();
+      const v02State = initializeLocmafV02Track(init).state;
+
+      const sizes = [10n, 12n, 8n];
+      const durations = [512n, 512n, 512n];
+      const mdatLen = Number(sizes.reduce((s, v) => s + v, 0n));
+      const mdat = new Uint8Array(mdatLen);
+
+      const props = buildProperties([
+        { fieldId: fieldV02IDs.tfdtBaseMediaDecodeTime, scalar: 0n },
+        { fieldId: fieldV02IDs.trunSampleCount, scalar: BigInt(sizes.length) },
+        // §15.1: drop the last size; decoder derives it from mdat length.
+        { fieldId: fieldV02IDs.trunSampleSizes, list: sizes.slice(0, -1) },
+        { fieldId: fieldV02IDs.trunSampleDurations, list: durations },
+      ]);
+      const wire = buildLocmafV02Object(LOCMAF_V02_FULL, props, mdat);
+      const v02Result = decompressMoofV02WithTrackInfo(wire, 1, v02State);
+      const v02Summary = summarize(v02Result!.bytes);
+
+      // Equivalence check: sample-level fields match the canned inputs.
+      expect(v02Summary.sampleCount).toBe(3);
+      expect(v02Summary.samples?.map((x: any) => x.sampleSize)).toEqual([
+        10, 12, 8,
+      ]);
+      expect(v02Summary.samples?.map((x: any) => x.sampleDuration)).toEqual([
+        512, 512, 512,
+      ]);
+      expect(v02Summary.bmdt).toBe(0);
+      expect(v02Summary.mdatLen).toBe(mdatLen);
+    });
+  });
+
+  // Touch the unused import so the import is observable; encodeVarint is
+  // also re-exported for downstream test files.
+  it("exposes encodeVarint helper", () => {
+    expect(encodeVarint(0n)).toEqual(new Uint8Array([0]));
+    expect(encodeVarint(63n)).toEqual(new Uint8Array([63]));
+  });
+});

--- a/src/locmaf/v02/decoder.ts
+++ b/src/locmaf/v02/decoder.ts
@@ -1,0 +1,1161 @@
+/**
+ * LOCMAF v0.2 wire-format decoder.
+ *
+ * Implements draft-einarsson-moq-locmaf §12 (Object Framing),
+ * §13 (Field Reference), §15 (Full Chunk), §16 (Delta Chunk),
+ * and §14 (Compact sample_flags).
+ *
+ * v0.2 is intentionally independent of v0.1:
+ * - Init data is raw CMAF — no LOCMAF wrapping. The init bytes are
+ *   handed to MSE unchanged; we only parse them once to derive the
+ *   track context (track_id, timescale, trex defaults, tenc IV size).
+ * - Media chunks carry one of two top-level header IDs:
+ *     23 = LocmafFullHeader, 25 = LocmafDeltaHeader
+ *   Inside the property block, field IDs 1–16 are moof fields,
+ *   18/20/22/24 are prft fields, 23 is styp, 25 is emsg, and 27 is
+ *   the delta deletion marker.
+ */
+
+import {
+  IsoBoxStreamable,
+  ProducerReferenceTimeBox,
+  TrackExtendsBox,
+  TrackFragmentBaseMediaDecodeTimeBox,
+  TrackFragmentBox,
+  TrackFragmentHeaderBox,
+  TrackRunBox,
+  TrackRunSample,
+  defaultReaderConfig,
+  defaultWriterConfig,
+  readIsoBoxes,
+  writeIsoBox,
+  type MovieBox,
+  type MovieFragmentBox,
+  type ParsedIsoBox,
+} from "@svta/cml-iso-bmff";
+
+import type { MediaTrackInfo } from "../../buffer/mediaBuffer";
+import {
+  SENC_USE_SUBSAMPLE_ENCRYPTION,
+  writeSenc,
+  type ExtendedSampleEncryptionBox,
+  type SampleEncryptionEntry,
+} from "../senc";
+
+const TFHD_DEFAULT_BASE_IS_MOOF = 0x020000;
+const TFHD_SAMPLE_DESCRIPTION_INDEX_PRESENT = 0x000002;
+const TFHD_DEFAULT_SAMPLE_DURATION_PRESENT = 0x000008;
+const TFHD_DEFAULT_SAMPLE_SIZE_PRESENT = 0x000010;
+const TFHD_DEFAULT_SAMPLE_FLAGS_PRESENT = 0x000020;
+const TRUN_DATA_OFFSET_PRESENT = 0x000001;
+const TRUN_FIRST_SAMPLE_FLAGS_PRESENT = 0x000004;
+const TRUN_SAMPLE_DURATION_PRESENT = 0x000100;
+const TRUN_SAMPLE_SIZE_PRESENT = 0x000200;
+const TRUN_SAMPLE_FLAGS_PRESENT = 0x000400;
+const TRUN_SAMPLE_COMPOSITION_TIME_OFFSET_PRESENT = 0x000800;
+
+export const LOCMAF_V02_FULL = 23;
+export const LOCMAF_V02_DELTA = 25;
+
+/** Field IDs drawn from `moof.traf` child boxes (1–16). The key
+ * prefix names the source box: `trun`, `tfhd`, `tfdt`, or `senc`. */
+export const fieldV02IDs = {
+  trunSampleSizes: 1,
+  tfhdSampleDescriptionIndex: 2,
+  trunSampleDurations: 3,
+  tfhdDefaultSampleDuration: 4,
+  trunSampleCompositionTimeOffsets: 5,
+  tfhdDefaultSampleSize: 6,
+  trunSampleFlags: 7,
+  tfhdDefaultSampleFlags: 8,
+  sencInitializationVector: 9,
+  tfdtBaseMediaDecodeTime: 10,
+  sencSubsampleCount: 11,
+  trunFirstSampleFlags: 12,
+  sencBytesOfClearData: 13,
+  trunSampleCount: 14,
+  sencBytesOfProtectedData: 15,
+  sencPerSampleIVSize: 16,
+} as const;
+
+/** prft, styp, emsg field IDs and the delta deletion marker, all
+ * carried inside the property block alongside the moof child-box
+ * fields above. */
+export const auxV02IDs = {
+  prftNtpTimestamp: 18,
+  prftMediaTime: 20,
+  prftVersion: 22,
+  prftFlags: 24,
+  stypBrandList: 23,
+  emsgList: 25,
+  deltaDeletedLocmafIDs: 27,
+} as const;
+
+const SAMPLE_FLAGS_FIELDS = new Set<number>([
+  fieldV02IDs.trunSampleFlags,
+  fieldV02IDs.tfhdDefaultSampleFlags,
+  fieldV02IDs.trunFirstSampleFlags,
+]);
+
+const RAW_BYTE_FIELDS = new Set<number>([
+  fieldV02IDs.sencInitializationVector,
+  auxV02IDs.stypBrandList,
+  auxV02IDs.emsgList,
+]);
+
+const PER_SAMPLE_LIST_FIELDS = new Set<number>([
+  fieldV02IDs.trunSampleSizes,
+  fieldV02IDs.trunSampleDurations,
+  fieldV02IDs.trunSampleCompositionTimeOffsets,
+  fieldV02IDs.trunSampleFlags,
+  fieldV02IDs.sencSubsampleCount,
+]);
+
+// Odd-ID list fields whose elements are signed quantities and are therefore
+// zigzag-encoded in BOTH Full and Delta chunks (unlike the other odd lists,
+// which are plain unsigned varints in a Full chunk). The only such field is
+// trunSampleCompositionTimeOffsets (ID 5): composition time offsets are
+// signed in trun version 1 — the common CMAF case, where B-frames make the
+// composition/decode relation non-monotonic.
+const SIGNED_LIST_FIELDS = new Set<number>([
+  fieldV02IDs.trunSampleCompositionTimeOffsets,
+]);
+
+export interface LocmafV02InitContext {
+  trackId: number;
+  timescale: number;
+  defaultSampleDescriptionIndex: number;
+  defaultSampleDuration: number;
+  defaultSampleSize: number;
+  defaultSampleFlags: number;
+  defaultPerSampleIVSize: number;
+}
+
+/** Reconstructed previous chunk's effective field values (after parity / list-length / sample-flags expansion). */
+interface PrevChunkState {
+  /** Scalar values keyed by field_id; bigint to hold 64-bit varints. */
+  scalars: Map<number, bigint>;
+  /** Per-sample list values (decoded element values, already in the "32-bit reconstructed" space for sample_flags). */
+  lists: Map<number, bigint[]>;
+  /** Raw-byte field bytes. */
+  raw: Map<number, Uint8Array>;
+  /** Sample count of the prior chunk (used for BMDT derivation and list-length math). */
+  sampleCount: number;
+  /** Per-sample sample_durations of the prior chunk (used for BMDT derivation). */
+  sampleDurations: bigint[];
+  /** Effective BMDT used for the prior chunk's reconstruction. */
+  baseMediaDecodeTime: bigint;
+}
+
+export interface LocmafV02TrackState {
+  initContext: LocmafV02InitContext;
+  initSegment: Uint8Array;
+  /** In-group delta-decoder state; reset whenever a Full chunk arrives. */
+  prev?: PrevChunkState;
+}
+
+export interface InitializedLocmafV02Track {
+  state: LocmafV02TrackState;
+  /** Always false for v0.2 — init is raw CMAF, never reconstructed. */
+  initWasReconstructed: boolean;
+}
+
+export interface LocmafV02MoofDecompressionResult {
+  bytes: Uint8Array;
+  trackInfo: MediaTrackInfo;
+}
+
+const readerConfig = defaultReaderConfig();
+const writerConfig = (() => {
+  const config = defaultWriterConfig();
+  return {
+    ...config,
+    writers: {
+      ...config.writers,
+      // The library has no native senc writer; reuse v0.1's serializer
+      // so v0.2 moofs carry per-sample CENC metadata into MSE.
+      senc: (box: ExtendedSampleEncryptionBox) => writeSenc(box),
+    },
+  };
+})();
+
+// -----------------------------------------------------------------------------
+// QUIC varint helpers (same algorithm as v0.1; duplicated to keep modules
+// independent and to avoid exporting v0.1 internals across the version
+// boundary).
+// -----------------------------------------------------------------------------
+
+function ensureUint8Array(data: Uint8Array | ArrayBuffer): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+function decodeVarint(
+  bytes: Uint8Array,
+  offset: number,
+): { value: bigint; bytesRead: number } {
+  const first = bytes[offset];
+  if (first === undefined) {
+    throw new Error("locmaf v0.2: unexpected end of payload");
+  }
+  const bytesRead = 1 << (first >> 6);
+  if (offset + bytesRead > bytes.byteLength) {
+    throw new Error("locmaf v0.2: truncated varint");
+  }
+  let value = BigInt(first & 0x3f);
+  for (let i = 1; i < bytesRead; i++) {
+    value = (value << 8n) | BigInt(bytes[offset + i]);
+  }
+  return { value, bytesRead };
+}
+
+// (The Full/Delta decoder only reads varints; encoding is needed exclusively
+// in the test helpers — see ./testEncoder.ts. We intentionally do NOT export
+// an encodeVarint from this production module to keep the decoder surface
+// minimal.)
+
+/** Zigzag decode per §11 of the draft: n = (z >> 1) ^ -(z & 1). */
+function unzigzag(z: bigint): bigint {
+  return (z >> 1n) ^ -(z & 1n);
+}
+
+function asSafeNumber(value: bigint, label: string): number {
+  const minSafe = BigInt(Number.MIN_SAFE_INTEGER);
+  const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+  if (value < minSafe || value > maxSafe) {
+    throw new Error(
+      `locmaf v0.2: ${label} exceeds JavaScript safe integer range`,
+    );
+  }
+  return Number(value);
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((s, p) => s + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.byteLength;
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// Object framing
+// -----------------------------------------------------------------------------
+
+interface ParsedObject {
+  headerId: number;
+  propertyBytes: Uint8Array;
+  mdatPayload: Uint8Array;
+}
+
+function parseObject(payload: Uint8Array | ArrayBuffer): ParsedObject {
+  const bytes = ensureUint8Array(payload);
+  const header = decodeVarint(bytes, 0);
+  const propsLen = decodeVarint(bytes, header.bytesRead);
+  const propsStart = header.bytesRead + propsLen.bytesRead;
+  const propsEnd =
+    propsStart + asSafeNumber(propsLen.value, "properties_length");
+  if (propsEnd > bytes.byteLength) {
+    throw new Error("locmaf v0.2: properties_length exceeds object size");
+  }
+  return {
+    headerId: asSafeNumber(header.value, "header_id"),
+    propertyBytes: bytes.subarray(propsStart, propsEnd),
+    mdatPayload: bytes.subarray(propsEnd),
+  };
+}
+
+/** Raw, undecoded (field_id, bytes) tuples in wire order. */
+interface RawProperty {
+  fieldId: number;
+  /** For even IDs this is the encoded scalar varint bytes; for odd IDs it is the value_bytes (length already stripped). */
+  bytes: Uint8Array;
+}
+
+function parseProperties(bytes: Uint8Array): RawProperty[] {
+  const result: RawProperty[] = [];
+  let off = 0;
+  while (off < bytes.byteLength) {
+    const fid = decodeVarint(bytes, off);
+    off += fid.bytesRead;
+    const fieldId = asSafeNumber(fid.value, "field_id");
+    if (fieldId % 2 === 0) {
+      // Scalar varint, no length prefix. Capture the encoded varint bytes.
+      const scalar = decodeVarint(bytes, off);
+      result.push({
+        fieldId,
+        bytes: bytes.subarray(off, off + scalar.bytesRead),
+      });
+      off += scalar.bytesRead;
+    } else {
+      const len = decodeVarint(bytes, off);
+      off += len.bytesRead;
+      const valLen = asSafeNumber(len.value, `field ${fieldId} length`);
+      const end = off + valLen;
+      if (end > bytes.byteLength) {
+        throw new Error(
+          `locmaf v0.2: field ${fieldId} payload overruns properties block`,
+        );
+      }
+      result.push({ fieldId, bytes: bytes.subarray(off, end) });
+      off = end;
+    }
+  }
+  return result;
+}
+
+function decodeScalar(bytes: Uint8Array): bigint {
+  const dec = decodeVarint(bytes, 0);
+  if (dec.bytesRead !== bytes.byteLength) {
+    throw new Error("locmaf v0.2: scalar field has trailing bytes");
+  }
+  return dec.value;
+}
+
+function decodeVarintList(bytes: Uint8Array): bigint[] {
+  const out: bigint[] = [];
+  let off = 0;
+  while (off < bytes.byteLength) {
+    const v = decodeVarint(bytes, off);
+    out.push(v.value);
+    off += v.bytesRead;
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// sample_flags 5-bit packing (§14)
+// -----------------------------------------------------------------------------
+
+/** Expand the 5-bit transport value (0..31) into a 32-bit `sample_flags`. */
+function expandSampleFlags(packed: bigint): bigint {
+  const v = packed & 0x1fn;
+  const nonSync = v & 0x1n;
+  const dependsOn = (v >> 1n) & 0x3n;
+  const isDependedOn = (v >> 3n) & 0x3n;
+  return (isDependedOn << 22n) | (dependsOn << 24n) | (nonSync << 16n);
+}
+
+// -----------------------------------------------------------------------------
+// Init parse
+// -----------------------------------------------------------------------------
+
+function findBoxRecursive(
+  boxes: Array<{ type: string; boxes?: any[] }> | undefined,
+  type: string,
+): any | undefined {
+  if (!boxes) {
+    return undefined;
+  }
+  for (const box of boxes) {
+    if (box.type === type) {
+      return box;
+    }
+    if (box.boxes) {
+      const nested = findBoxRecursive(box.boxes, type);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function initializeLocmafV02Track(
+  initBytes: Uint8Array | ArrayBuffer,
+): InitializedLocmafV02Track {
+  const init = ensureUint8Array(initBytes);
+  const parsed = readIsoBoxes(init, readerConfig) as ParsedIsoBox[];
+  const moov = parsed.find((b) => b.type === "moov") as MovieBox | undefined;
+  if (!moov) {
+    throw new Error("locmaf v0.2: init data does not contain moov");
+  }
+  const trex = findBoxRecursive(moov.boxes, "trex") as
+    | TrackExtendsBox
+    | undefined;
+  if (!trex) {
+    throw new Error("locmaf v0.2: init data does not contain trex");
+  }
+  const mdhd = findBoxRecursive(moov.boxes, "mdhd") as
+    | { timescale: number }
+    | undefined;
+  if (!mdhd) {
+    throw new Error("locmaf v0.2: init data does not contain mdhd");
+  }
+  const tenc = findBoxRecursive(moov.boxes, "tenc") as
+    | { defaultIvSize?: number }
+    | undefined;
+
+  return {
+    state: {
+      initContext: {
+        trackId: trex.trackId,
+        timescale: mdhd.timescale,
+        defaultSampleDescriptionIndex: trex.defaultSampleDescriptionIndex,
+        defaultSampleDuration: trex.defaultSampleDuration,
+        defaultSampleSize: trex.defaultSampleSize,
+        defaultSampleFlags: trex.defaultSampleFlags,
+        defaultPerSampleIVSize: tenc?.defaultIvSize ?? 0,
+      },
+      // v0.2 init is raw CMAF — hand it back unchanged for MSE.
+      initSegment: new Uint8Array(init),
+    },
+    initWasReconstructed: false,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Full / Delta decoding
+// -----------------------------------------------------------------------------
+
+interface DecodedFields {
+  scalars: Map<number, bigint>;
+  lists: Map<number, bigint[]>;
+  raw: Map<number, Uint8Array>;
+  /** ordered field IDs present after decoding (Full) or after merge (Delta). */
+  presentIds: Set<number>;
+}
+
+/** Read a Full chunk: even = absolute unsigned varint; odd lists = unsigned
+ * varint per element, EXCEPT the signed lists (ID 5,
+ * trunSampleCompositionTimeOffsets), which are zigzag-encoded in full chunks
+ * too because composition time offsets are signed (trun version 1). */
+function decodeFullProperties(props: RawProperty[]): DecodedFields {
+  const out: DecodedFields = {
+    scalars: new Map(),
+    lists: new Map(),
+    raw: new Map(),
+    presentIds: new Set(),
+  };
+  for (const p of props) {
+    out.presentIds.add(p.fieldId);
+    if (RAW_BYTE_FIELDS.has(p.fieldId)) {
+      out.raw.set(p.fieldId, new Uint8Array(p.bytes));
+      continue;
+    }
+    if (p.fieldId === auxV02IDs.deltaDeletedLocmafIDs) {
+      // Should not occur in a Full chunk; tolerate by storing the parsed list.
+      out.lists.set(p.fieldId, decodeVarintList(p.bytes));
+      continue;
+    }
+    if (p.fieldId % 2 === 0) {
+      const raw = decodeScalar(p.bytes);
+      out.scalars.set(
+        p.fieldId,
+        SAMPLE_FLAGS_FIELDS.has(p.fieldId) ? expandSampleFlags(raw) : raw,
+      );
+    } else {
+      // Odd-ID list elements are absolute unsigned MOQT varints in a Full
+      // chunk, with one exception: signed lists (ID 5,
+      // trunSampleCompositionTimeOffsets) carry zigzag-encoded signed values
+      // in both Full and Delta chunks, since composition time offsets are
+      // signed in trun version 1.
+      let values = SIGNED_LIST_FIELDS.has(p.fieldId)
+        ? decodeVarintList(p.bytes).map(unzigzag)
+        : decodeVarintList(p.bytes);
+      if (SAMPLE_FLAGS_FIELDS.has(p.fieldId)) {
+        values = values.map(expandSampleFlags);
+      }
+      out.lists.set(p.fieldId, values);
+    }
+  }
+  return out;
+}
+
+/**
+ * Apply a Delta chunk on top of `prev`.
+ *
+ * Rules (§16):
+ *  - Even ID scalars: wire = zigzag(current - previous); current = previous + delta.
+ *  - Odd ID varint lists: wire elements are zigzag deltas with §16.1 length rules.
+ *  - Odd ID raw-bytes (IDs 9, 23, 25): full overwrite.
+ *  - ID 27 (deletion marker): plain unsigned varints, applied BEFORE deltas.
+ *  - BMDT: if absent, derive previous_bmdt + sum(previous_sample_durations);
+ *    if present, decoded as an ABSOLUTE unsigned varint (re-anchor).
+ */
+function decodeDeltaProperties(
+  props: RawProperty[],
+  prev: PrevChunkState,
+): DecodedFields {
+  // 1) Apply deletions first.
+  const deletions: Set<number> = new Set();
+  for (const p of props) {
+    if (p.fieldId === auxV02IDs.deltaDeletedLocmafIDs) {
+      for (const id of decodeVarintList(p.bytes)) {
+        deletions.add(asSafeNumber(id, "deletion field id"));
+      }
+    }
+  }
+
+  // Seed the merge from the previous state, minus deletions.
+  const scalars = new Map<number, bigint>(prev.scalars);
+  const lists = new Map<number, bigint[]>();
+  for (const [k, v] of prev.lists.entries()) {
+    lists.set(k, v.slice());
+  }
+  const raw = new Map<number, Uint8Array>();
+  for (const [k, v] of prev.raw.entries()) {
+    raw.set(k, new Uint8Array(v));
+  }
+  for (const id of deletions) {
+    scalars.delete(id);
+    lists.delete(id);
+    raw.delete(id);
+  }
+
+  // 2) Determine the new sample_count up-front (it's always emitted in deltas
+  //    too, so we can size lists correctly per §16.1).
+  let newSampleCount = prev.sampleCount;
+  for (const p of props) {
+    if (p.fieldId === fieldV02IDs.trunSampleCount) {
+      // sampleCount is even / scalar: in Delta it's a ZIGZAG delta.
+      const delta = unzigzag(decodeScalar(p.bytes));
+      newSampleCount = asSafeNumber(
+        BigInt(prev.sampleCount) + delta,
+        "sample count",
+      );
+      break;
+    }
+  }
+
+  // 3) Walk delta fields.
+  const presentIds = new Set<number>();
+  // Carry over all non-deleted previous IDs initially; they remain effective.
+  for (const id of prev.scalars.keys()) {
+    presentIds.add(id);
+  }
+  for (const id of prev.lists.keys()) {
+    presentIds.add(id);
+  }
+  for (const id of prev.raw.keys()) {
+    presentIds.add(id);
+  }
+  for (const id of deletions) {
+    presentIds.delete(id);
+  }
+
+  for (const p of props) {
+    if (p.fieldId === auxV02IDs.deltaDeletedLocmafIDs) {
+      continue;
+    }
+    presentIds.add(p.fieldId);
+
+    if (RAW_BYTE_FIELDS.has(p.fieldId)) {
+      raw.set(p.fieldId, new Uint8Array(p.bytes));
+      continue;
+    }
+    if (p.fieldId % 2 === 0) {
+      // Even / scalar — zigzag delta unless it's an explicit absolute BMDT.
+      if (p.fieldId === fieldV02IDs.tfdtBaseMediaDecodeTime) {
+        // §16.2: absolute unsigned varint (re-anchor).
+        scalars.set(p.fieldId, decodeScalar(p.bytes));
+        continue;
+      }
+      const delta = unzigzag(decodeScalar(p.bytes));
+      const previous = prev.scalars.get(p.fieldId) ?? 0n;
+      let combined = previous + delta;
+      if (SAMPLE_FLAGS_FIELDS.has(p.fieldId)) {
+        // The 5-bit packed value is what was delta-encoded on the wire.
+        // We stored the previous as a 32-bit expanded value; collapse the
+        // previous back to its 5-bit form before applying the delta, then
+        // re-expand.
+        const prevPacked = collapseSampleFlags(previous);
+        combined = expandSampleFlags(prevPacked + delta);
+      }
+      scalars.set(p.fieldId, combined);
+      continue;
+    }
+
+    // Odd / list — per-element zigzag delta with §16.1 length rules.
+    const elements = decodeVarintList(p.bytes).map(unzigzag);
+    const previousList = lists.get(p.fieldId) ?? [];
+    // Determine target length:
+    //   per-sample lists (1, 3, 5, 7, 11)         → newSampleCount
+    //   per-subsample lists (13, 15)              → sum(subsampleCount) — we'll
+    //   resolve those by trusting len(elements) (encoder knows it; receiver too).
+    let targetLen: number;
+    if (p.fieldId === fieldV02IDs.trunSampleSizes) {
+      // §15.1: sampleSizes carries n−1 entries; the last is derived
+      // from the mdat payload length at reconstruction time.
+      targetLen = Math.max(newSampleCount - 1, 0);
+    } else if (PER_SAMPLE_LIST_FIELDS.has(p.fieldId)) {
+      targetLen = newSampleCount;
+    } else {
+      targetLen = elements.length;
+    }
+
+    const merged: bigint[] = [];
+    for (let i = 0; i < targetLen; i++) {
+      const previousElement = previousList[i];
+      const wireDelta = elements[i] ?? 0n;
+      if (previousElement === undefined) {
+        // §16.1: longer current — missing previous treated as 0.
+        merged.push(
+          SAMPLE_FLAGS_FIELDS.has(p.fieldId)
+            ? expandSampleFlags(wireDelta)
+            : wireDelta,
+        );
+      } else if (SAMPLE_FLAGS_FIELDS.has(p.fieldId)) {
+        const prevPacked = collapseSampleFlags(previousElement);
+        merged.push(expandSampleFlags(prevPacked + wireDelta));
+      } else {
+        merged.push(previousElement + wireDelta);
+      }
+    }
+    // §16.1: shorter current — truncation is implicit in targetLen.
+    lists.set(p.fieldId, merged);
+  }
+
+  // If the property block did not mention a per-sample list at all but the
+  // sample_count changed, truncate or extend (with previous-as-0) lists that
+  // were carried over from the previous state.
+  for (const fid of PER_SAMPLE_LIST_FIELDS) {
+    if (!lists.has(fid)) {
+      continue;
+    }
+    const list = lists.get(fid)!;
+    // sampleSizes (ID 1) carries n−1 entries per §15.1; every other
+    // per-sample list carries n.
+    const want =
+      fid === fieldV02IDs.trunSampleSizes
+        ? Math.max(newSampleCount - 1, 0)
+        : newSampleCount;
+    if (list.length === want) {
+      continue;
+    }
+    if (list.length > want) {
+      lists.set(fid, list.slice(0, want));
+    } else {
+      const extended = list.slice();
+      while (extended.length < want) {
+        extended.push(0n);
+      }
+      lists.set(fid, extended);
+    }
+  }
+
+  // 4) BMDT derivation: if no explicit value emerged from the merge — i.e.
+  //    the previous BMDT was unchanged in the delta — derive the new BMDT
+  //    from previous_bmdt + sum(previous_sample_durations).
+  if (!hasExplicitBmdt(props)) {
+    const derived = prev.baseMediaDecodeTime + sumBigInts(prev.sampleDurations);
+    scalars.set(fieldV02IDs.tfdtBaseMediaDecodeTime, derived);
+    presentIds.add(fieldV02IDs.tfdtBaseMediaDecodeTime);
+  }
+
+  return { scalars, lists, raw, presentIds };
+}
+
+function hasExplicitBmdt(props: RawProperty[]): boolean {
+  return props.some((p) => p.fieldId === fieldV02IDs.tfdtBaseMediaDecodeTime);
+}
+
+function sumBigInts(values: bigint[]): bigint {
+  let s = 0n;
+  for (const v of values) {
+    s += v;
+  }
+  return s;
+}
+
+/** Reverse the 32-bit expansion to recover the 5-bit packed value for delta math. */
+function collapseSampleFlags(expanded: bigint): bigint {
+  const nonSync = (expanded >> 16n) & 0x1n;
+  const dependsOn = (expanded >> 24n) & 0x3n;
+  const isDependedOn = (expanded >> 22n) & 0x3n;
+  return nonSync | (dependsOn << 1n) | (isDependedOn << 3n);
+}
+
+// -----------------------------------------------------------------------------
+// CMAF box reconstruction
+// -----------------------------------------------------------------------------
+
+function reconstructMoof(
+  decoded: DecodedFields,
+  ctx: LocmafV02InitContext,
+  sequenceNumber: number,
+  mdatPayloadLen: number,
+): {
+  box: MovieFragmentBox;
+  trackInfo: MediaTrackInfo;
+  sampleDurations: bigint[];
+} {
+  const scalars = decoded.scalars;
+  const lists = decoded.lists;
+
+  const sampleCountVal = scalars.get(fieldV02IDs.trunSampleCount);
+  if (sampleCountVal === undefined) {
+    throw new Error("locmaf v0.2: moof missing sampleCount");
+  }
+  const sampleCount = asSafeNumber(sampleCountVal, "sample count");
+
+  const bmdtVal = scalars.get(fieldV02IDs.tfdtBaseMediaDecodeTime);
+  if (bmdtVal === undefined) {
+    throw new Error("locmaf v0.2: moof missing baseMediaDecodeTime");
+  }
+
+  // tfhd defaults (only emit fields the wire explicitly carried).
+  const wireHas = (id: number) => decoded.presentIds.has(id);
+
+  const tfhdDefaultSampleDuration =
+    scalars.get(fieldV02IDs.tfhdDefaultSampleDuration) ??
+    BigInt(ctx.defaultSampleDuration);
+  const tfhdDefaultSampleSize =
+    scalars.get(fieldV02IDs.tfhdDefaultSampleSize) ??
+    BigInt(ctx.defaultSampleSize);
+  const tfhdDefaultSampleFlags =
+    scalars.get(fieldV02IDs.tfhdDefaultSampleFlags) ??
+    BigInt(ctx.defaultSampleFlags);
+
+  // Resolve per-sample lists, falling back to "repeat default" or single-sample
+  // derivation from mdat length.
+  const sampleSizes = ((): bigint[] => {
+    const list = lists.get(fieldV02IDs.trunSampleSizes);
+    if (list && list.length > 0) {
+      // §15.1: list carries n−1 entries; derive the last from the
+      // mdat payload length.
+      if (list.length !== sampleCount - 1) {
+        throw new Error(
+          `locmaf v0.2: sample_sizes list has ${list.length} entries, expected ${sampleCount - 1}`,
+        );
+      }
+      if (mdatPayloadLen < 0) {
+        throw new Error(
+          "locmaf v0.2: variable-sized samples need mdat payload length",
+        );
+      }
+      let sum = 0n;
+      for (const v of list) {
+        sum += v;
+      }
+      if (BigInt(mdatPayloadLen) < sum) {
+        throw new Error(
+          `locmaf v0.2: mdat payload length ${mdatPayloadLen} < sum of listed sample sizes ${sum}`,
+        );
+      }
+      return [...list, BigInt(mdatPayloadLen) - sum];
+    }
+    if (sampleCount === 1) {
+      // Single-sample chunk — derive from mdat payload length.
+      if (mdatPayloadLen <= 0) {
+        throw new Error(
+          "locmaf v0.2: single-sample moof has empty mdat payload",
+        );
+      }
+      return [BigInt(mdatPayloadLen)];
+    }
+    // Uniform sizes: moofDefaultSampleSize (already merged into ctx)
+    // or trex.default_sample_size.
+    return new Array(sampleCount).fill(tfhdDefaultSampleSize);
+  })();
+
+  const sampleDurations = ((): bigint[] => {
+    const list = lists.get(fieldV02IDs.trunSampleDurations);
+    if (list) {
+      return list;
+    }
+    return new Array(sampleCount).fill(tfhdDefaultSampleDuration);
+  })();
+
+  const sampleFlagsList = ((): bigint[] => {
+    const list = lists.get(fieldV02IDs.trunSampleFlags);
+    if (list) {
+      return list;
+    }
+    return new Array(sampleCount).fill(tfhdDefaultSampleFlags);
+  })();
+
+  const compositionList = lists.get(
+    fieldV02IDs.trunSampleCompositionTimeOffsets,
+  );
+  const hasCompositionOffsets = compositionList !== undefined;
+  const compositionOffsets = compositionList ?? new Array(sampleCount).fill(0n);
+
+  if (
+    sampleSizes.length !== sampleCount ||
+    sampleDurations.length !== sampleCount ||
+    sampleFlagsList.length !== sampleCount ||
+    compositionOffsets.length !== sampleCount
+  ) {
+    throw new Error("locmaf v0.2: moof per-sample list length mismatch");
+  }
+
+  const tfhdFlags =
+    TFHD_DEFAULT_BASE_IS_MOOF |
+    (wireHas(fieldV02IDs.tfhdSampleDescriptionIndex)
+      ? TFHD_SAMPLE_DESCRIPTION_INDEX_PRESENT
+      : 0) |
+    (wireHas(fieldV02IDs.tfhdDefaultSampleDuration)
+      ? TFHD_DEFAULT_SAMPLE_DURATION_PRESENT
+      : 0) |
+    (wireHas(fieldV02IDs.tfhdDefaultSampleSize)
+      ? TFHD_DEFAULT_SAMPLE_SIZE_PRESENT
+      : 0) |
+    (wireHas(fieldV02IDs.tfhdDefaultSampleFlags)
+      ? TFHD_DEFAULT_SAMPLE_FLAGS_PRESENT
+      : 0);
+
+  const tfhd: TrackFragmentHeaderBox = {
+    type: "tfhd",
+    version: 0,
+    flags: tfhdFlags,
+    trackId: ctx.trackId,
+  };
+  const sdiVal = scalars.get(fieldV02IDs.tfhdSampleDescriptionIndex);
+  if (sdiVal !== undefined && wireHas(fieldV02IDs.tfhdSampleDescriptionIndex)) {
+    tfhd.sampleDescriptionIndex = asSafeNumber(
+      sdiVal,
+      "sample description index",
+    );
+  }
+  if (wireHas(fieldV02IDs.tfhdDefaultSampleDuration)) {
+    tfhd.defaultSampleDuration = asSafeNumber(
+      tfhdDefaultSampleDuration,
+      "default sample duration",
+    );
+  }
+  if (wireHas(fieldV02IDs.tfhdDefaultSampleSize)) {
+    tfhd.defaultSampleSize = asSafeNumber(
+      tfhdDefaultSampleSize,
+      "default sample size",
+    );
+  }
+  if (wireHas(fieldV02IDs.tfhdDefaultSampleFlags)) {
+    tfhd.defaultSampleFlags = asSafeNumber(
+      tfhdDefaultSampleFlags,
+      "default sample flags",
+    );
+  }
+
+  const samples: TrackRunSample[] = Array.from(
+    { length: sampleCount },
+    (_, i) => ({
+      sampleDuration: asSafeNumber(sampleDurations[i], `sample ${i} duration`),
+      sampleSize: asSafeNumber(sampleSizes[i], `sample ${i} size`),
+      sampleFlags: asSafeNumber(sampleFlagsList[i], `sample ${i} flags`),
+      sampleCompositionTimeOffset: asSafeNumber(
+        compositionOffsets[i],
+        `sample ${i} composition offset`,
+      ),
+    }),
+  );
+
+  const firstSampleFlags = scalars.get(fieldV02IDs.trunFirstSampleFlags);
+
+  const trun: TrackRunBox = {
+    type: "trun",
+    version: samples.some((s) => (s.sampleCompositionTimeOffset ?? 0) < 0)
+      ? 1
+      : 0,
+    flags:
+      TRUN_DATA_OFFSET_PRESENT |
+      (firstSampleFlags !== undefined &&
+      wireHas(fieldV02IDs.trunFirstSampleFlags)
+        ? TRUN_FIRST_SAMPLE_FLAGS_PRESENT
+        : 0) |
+      TRUN_SAMPLE_DURATION_PRESENT |
+      TRUN_SAMPLE_SIZE_PRESENT |
+      TRUN_SAMPLE_FLAGS_PRESENT |
+      (hasCompositionOffsets ? TRUN_SAMPLE_COMPOSITION_TIME_OFFSET_PRESENT : 0),
+    sampleCount,
+    dataOffset: 0,
+    samples,
+  };
+  if (
+    firstSampleFlags !== undefined &&
+    wireHas(fieldV02IDs.trunFirstSampleFlags)
+  ) {
+    trun.firstSampleFlags = asSafeNumber(
+      firstSampleFlags,
+      "first sample flags",
+    );
+  }
+
+  const tfdt: TrackFragmentBaseMediaDecodeTimeBox = {
+    type: "tfdt",
+    version: bmdtVal > 0xffffffffn ? 1 : 0,
+    flags: 0,
+    baseMediaDecodeTime: asSafeNumber(bmdtVal, "base media decode time"),
+  };
+
+  const trafBoxes: TrackFragmentBox["boxes"] = [tfhd, tfdt, trun];
+
+  // Reconstruct senc from the encryption fields (IDs 9, 11, 13, 15, 16)
+  // if any are present. Without it MSE/EME sees the moof as carrying
+  // cleartext samples and the decoder rejects the scrambled bytes.
+  const ivOverride = scalars.get(fieldV02IDs.sencPerSampleIVSize);
+  const perSampleIVSize =
+    ivOverride !== undefined
+      ? asSafeNumber(ivOverride, "per_sample_iv_size")
+      : ctx.defaultPerSampleIVSize;
+  const senc = buildSencV02(decoded, sampleCount, perSampleIVSize);
+  if (senc) {
+    trafBoxes.push(senc as TrackFragmentBox["boxes"][number]);
+  }
+
+  const totalDuration = sampleDurations.reduce(
+    (sum, d) => sum + asSafeNumber(d, "sample duration"),
+    0,
+  );
+
+  return {
+    box: {
+      type: "moof",
+      boxes: [
+        { type: "mfhd", version: 0, flags: 0, sequenceNumber },
+        { type: "traf", boxes: trafBoxes },
+      ],
+    },
+    trackInfo: {
+      timescale: ctx.timescale,
+      baseMediaDecodeTime: tfdt.baseMediaDecodeTime,
+      duration: totalDuration,
+      sequenceNumber,
+    },
+    sampleDurations,
+  };
+}
+
+function encodeMoof(box: MovieFragmentBox): Uint8Array {
+  const draft = writeIsoBox(box as IsoBoxStreamable, writerConfig);
+  const traf = box.boxes.find(
+    (b: { type: string }) => b.type === "traf",
+  ) as TrackFragmentBox;
+  const trun = traf.boxes.find(
+    (b: { type: string }) => b.type === "trun",
+  ) as TrackRunBox;
+  trun.dataOffset = draft.byteLength + 8;
+  return writeIsoBox(box as IsoBoxStreamable, writerConfig);
+}
+
+function makeMdat(payload: Uint8Array): Uint8Array {
+  const useLarge = payload.byteLength > 0xfffffff7;
+  const headerLen = useLarge ? 16 : 8;
+  const out = new Uint8Array(headerLen + payload.byteLength);
+  const view = new DataView(out.buffer);
+  if (useLarge) {
+    view.setUint32(0, 1);
+    view.setBigUint64(8, BigInt(out.byteLength));
+  } else {
+    view.setUint32(0, out.byteLength);
+  }
+  out[4] = 0x6d;
+  out[5] = 0x64;
+  out[6] = 0x61;
+  out[7] = 0x74;
+  out.set(payload, headerLen);
+  return out;
+}
+
+/** Build the optional `prft` box from prft fields, if any. */
+function maybeBuildPrft(
+  decoded: DecodedFields,
+  ctx: LocmafV02InitContext,
+): Uint8Array | undefined {
+  const hasAny =
+    decoded.scalars.has(auxV02IDs.prftNtpTimestamp) ||
+    decoded.scalars.has(auxV02IDs.prftMediaTime) ||
+    decoded.scalars.has(auxV02IDs.prftVersion) ||
+    decoded.scalars.has(auxV02IDs.prftFlags);
+  if (!hasAny) {
+    return undefined;
+  }
+
+  const ntp64 = decoded.scalars.get(auxV02IDs.prftNtpTimestamp) ?? 0n;
+  const mediaTime = decoded.scalars.get(auxV02IDs.prftMediaTime) ?? 0n;
+  const version = asSafeNumber(
+    decoded.scalars.get(auxV02IDs.prftVersion) ?? 1n,
+    "prft version",
+  );
+  const flags = asSafeNumber(
+    decoded.scalars.get(auxV02IDs.prftFlags) ?? 0n,
+    "prft flags",
+  );
+
+  const ntpTimestampSec = asSafeNumber(
+    (ntp64 >> 32n) & 0xffffffffn,
+    "prft ntp seconds",
+  );
+  const ntpTimestampFrac = asSafeNumber(
+    ntp64 & 0xffffffffn,
+    "prft ntp fraction",
+  );
+
+  const box: ProducerReferenceTimeBox = {
+    type: "prft",
+    version,
+    flags,
+    referenceTrackId: ctx.trackId,
+    ntpTimestampSec,
+    ntpTimestampFrac,
+    mediaTime: asSafeNumber(mediaTime, "prft media time"),
+  };
+  return writeIsoBox(box as IsoBoxStreamable, writerConfig);
+}
+
+// -----------------------------------------------------------------------------
+// Public chunk decode
+// -----------------------------------------------------------------------------
+
+export function decompressMoofV02WithTrackInfo(
+  payload: Uint8Array | ArrayBuffer,
+  sequenceNumber: number,
+  state: LocmafV02TrackState,
+): LocmafV02MoofDecompressionResult | undefined {
+  const obj = parseObject(payload);
+  if (obj.headerId !== LOCMAF_V02_FULL && obj.headerId !== LOCMAF_V02_DELTA) {
+    console.warn(
+      `[locmaf v0.2] skipping unknown top-level header_id=${obj.headerId}`,
+    );
+    return undefined;
+  }
+
+  const rawProps = parseProperties(obj.propertyBytes);
+
+  let decoded: DecodedFields;
+  if (obj.headerId === LOCMAF_V02_FULL) {
+    decoded = decodeFullProperties(rawProps);
+  } else {
+    if (!state.prev) {
+      throw new Error(
+        "locmaf v0.2: cannot decode delta chunk without prior full chunk",
+      );
+    }
+    decoded = decodeDeltaProperties(rawProps, state.prev);
+  }
+
+  const moof = reconstructMoof(
+    decoded,
+    state.initContext,
+    sequenceNumber,
+    obj.mdatPayload.byteLength,
+  );
+  const moofBytes = encodeMoof(moof.box);
+  const mdat = makeMdat(obj.mdatPayload);
+  const prft = maybeBuildPrft(decoded, state.initContext);
+
+  // Update in-group reference for the next delta chunk.
+  state.prev = {
+    scalars: new Map(decoded.scalars),
+    lists: new Map(
+      Array.from(decoded.lists.entries(), ([k, v]) => [k, v.slice()]),
+    ),
+    raw: new Map(
+      Array.from(decoded.raw.entries(), ([k, v]) => [k, new Uint8Array(v)]),
+    ),
+    sampleCount: asSafeNumber(
+      decoded.scalars.get(fieldV02IDs.trunSampleCount) ?? 0n,
+      "sample count",
+    ),
+    sampleDurations: moof.sampleDurations.slice(),
+    baseMediaDecodeTime:
+      decoded.scalars.get(fieldV02IDs.tfdtBaseMediaDecodeTime) ?? 0n,
+  };
+
+  return {
+    bytes: prft
+      ? concatBytes(prft, moofBytes, mdat)
+      : concatBytes(moofBytes, mdat),
+    trackInfo: moof.trackInfo,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// senc reconstruction (CENC per-sample encryption metadata)
+// -----------------------------------------------------------------------------
+
+/**
+ * Build a SampleEncryptionBox from the encryption fields decoded out of the
+ * v0.2 wire format. Returns undefined when no encryption metadata was emitted
+ * (clear track). Mirrors v0.1's createSencBox but consumes the decoded
+ * lists/raw maps instead of raw varint blobs.
+ */
+function buildSencV02(
+  decoded: DecodedFields,
+  sampleCount: number,
+  perSampleIVSize: number,
+): ExtendedSampleEncryptionBox | undefined {
+  const ivBytes = decoded.raw.get(fieldV02IDs.sencInitializationVector);
+  const subsampleCounts = decoded.lists.get(fieldV02IDs.sencSubsampleCount);
+  const bytesOfClearData = decoded.lists.get(fieldV02IDs.sencBytesOfClearData);
+  const bytesOfProtectedData = decoded.lists.get(
+    fieldV02IDs.sencBytesOfProtectedData,
+  );
+
+  if (
+    !ivBytes &&
+    (!subsampleCounts || subsampleCounts.length === 0) &&
+    (!bytesOfClearData || bytesOfClearData.length === 0) &&
+    (!bytesOfProtectedData || bytesOfProtectedData.length === 0)
+  ) {
+    return undefined;
+  }
+
+  if (ivBytes) {
+    if (perSampleIVSize === 0) {
+      throw new Error(
+        "locmaf v0.2: senc carries IVs but per_sample_iv_size is 0",
+      );
+    }
+    if (ivBytes.byteLength !== sampleCount * perSampleIVSize) {
+      throw new Error(
+        `locmaf v0.2: IV field length ${ivBytes.byteLength} ≠ sample_count (${sampleCount}) × per_sample_iv_size (${perSampleIVSize})`,
+      );
+    }
+  }
+
+  if (subsampleCounts && subsampleCounts.length !== sampleCount) {
+    throw new Error(
+      `locmaf v0.2: subsample_count length ${subsampleCounts.length} ≠ sample_count ${sampleCount}`,
+    );
+  }
+  if ((bytesOfClearData || bytesOfProtectedData) && !subsampleCounts) {
+    throw new Error(
+      "locmaf v0.2: subsample byte counts require subsample_count",
+    );
+  }
+
+  let clearIdx = 0;
+  let protIdx = 0;
+  const samples: SampleEncryptionEntry[] = [];
+
+  for (let i = 0; i < sampleCount; i++) {
+    const entry: SampleEncryptionEntry = {};
+    if (ivBytes) {
+      const start = i * perSampleIVSize;
+      entry.initializationVector = ivBytes.slice(
+        start,
+        start + perSampleIVSize,
+      );
+    }
+    const subCount = subsampleCounts
+      ? asSafeNumber(subsampleCounts[i], `subsample_count[${i}]`)
+      : 0;
+    if (subCount > 0) {
+      entry.subsampleEncryption = [];
+      for (let j = 0; j < subCount; j++) {
+        const clear = bytesOfClearData?.[clearIdx] ?? 0n;
+        const prot = bytesOfProtectedData?.[protIdx] ?? 0n;
+        entry.subsampleEncryption.push({
+          bytesOfClearData: asSafeNumber(clear, "bytes_of_clear_data"),
+          bytesOfProtectedData: asSafeNumber(prot, "bytes_of_protected_data"),
+        });
+        clearIdx++;
+        protIdx++;
+      }
+    }
+    samples.push(entry);
+  }
+
+  return {
+    type: "senc",
+    version: 0,
+    flags: samples.some((s) => s.subsampleEncryption?.length)
+      ? SENC_USE_SUBSAMPLE_ENCRYPTION
+      : 0,
+    sampleCount,
+    samples,
+  } as ExtendedSampleEncryptionBox;
+}

--- a/src/locmaf/v02/decoder.ts
+++ b/src/locmaf/v02/decoder.ts
@@ -378,6 +378,13 @@ export function initializeLocmafV02Track(
   if (!trex) {
     throw new Error("locmaf v0.2: init data does not contain trex");
   }
+  // The reconstructed moof's tfhd.track_ID is taken from the track's
+  // tkhd.track_ID — the authoritative track identifier — falling back to
+  // trex.track_ID. In conformant CMAF the two are equal; preferring tkhd
+  // matches the Go reference decoder (internal/locmafv02 reconstructMoof).
+  const tkhd = findBoxRecursive(moov.boxes, "tkhd") as
+    | { trackId?: number }
+    | undefined;
   const mdhd = findBoxRecursive(moov.boxes, "mdhd") as
     | { timescale: number }
     | undefined;
@@ -391,7 +398,7 @@ export function initializeLocmafV02Track(
   return {
     state: {
       initContext: {
-        trackId: trex.trackId,
+        trackId: tkhd?.trackId ?? trex.trackId,
         timescale: mdhd.timescale,
         defaultSampleDescriptionIndex: trex.defaultSampleDescriptionIndex,
         defaultSampleDuration: trex.defaultSampleDuration,

--- a/src/locmaf/v02/decoder.ts
+++ b/src/locmaf/v02/decoder.ts
@@ -619,10 +619,10 @@ function decodeDeltaProperties(
   // sample_count changed, truncate or extend (with previous-as-0) lists that
   // were carried over from the previous state.
   for (const fid of PER_SAMPLE_LIST_FIELDS) {
-    if (!lists.has(fid)) {
+    const list = lists.get(fid);
+    if (!list) {
       continue;
     }
-    const list = lists.get(fid)!;
     // sampleSizes (ID 1) carries n−1 entries per §15.1; every other
     // per-sample list carries n.
     const want =

--- a/src/locmaf/v02/testEncoder.ts
+++ b/src/locmaf/v02/testEncoder.ts
@@ -1,0 +1,115 @@
+/**
+ * Test-only helpers that build LOCMAF v0.2 wire bytes from structured inputs.
+ *
+ * Lives under `src/` so Jest can import it via the same ts-jest pipeline as
+ * the production decoder.
+ */
+
+const MAX_QUIC_VARINT = (1n << 62n) - 1n;
+
+export function encodeVarint(value: bigint): Uint8Array {
+  if (value < 0n || value > MAX_QUIC_VARINT) {
+    throw new Error(`varint out of range: ${value}`);
+  }
+  if (value < 64n) {
+    return Uint8Array.of(Number(value));
+  }
+  if (value < 16384n) {
+    return Uint8Array.of(
+      Number(((value >> 8n) & 0x3fn) | 0x40n),
+      Number(value & 0xffn),
+    );
+  }
+  if (value < 1073741824n) {
+    return Uint8Array.of(
+      Number(((value >> 24n) & 0x3fn) | 0x80n),
+      Number((value >> 16n) & 0xffn),
+      Number((value >> 8n) & 0xffn),
+      Number(value & 0xffn),
+    );
+  }
+  return Uint8Array.of(
+    Number(((value >> 56n) & 0x3fn) | 0xc0n),
+    Number((value >> 48n) & 0xffn),
+    Number((value >> 40n) & 0xffn),
+    Number((value >> 32n) & 0xffn),
+    Number((value >> 24n) & 0xffn),
+    Number((value >> 16n) & 0xffn),
+    Number((value >> 8n) & 0xffn),
+    Number(value & 0xffn),
+  );
+}
+
+export function zigzag(n: bigint): bigint {
+  return (n << 1n) ^ (n >> 63n);
+}
+
+export function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((s, p) => s + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.byteLength;
+  }
+  return out;
+}
+
+/** Pack a (non_sync, depends_on, is_depended_on) triple into the 5-bit transport. */
+export function packSampleFlags(
+  nonSync: number,
+  dependsOn: number,
+  isDependedOn: number,
+): bigint {
+  return (
+    BigInt(nonSync & 0x1) |
+    (BigInt(dependsOn & 0x3) << 1n) |
+    (BigInt(isDependedOn & 0x3) << 3n)
+  );
+}
+
+export interface FieldEntry {
+  fieldId: number;
+  /** Even (scalar) value, raw varint encoded as-is. Either absolute or zigzag — caller decides. */
+  scalar?: bigint;
+  /** Odd (list) values, each varint encoded as-is (absolute or zigzag — caller decides). */
+  list?: bigint[];
+  /** Odd (raw bytes) value. */
+  raw?: Uint8Array;
+}
+
+/**
+ * Build a property block from a list of entries IN THE ORDER PROVIDED.
+ *
+ * Each entry must supply exactly one of {scalar, list, raw}. The caller is
+ * responsible for choosing absolute vs zigzag encoding per the chunk kind.
+ */
+export function buildProperties(entries: FieldEntry[]): Uint8Array {
+  const parts: Uint8Array[] = [];
+  for (const e of entries) {
+    parts.push(encodeVarint(BigInt(e.fieldId)));
+    if (e.scalar !== undefined) {
+      parts.push(encodeVarint(e.scalar));
+    } else if (e.list !== undefined) {
+      const listBytes = concatBytes(...e.list.map(encodeVarint));
+      parts.push(encodeVarint(BigInt(listBytes.byteLength)));
+      parts.push(listBytes);
+    } else if (e.raw !== undefined) {
+      parts.push(encodeVarint(BigInt(e.raw.byteLength)));
+      parts.push(e.raw);
+    } else {
+      throw new Error(`field ${e.fieldId} has no value`);
+    }
+  }
+  return concatBytes(...parts);
+}
+
+export function buildLocmafV02Object(
+  headerId: number,
+  properties: Uint8Array,
+  mdatPayload: Uint8Array,
+): Uint8Array {
+  const header = encodeVarint(BigInt(headerId));
+  const propLen = encodeVarint(BigInt(properties.byteLength));
+  return concatBytes(header, propLen, properties, mdatPayload);
+}


### PR DESCRIPTION
## Summary

Adds a **LOCMAF v0.2** wire-format decoder to the MSE pipeline, alongside the existing v0.1 decoder, and dispatches between them on the catalog's `locmafVersion`. This is the client counterpart to Eyevinn/moqlivemock#88, which advertises `locmafVersion: "0.2"`.

This PR also **prepares the v0.10.0 release** (see the Release section below).

v0.2 is intentionally independent of v0.1:

- **Init is raw CMAF** — no LOCMAF wrapping. The init bytes are handed to MSE unchanged; we parse them once to derive track context (track_id, timescale, trex defaults, tenc IV size).
- **Media chunks** carry one of two top-level header IDs: `23` (full chunk) / `25` (delta chunk), with a flat `(field_id, value)` property block (even = scalar varint, odd = length-prefixed list/bytes).

## What's included

- **`src/locmaf/v02/decoder.ts`** — the v0.2 decoder implementing draft-einarsson-moq-locmaf §12 (object framing), §13 (field reference), §15 (full chunk), §16 (delta chunk), and the 5-bit compact `sample_flags`. Reconstructs a standard CMAF `moof+mdat` so the existing `MediaBuffer` / `MediaSegmentBuffer` path is reused unchanged.
- **Version dispatch in `src/locmaf/locmaf.ts`** — `LOCMAF_SUPPORTED_VERSIONS = {"0.1", "0.2"}`; `createLocmafTrackState` / `initializeLocmafTrack` / `decompressMoofWithTrackInfo` branch on the track's `locmafVersion`. The v0.1 path is untouched.
- **Shared senc helpers (`src/locmaf/senc.ts`)** — `writeSenc` + types factored out of the v0.1 decoder so both versions serialize cenc per-sample metadata into the reconstructed CMAF.
- **`src/locmaf/v02/testEncoder.ts`** — test-only helper that builds v0.2 wire bytes from structured inputs (the decoder itself never encodes).

## Signed composition time offsets

`trunSampleCompositionTimeOffsets` (field 5) is **zigzag-signed in both full and delta chunks**, because composition time offsets are signed in `trun` version 1 — the common CMAF case where B-frames make the composition/decode-time relation non-monotonic. This is the one odd-ID list whose full-chunk elements are not plain unsigned varints. The matching spec text lives in draft-einarsson-moq-locmaf.

## Release

Prepares the **v0.10.0** release:

- Bumps `package.json` / `package-lock.json` `0.9.0` → `0.10.0`.
- Adds a dated `## [0.10.0] - 2026-06-02` section to `CHANGELOG.md` covering the LOCMAF v0.2 decoder (Added) and the v0.2 `moof` `track_ID`-from-`tkhd` fix (Fixed), and updates the compare links.
- Silences the `no-non-null-assertion` ESLint warnings introduced by the v0.2 decoder test (rule relaxed for `*.test.ts` to match the existing `no-explicit-any` relaxation; production `Map.get()!` in `decoder.ts` replaced with a `get()` + truthy check).

The `v0.10.0` git tag is created separately after merge to `main`.

## Testing

- New `decoder.test.ts` (12 cases): full-chunk round-trip, signed composition-time-offset round-trip (forces `trun` v1), 5-bit `sample_flags` expansion, and a full + multi-delta sequence exercising BMDT derivation, per-sample list-length changes, and the delta deletion marker.
- Full suite: **152/152 tests pass**, `tsc` clean, ESLint 0 errors.

## Notes / limitations

- LOCMAF (v0.1 and v0.2) runs on the **MSE engine only** — unsupported on the WebCodecs engine per the capability matrix in `src/pipeline/index.ts`.
- `prft` / `styp` / `emsg` field carriage is decoded where present, but the moqlivemock publisher does not emit them yet, so those paths are not exercised end-to-end.
