### PR TITLE
feat: retrieve catalog via SUBSCRIBE plus relative joining FETCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Catalog retrieval now uses a relative joining FETCH, aligned to the live edge.
+
+### Added
+
+- "Catalog retrieval" mode selector (joining | subscribe | fetch), replacing the
+  old FETCH checkbox. The default retrieves the catalog via SUBSCRIBE plus a
+  relative joining FETCH (offset 0), so the player starts from the latest catalog
+  group aligned to the live edge.
+- `subscribeTrackWithInfo` (exposes the request ID and largest location from
+  SUBSCRIBE_OK) and `fetchJoiningRelative` on the transport layer; FETCH message
+  types `0x02`/`0x03` in the wire encoder.
+
+### Changed
+
+- `joiningFetchCatalog` is now the default catalog-retrieval path in the player.
+  It falls back to a plain subscription when SUBSCRIBE_OK carries no largest
+  location (legacy publisher).
+
 ## [0.11.0] - 2026-06-04
 
 MSF/CMSF catalog support updated to draft-ietf-moq-msf-01, with the new

--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ See [CONFIG.md](CONFIG.md) for detailed configuration options.
   (auto-negotiated via WebTransport ALPN; can be forced from the UI)
 - MSF/CMSF catalog support for discovering available media streams
   ([draft-ietf-moq-msf-00], [draft-ietf-moq-cmsf-00])
+- Catalog retrieval via SUBSCRIBE plus a relative joining FETCH by default, so
+  playback starts from the latest catalog group aligned to the live edge; a
+  "Catalog retrieval" selector (joining | subscribe | fetch) is exposed in the
+  UI, with a fallback to a plain subscription against legacy publishers
 - Two interchangeable render engines selected per session:
   - **MSE / CMAF** — the default for CMAF tracks, also handles encrypted content via EME
   - **WebCodecs / LOC** — clear-only pipeline for `packaging: "loc"` tracks,

--- a/src/index.html
+++ b/src/index.html
@@ -850,8 +850,12 @@
               <span>●</span> Disconnected
             </div>
             <div class="fetch-option">
-              <input type="checkbox" id="useFetchCatalog" />
-              <label for="useFetchCatalog">Use FETCH for catalog</label>
+              <label for="catalogMode">Catalog retrieval</label>
+              <select id="catalogMode" class="track-select">
+                <option value="joining">SUBSCRIBE + joining FETCH</option>
+                <option value="subscribe">SUBSCRIBE only</option>
+                <option value="fetch">Standalone FETCH</option>
+              </select>
             </div>
           </div>
         </div>

--- a/src/player.ts
+++ b/src/player.ts
@@ -16,6 +16,7 @@ import { EngineChoice, IPlaybackPipeline, resolveEngine } from "./pipeline";
 import { MsePipeline } from "./pipeline/msePipeline";
 import { WebCodecsLocPipeline } from "./pipeline/webcodecsLocPipeline";
 import { Client, DraftVersion } from "./transport/client";
+import { FilterType } from "./transport/control";
 import { MOQObject } from "./transport/tracks";
 import {
   WarpCatalog,
@@ -627,12 +628,13 @@ export class Player {
     // Update the visual selection state
     this.renderNamespaceSelector();
 
-    // Check if we should use FETCH instead of SUBSCRIBE
-    const useFetch = (
-      document.getElementById("useFetchCatalog") as HTMLInputElement
-    )?.checked;
+    // Catalog retrieval mode: "joining" (SUBSCRIBE + relative joining FETCH,
+    // the MSF draft-01 §5 way, default), "subscribe", or "fetch"
+    const catalogMode =
+      (document.getElementById("catalogMode") as HTMLSelectElement)?.value ??
+      "joining";
 
-    if (useFetch) {
+    if (catalogMode === "fetch") {
       this.fetchCatalog(namespace).catch((error) => {
         this.logger.error(
           `Error fetching catalog: ${
@@ -640,10 +642,18 @@ export class Player {
           }`,
         );
       });
-    } else {
+    } else if (catalogMode === "subscribe") {
       this.subscribeToCatalog(namespace).catch((error) => {
         this.logger.error(
           `Error subscribing to catalog: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    } else {
+      this.joiningFetchCatalog(namespace).catch((error) => {
+        this.logger.error(
+          `Error retrieving catalog via joining fetch: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
@@ -722,6 +732,96 @@ export class Player {
         }`,
       );
     }
+  }
+
+  /**
+   * Retrieve the catalog the MSF draft-01 §5 way: SUBSCRIBE with Filter Type
+   * Largest Object plus a relative Joining FETCH (offset 0). The FETCH
+   * delivers the latest complete catalog (object 0 of the current group)
+   * plus any deltas up to the live edge; the SUBSCRIBE then carries
+   * subsequent updates. Objects at or before the subscription's largest
+   * location are covered by the FETCH and are skipped on the subscription.
+   */
+  private async joiningFetchCatalog(namespace: string[]): Promise<void> {
+    if (!this.client) {
+      this.logger.error("Cannot retrieve catalog: Not connected");
+      return;
+    }
+    const client = this.client;
+
+    const namespaceStr = namespace.join("/");
+    this.logger.info(
+      `Retrieving catalog via joining FETCH in namespace: ${namespaceStr}`,
+    );
+
+    const applyCatalogObject = (obj: MOQObject, source: string) => {
+      try {
+        const text = new TextDecoder().decode(obj.data);
+        const catalog = JSON.parse(text);
+        this.catalogManager.handleCatalogData(catalog, namespaceStr);
+      } catch (e) {
+        this.logger.error(
+          `Failed to decode catalog data from ${source}: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+      }
+    };
+
+    // Subscribe first: the joining FETCH is resolved by the publisher from
+    // this subscription, so it must be established before the FETCH is sent.
+    const sub = await client.subscribeTrackWithInfo(
+      namespaceStr,
+      "catalog",
+      (obj: MOQObject) => applyCatalogObject(obj, "catalog subscription"),
+      {
+        filterType: FilterType.LatestObject,
+        skipObjectsUpToLargest: true,
+      },
+    );
+
+    if (this.unregisterCatalogCallback) {
+      this.logger.info("Unregistering previous catalog callback");
+      this.unregisterCatalogCallback();
+    }
+    this.unregisterCatalogCallback = () => {
+      if (this.isDisconnecting) {
+        this.logger.debug("Skipping catalog unsubscribe during disconnect");
+        return;
+      }
+      this.logger.info(
+        `Unsubscribing from catalog track with alias ${sub.trackAlias}`,
+      );
+      this.client?.unsubscribeTrack(sub.trackAlias).catch((err) => {
+        this.logger.error(`Failed to unsubscribe from catalog: ${err}`);
+      });
+    };
+
+    if (!sub.largest) {
+      // Without a largest location a joining FETCH is impossible
+      // (the publisher would reject it with INVALID_RANGE). A legacy
+      // publisher replays the catalog on the subscription instead, so
+      // keep the subscription and rely on that.
+      this.logger.warn(
+        "SUBSCRIBE_OK carried no largest location; skipping joining FETCH " +
+          "and relying on the catalog subscription",
+      );
+      return;
+    }
+
+    this.logger.info(
+      `Catalog subscription established (requestId=${sub.requestId}, ` +
+        `largest group=${sub.largest.group}, object=${sub.largest.object}); ` +
+        `sending relative joining FETCH (offset 0)`,
+    );
+
+    await client.fetchJoiningRelative(sub.requestId, 0n, (obj: MOQObject) =>
+      applyCatalogObject(obj, "joining fetch"),
+    );
+
+    this.logger.info(
+      `Successfully retrieved catalog via joining FETCH in namespace: ${namespaceStr}`,
+    );
   }
 
   /**

--- a/src/transport/bufferctrlwriter.test.ts
+++ b/src/transport/bufferctrlwriter.test.ts
@@ -12,6 +12,9 @@ import {
   Unsubscribe,
   PublishNamespaceError,
   UnpublishNamespace,
+  Fetch,
+  FetchTypeStandalone,
+  FetchTypeRelativeJoining,
 } from "./control";
 import { Version } from "./setup";
 import { KeyValuePair } from "./stream";
@@ -578,6 +581,113 @@ describe("BufferCtrlWriter", () => {
       // Verify the buffer was reset and now contains the Subscribe message
       expect(bytes2[0]).toBe(0x03); // Subscribe type
       expect(bytes2.length).not.toBe(bytes1.length);
+    });
+  });
+
+  describe("Fetch message", () => {
+    it("should marshal a relative joining Fetch without namespace/track/range", () => {
+      const msg: Fetch = {
+        kind: Msg.Fetch,
+        requestId: 4n,
+        subscriberPriority: 0,
+        groupOrder: 0,
+        fetchType: FetchTypeRelativeJoining,
+        joiningRequestId: 2n,
+        joiningStart: 0n,
+        params: [],
+      };
+
+      writer.marshalFetch(msg);
+      const bytes = writer.getBytes();
+
+      // Message type (0x16 for Fetch) and 16-bit length
+      expect(bytes[0]).toBe(0x16);
+      const length = (bytes[1] << 8) | bytes[2];
+      expect(length).toBe(bytes.length - 3);
+
+      // requestId, subscriberPriority, groupOrder, fetchType,
+      // joiningRequestId, joiningStart, parameter count — and nothing else
+      expect(Array.from(bytes.slice(3))).toEqual([4, 0, 0, 0x02, 2, 0, 0]);
+    });
+
+    it("should marshal a relative joining Fetch identically on draft-16", () => {
+      const d16Writer = new BufferCtrlWriter(Version.DRAFT_16);
+      const msg: Fetch = {
+        kind: Msg.Fetch,
+        requestId: 4n,
+        subscriberPriority: 0,
+        groupOrder: 0,
+        fetchType: FetchTypeRelativeJoining,
+        joiningRequestId: 2n,
+        joiningStart: 0n,
+        params: [],
+      };
+
+      d16Writer.marshalFetch(msg);
+      const bytes = d16Writer.getBytes();
+
+      expect(bytes[0]).toBe(0x16);
+      expect(Array.from(bytes.slice(3))).toEqual([4, 0, 0, 0x02, 2, 0, 0]);
+    });
+
+    it("should marshal a standalone Fetch with namespace, track and range", () => {
+      const msg: Fetch = {
+        kind: Msg.Fetch,
+        requestId: 6n,
+        subscriberPriority: 0,
+        groupOrder: 0,
+        fetchType: FetchTypeStandalone,
+        namespace: ["ns"],
+        trackName: "catalog",
+        startGroup: 0n,
+        startObject: 0n,
+        endGroup: 0n,
+        endObject: 0n,
+        params: [],
+      };
+
+      writer.marshalFetch(msg);
+      const bytes = writer.getBytes();
+
+      expect(bytes[0]).toBe(0x16);
+      expect(Array.from(bytes.slice(3))).toEqual([
+        6, // requestId
+        0, // subscriberPriority
+        0, // groupOrder
+        0x01, // fetchType standalone
+        1, // namespace tuple count
+        2, // "ns" length
+        0x6e,
+        0x73,
+        7, // "catalog" length
+        0x63,
+        0x61,
+        0x74,
+        0x61,
+        0x6c,
+        0x6f,
+        0x67,
+        0, // startGroup
+        0, // startObject
+        0, // endGroup
+        0, // endObject
+        0, // parameter count
+      ]);
+    });
+
+    it("should reject a joining Fetch without joiningRequestId", () => {
+      const msg: Fetch = {
+        kind: Msg.Fetch,
+        requestId: 8n,
+        subscriberPriority: 0,
+        groupOrder: 0,
+        fetchType: FetchTypeRelativeJoining,
+        params: [],
+      };
+
+      expect(() => writer.marshalFetch(msg)).toThrow(
+        "Missing joiningRequestId for joining fetch",
+      );
     });
   });
 });

--- a/src/transport/bufferctrlwriter.ts
+++ b/src/transport/bufferctrlwriter.ts
@@ -6,6 +6,7 @@ import {
   PublishDone,
   Unsubscribe,
   Fetch,
+  FetchTypeStandalone,
   PublishNamespace,
   PublishNamespaceOk,
   PublishNamespaceError,
@@ -574,7 +575,10 @@ export class BufferCtrlWriter {
   }
 
   /**
-   * Marshals a Fetch message to the buffer (standalone fetch type)
+   * Marshals a Fetch message to the buffer (standalone or joining fetch).
+   * The layout is identical in draft-14 and draft-16 (§9.16): a standalone
+   * fetch carries namespace/track/range inline; a joining fetch carries
+   * only the joining request ID and joining start.
    */
   public marshalFetch(msg: Fetch): BufferCtrlWriter {
     this.marshalWithLength(Id.Fetch, () => {
@@ -582,13 +586,23 @@ export class BufferCtrlWriter {
       this.writeUint8(msg.subscriberPriority);
       this.writeUint8(msg.groupOrder);
       this.writeVarInt62(BigInt(msg.fetchType));
-      // Standalone fetch includes namespace, trackName, start/end
-      this.writeTuple(msg.namespace);
-      this.writeString(msg.trackName);
-      this.writeVarInt62(msg.startGroup);
-      this.writeVarInt62(msg.startObject);
-      this.writeVarInt62(msg.endGroup);
-      this.writeVarInt62(msg.endObject);
+      if (msg.fetchType === FetchTypeStandalone) {
+        if (msg.namespace === undefined || msg.trackName === undefined) {
+          throw new Error("Missing namespace/trackName for standalone fetch");
+        }
+        this.writeTuple(msg.namespace);
+        this.writeString(msg.trackName);
+        this.writeVarInt62(msg.startGroup ?? 0n);
+        this.writeVarInt62(msg.startObject ?? 0n);
+        this.writeVarInt62(msg.endGroup ?? 0n);
+        this.writeVarInt62(msg.endObject ?? 0n);
+      } else {
+        if (msg.joiningRequestId === undefined) {
+          throw new Error("Missing joiningRequestId for joining fetch");
+        }
+        this.writeVarInt62(msg.joiningRequestId);
+        this.writeVarInt62(msg.joiningStart ?? 0n);
+      }
       this.writeKeyValuePairs(msg.params);
     });
     return this;

--- a/src/transport/client.ts
+++ b/src/transport/client.ts
@@ -10,7 +10,12 @@ import {
 } from "./control";
 import * as Setup from "./setup";
 import * as Stream from "./stream";
-import { TracksManager, ObjectCallback } from "./tracks";
+import {
+  TracksManager,
+  ObjectCallback,
+  SubscribeOptions,
+  SubscriptionInfo,
+} from "./tracks";
 import {
   Version,
   isDraft16,
@@ -508,6 +513,55 @@ export class Client {
 
     this.logger.info(`Client subscribing to track ${namespace}:${trackName}`);
     return this.#tracksManager.subscribeTrack(namespace, trackName, callback);
+  }
+
+  /**
+   * Subscribe to a track and return the subscription's request ID and the
+   * largest location from SUBSCRIBE_OK, as needed for a joining FETCH
+   * @param options Filter type and joining-fetch dedup behavior
+   */
+  async subscribeTrackWithInfo(
+    namespace: string,
+    trackName: string,
+    callback: ObjectCallback,
+    options?: SubscribeOptions,
+  ): Promise<SubscriptionInfo> {
+    if (!this.#tracksManager) {
+      throw new Error("Cannot subscribe: Tracks manager not initialized");
+    }
+
+    this.logger.info(`Client subscribing to track ${namespace}:${trackName}`);
+    return this.#tracksManager.subscribeTrackWithInfo(
+      namespace,
+      trackName,
+      callback,
+      options,
+    );
+  }
+
+  /**
+   * Send a Relative Joining FETCH tied to an existing subscription
+   * @param joiningRequestId The request ID of the subscription to join
+   * @param joiningStart Group offset back from the largest group (0 = current group)
+   * @param callback The callback for objects delivered on the FETCH stream
+   */
+  async fetchJoiningRelative(
+    joiningRequestId: bigint,
+    joiningStart: bigint,
+    callback: ObjectCallback,
+  ): Promise<void> {
+    if (!this.#tracksManager) {
+      throw new Error("Cannot fetch: Tracks manager not initialized");
+    }
+
+    this.logger.info(
+      `Client sending joining FETCH for subscription ${joiningRequestId}`,
+    );
+    return this.#tracksManager.fetchJoiningRelative(
+      joiningRequestId,
+      joiningStart,
+      callback,
+    );
   }
 
   /**

--- a/src/transport/control.ts
+++ b/src/transport/control.ts
@@ -157,6 +157,8 @@ export interface Unsubscribe {
 }
 
 export const FetchTypeStandalone = 0x01;
+export const FetchTypeRelativeJoining = 0x02;
+export const FetchTypeAbsoluteJoining = 0x03;
 
 export interface Fetch {
   kind: Msg.Fetch;
@@ -164,12 +166,16 @@ export interface Fetch {
   subscriberPriority: number;
   groupOrder: number;
   fetchType: number;
-  namespace: string[];
-  trackName: string;
-  startGroup: bigint;
-  startObject: bigint;
-  endGroup: bigint;
-  endObject: bigint;
+  // Standalone fetch (0x01) fields
+  namespace?: string[];
+  trackName?: string;
+  startGroup?: bigint;
+  startObject?: bigint;
+  endGroup?: bigint;
+  endObject?: bigint;
+  // Joining fetch (0x02 relative / 0x03 absolute) fields
+  joiningRequestId?: bigint;
+  joiningStart?: bigint;
   params: KeyValuePair[];
 }
 

--- a/src/transport/tracks.ts
+++ b/src/transport/tracks.ts
@@ -10,6 +10,7 @@ import {
   Fetch,
   FetchError,
   FetchTypeStandalone,
+  FetchTypeRelativeJoining,
   FilterType,
   GroupOrder,
   Message,
@@ -50,6 +51,31 @@ export interface MOQObject {
 
 // Callback for receiving objects
 export type ObjectCallback = (obj: MOQObject) => void;
+
+// Options for subscribeTrackWithInfo
+export interface SubscribeOptions {
+  // Subscription filter type; defaults to NextGroupStart (legacy behavior).
+  filterType?: FilterType;
+  // Drop objects at or before the SUBSCRIBE_OK largest location before they
+  // reach the callback. Used with a joining FETCH, which already covers that
+  // range, so the combined delivery is contiguous and non-overlapping.
+  skipObjectsUpToLargest?: boolean;
+}
+
+// Result of subscribeTrackWithInfo
+export interface SubscriptionInfo {
+  trackAlias: bigint;
+  requestId: bigint;
+  largest?: Location;
+}
+
+/** Reports whether location a lies strictly after b in (group, object) order */
+function afterLocation(a: Location, b: Location): boolean {
+  if (a.group !== b.group) {
+    return a.group > b.group;
+  }
+  return a.object > b.object;
+}
 
 // Tracks manager to handle incoming data streams
 export class TracksManager {
@@ -715,11 +741,107 @@ export class TracksManager {
     await fetchPromise;
   }
 
+  /**
+   * Send a Relative Joining FETCH (draft-14/16 §9.16.2) tied to an existing
+   * subscription. The publisher derives namespace, track and range from the
+   * subscription identified by joiningRequestId: with joiningStart = 0 the
+   * FETCH returns the current group from object 0 up to and including the
+   * subscription's largest location.
+   * Returns a promise that resolves when the FETCH_OK is received.
+   */
+  public async fetchJoiningRelative(
+    joiningRequestId: bigint,
+    joiningStart: bigint,
+    callback: ObjectCallback,
+  ): Promise<void> {
+    this.logger.info(
+      `Joining FETCH for subscription requestId=${joiningRequestId}, joiningStart=${joiningStart}`,
+    );
+
+    if (!this.controlStream) {
+      throw new Error("Cannot fetch: Control stream not set");
+    }
+    if (!this.client) {
+      throw new Error("Cannot fetch: Client not set");
+    }
+
+    const requestId = this.getNextRequestId();
+
+    const fetchMsg: Fetch = {
+      kind: Msg.Fetch,
+      requestId,
+      subscriberPriority: 0,
+      groupOrder: 0, // Publisher order
+      fetchType: FetchTypeRelativeJoining,
+      joiningRequestId,
+      joiningStart,
+      params: [],
+    };
+
+    // Register callback for fetch data before sending the message
+    this.fetchCallbacks.set(requestId, callback);
+
+    const client = this.client;
+
+    const fetchPromise = new Promise<void>((resolve, reject) => {
+      const unregisterOk = client.registerMessageHandler(
+        Msg.FetchOk,
+        requestId,
+        () => {
+          this.logger.info(
+            `Received FetchOk for joining fetch, requestId=${requestId}`,
+          );
+          unregisterErr();
+          resolve();
+        },
+      );
+
+      const unregisterErr = client.registerMessageHandler(
+        Msg.FetchError,
+        requestId,
+        (response: Message) => {
+          const fetchError = response as FetchError;
+          this.logger.error(
+            `Joining fetch error (requestId=${requestId}): ${fetchError.reason}`,
+          );
+          unregisterOk();
+          this.fetchCallbacks.delete(requestId);
+          reject(new Error(`Fetch error: ${fetchError.reason}`));
+        },
+      );
+    });
+
+    this.logger.info(
+      `Sending joining FETCH with requestId ${requestId} joining subscription ${joiningRequestId}`,
+    );
+    await this.controlStream.send(fetchMsg);
+    await fetchPromise;
+  }
+
   public async subscribeTrack(
     namespace: string,
     trackName: string,
     callback: ObjectCallback,
   ): Promise<bigint> {
+    const info = await this.subscribeTrackWithInfo(
+      namespace,
+      trackName,
+      callback,
+    );
+    return info.trackAlias;
+  }
+
+  /**
+   * Subscribe to a track and return the subscription's request ID and the
+   * largest location reported in SUBSCRIBE_OK (needed for a joining FETCH),
+   * in addition to the track alias.
+   */
+  public async subscribeTrackWithInfo(
+    namespace: string,
+    trackName: string,
+    callback: ObjectCallback,
+    options?: SubscribeOptions,
+  ): Promise<SubscriptionInfo> {
     this.logger.info(`Subscribing to track ${namespace}:${trackName}`);
 
     if (!this.controlStream) {
@@ -742,7 +864,7 @@ export class TracksManager {
       subscriber_priority: 0,
       group_order: GroupOrder.Publisher,
       forward: true,
-      filterType: FilterType.NextGroupStart,
+      filterType: options?.filterType ?? FilterType.NextGroupStart,
       params: [] as KeyValuePair[],
     };
 
@@ -755,7 +877,7 @@ export class TracksManager {
       const client = this.client;
 
       // Set up Promise for SUBSCRIBE_OK response
-      const subscribePromise = new Promise<bigint>((resolve, reject) => {
+      const subscribePromise = new Promise<SubscribeOk>((resolve, reject) => {
         // Register handler for SUBSCRIBE_OK
         const unregisterOk = client.registerMessageHandler(
           Msg.SubscribeOk,
@@ -765,7 +887,7 @@ export class TracksManager {
             this.logger.info(
               `Received SubscribeOk for ${namespace}:${trackName} with requestId ${requestId}, trackAlias ${subscribeOk.trackAlias}`,
             );
-            resolve(subscribeOk.trackAlias);
+            resolve(subscribeOk);
           },
         );
 
@@ -798,7 +920,25 @@ export class TracksManager {
       await this.controlStream.send(subscribeMsg);
 
       // Wait for SUBSCRIBE_OK (with timeout)
-      const trackAlias = await subscribePromise;
+      const subscribeOk = await subscribePromise;
+      const trackAlias = subscribeOk.trackAlias;
+      const largest = subscribeOk.largest;
+
+      // When a joining FETCH covers everything up to the largest location,
+      // drop those objects here so the callback sees each object exactly once.
+      let deliverCallback = callback;
+      if (options?.skipObjectsUpToLargest && largest) {
+        deliverCallback = (obj: MOQObject) => {
+          if (!afterLocation(obj.location, largest)) {
+            this.logger.debug(
+              `Skipping object (group=${obj.location.group}, obj=${obj.location.object}) ` +
+                `at or before largest (group=${largest.group}, obj=${largest.object})`,
+            );
+            return;
+          }
+          callback(obj);
+        };
+      }
 
       // Register the callback
       // Stream handler will immediately find it and deliver any buffered objects
@@ -808,13 +948,13 @@ export class TracksManager {
         requestId,
         trackAlias,
       );
-      this.trackRegistry.registerCallback(trackAlias, callback);
+      this.trackRegistry.registerCallback(trackAlias, deliverCallback);
 
       this.logger.info(
         `Successfully subscribed to ${namespace}:${trackName} with trackAlias ${trackAlias}`,
       );
 
-      return trackAlias;
+      return { trackAlias, requestId, largest };
     } catch (error) {
       this.logger.error(
         `Error subscribing to track ${namespace}:${trackName}:`,


### PR DESCRIPTION
## Summary

Retrieve the catalog via a **SUBSCRIBE plus a relative joining FETCH**, so the player fetches the catalog group aligned to the live edge and starts playback from a consistent point.

## Changes

- `transport/tracks.ts`, `transport/client.ts`, `transport/control.ts`: issue and resolve the joining FETCH for the catalog track.
- `transport/bufferctrlwriter.ts`: handling for the joining-FETCH flow (unit tests added).
- `player.ts` / `index.html`: wire the catalog retrieval into player startup.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build` all pass.
- `npm test`: 145 tests pass (12 suites).
- Interoperates with `mlmpub`'s joining-FETCH catalog delivery (verified server-side on draft 14 and draft 16).
