### PR TITLE
Release v0.12.0: LOCMAF v0.3 release cut + Safari MSE latency stabilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Catalog retrieval now uses a relative joining FETCH, aligned to the live edge.
+## [0.12.0] - 2026-07-06
+
+LOCMAF packaging advanced to v0.3, and catalog retrieval now uses a relative
+joining FETCH aligned to the live edge.
 
 ### Added
 
@@ -21,9 +24,32 @@ Catalog retrieval now uses a relative joining FETCH, aligned to the live edge.
 
 ### Changed
 
+- LOCMAF packaging advanced to **v0.3**. `LOCMAF_SUPPORTED_VERSIONS` is now
+  `{"0.3"}` and an absent `locmafVersion` is assumed to be v0.3. The decoder
+  mirrors the Go reference module
+  [`github.com/Eyevinn/locmaf`](https://github.com/Eyevinn/locmaf) (normative
+  spec: the IETF draft `draft-einarsson-moq-locmaf`):
+  - `src/locmaf/vi64.ts` — MOQT (draft-18 §1.4.1) leading-ones varints and
+    zigzag, replacing the RFC 9000 varint the v0.2 wire used.
+  - `src/locmaf/v03/` — element-sequence decoding (genBox / full header /
+    delta header / rawBoxes) under the even-scalar / odd-length-prefixed parity
+    rule, full 32-bit sample flags, derived-only delta BMDT, and a hand-rolled
+    canonical CMAF writer (`mfhd`/`tfhd`/`tfdt`/`trun` + regenerated
+    `saiz`/`saio`/`senc` for protected tracks) that is byte-exact against the
+    reference golden vectors.
+  - `src/locmaf/locmaf.ts` keeps its four-export surface, so `player.ts` is
+    unchanged; the version gate now requires `locmafVersion` "0.3".
+  - `src/locmaf/v03/vectors.test.ts` runs a golden-vector conformance ladder
+    against the sibling `Eyevinn/locmaf` `testdata/vectors` corpus; it skips
+    when the corpus is absent.
 - `joiningFetchCatalog` is now the default catalog-retrieval path in the player.
   It falls back to a plain subscription when SUBSCRIBE_OK carries no largest
   location (legacy publisher).
+
+### Removed
+
+- The v0.2 LOCMAF decoder (`src/locmaf/v02/`) and its `senc` writer. LOCMAF v0.2
+  remains reachable at the `v0.11.0` tag.
 
 ## [0.11.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,32 @@ joining FETCH aligned to the live edge.
 - `joiningFetchCatalog` is now the default catalog-retrieval path in the player.
   It falls back to a plain subscription when SUBSCRIBE_OK carries no largest
   location (legacy publisher).
+- The MSE latency controller now runs on a fixed 250 ms cadence instead of the
+  media element's `timeupdate` event, which fires too sparsely on Safari (~1/s)
+  to control latency responsively. It also gains a steady-state resync seek that
+  jumps the playhead toward the live edge on large latency excursions rather than
+  waiting for the gentle rate nudge to recover.
+- Safari gets more latency catch-up authority (ceiling 1.12×, higher gain)
+  because its MSE clock runs ~1.5-2 % slow; Chrome is unchanged.
+- Buffer/latency defaults can be tuned per **render engine × browser** via a
+  `bufferProfiles` table in `config.json` (a `base` plus ordered `rules` matched
+  on optional `engine`/`browser`). With the fixed-cadence controller, 200 ms /
+  300 ms is stable across all engines and browsers, so the built-in default
+  applies it everywhere and ships no per-combination rule; add a rule (in
+  `config.json` or the built-in table) to raise a specific combination — e.g.
+  Safari + MSE to 500 ms / 600 ms. The resolved profile is applied when the
+  engine is determined at Start and pushed back to the buffer input fields;
+  editing those fields manually overrides the profile for the session.
+- Playback now starts once the **minimal buffer** is filled, not the full
+  target latency. Gating start on target latency could exceed what a
+  small-object track's buffer holds — an ~21 ms-per-object AAC track capped at
+  30 segments (~640 ms) could never reach a higher target, so playback
+  deadlocked and never started. The segment-buffer cap is also raised from 30 to
+  64 objects (~2.5 s video / ~1.3 s audio) so higher targets have room.
+- A CMAF video paired with a LOCMAF audio (or vice versa) is now allowed —
+  both are the same MSE-CMAF engine family (LOCMAF is reconstructed to CMAF), so
+  they play through the MSE pipeline together. Only mixes that span engine
+  families (e.g. LOC + CMAF) are still rejected.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,73 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0] - 2026-07-06
 
-LOCMAF packaging advanced to v0.3, and catalog retrieval now uses a relative
-joining FETCH aligned to the live edge.
+See the README for details on the catalog, packaging, and buffer control.
 
 ### Added
 
-- "Catalog retrieval" mode selector (joining | subscribe | fetch), replacing the
-  old FETCH checkbox. The default retrieves the catalog via SUBSCRIBE plus a
-  relative joining FETCH (offset 0), so the player starts from the latest catalog
-  group aligned to the live edge.
-- `subscribeTrackWithInfo` (exposes the request ID and largest location from
-  SUBSCRIBE_OK) and `fetchJoiningRelative` on the transport layer; FETCH message
-  types `0x02`/`0x03` in the wire encoder.
+- Catalog-retrieval selector (joining | subscribe | fetch); joining FETCH default.
+- Tunable per-engine/browser buffer profiles in `config.json` (`bufferProfiles`).
 
 ### Changed
 
-- LOCMAF packaging advanced to **v0.3**. `LOCMAF_SUPPORTED_VERSIONS` is now
-  `{"0.3"}` and an absent `locmafVersion` is assumed to be v0.3. The decoder
-  mirrors the Go reference module
-  [`github.com/Eyevinn/locmaf`](https://github.com/Eyevinn/locmaf) (normative
-  spec: the IETF draft `draft-einarsson-moq-locmaf`):
-  - `src/locmaf/vi64.ts` — MOQT (draft-18 §1.4.1) leading-ones varints and
-    zigzag, replacing the RFC 9000 varint the v0.2 wire used.
-  - `src/locmaf/v03/` — element-sequence decoding (genBox / full header /
-    delta header / rawBoxes) under the even-scalar / odd-length-prefixed parity
-    rule, full 32-bit sample flags, derived-only delta BMDT, and a hand-rolled
-    canonical CMAF writer (`mfhd`/`tfhd`/`tfdt`/`trun` + regenerated
-    `saiz`/`saio`/`senc` for protected tracks) that is byte-exact against the
-    reference golden vectors.
-  - `src/locmaf/locmaf.ts` keeps its four-export surface, so `player.ts` is
-    unchanged; the version gate now requires `locmafVersion` "0.3".
-  - `src/locmaf/v03/vectors.test.ts` runs a golden-vector conformance ladder
-    against the sibling `Eyevinn/locmaf` `testdata/vectors` corpus; it skips
-    when the corpus is absent.
-- `joiningFetchCatalog` is now the default catalog-retrieval path in the player.
-  It falls back to a plain subscription when SUBSCRIBE_OK carries no largest
-  location (legacy publisher).
-- The MSE latency controller now runs on a fixed 250 ms cadence instead of the
-  media element's `timeupdate` event, which fires too sparsely on Safari (~1/s)
-  to control latency responsively. It also gains a steady-state resync seek that
-  jumps the playhead toward the live edge on large latency excursions rather than
-  waiting for the gentle rate nudge to recover.
-- Safari gets more latency catch-up authority (ceiling 1.12×, higher gain)
-  because its MSE clock runs ~1.5-2 % slow; Chrome is unchanged.
-- Buffer/latency defaults can be tuned per **render engine × browser** via a
-  `bufferProfiles` table in `config.json` (a `base` plus ordered `rules` matched
-  on optional `engine`/`browser`). With the fixed-cadence controller, 200 ms /
-  300 ms is stable across all engines and browsers, so the built-in default
-  applies it everywhere and ships no per-combination rule; add a rule (in
-  `config.json` or the built-in table) to raise a specific combination — e.g.
-  Safari + MSE to 500 ms / 600 ms. The resolved profile is applied when the
-  engine is determined at Start and pushed back to the buffer input fields;
-  editing those fields manually overrides the profile for the session.
-- Playback now starts once the **minimal buffer** is filled, not the full
-  target latency. Gating start on target latency could exceed what a
-  small-object track's buffer holds — an ~21 ms-per-object AAC track capped at
-  30 segments (~640 ms) could never reach a higher target, so playback
-  deadlocked and never started. The segment-buffer cap is also raised from 30 to
-  64 objects (~2.5 s video / ~1.3 s audio) so higher targets have room.
-- A CMAF video paired with a LOCMAF audio (or vice versa) is now allowed —
-  both are the same MSE-CMAF engine family (LOCMAF is reconstructed to CMAF), so
-  they play through the MSE pipeline together. Only mixes that span engine
-  families (e.g. LOC + CMAF) are still rejected.
+- LOCMAF packaging updated to **v0.3** via the `Eyevinn/locmaf` module.
+- Reworked MSE latency control (fixed-cadence loop, live-edge resync); 200/300 ms
+  is stable across engines and browsers.
+- A CMAF video and a LOCMAF audio may now be selected together.
+- Playback starts on the minimal buffer; segment-buffer cap raised 30 → 64.
+- Catalog references updated to MSF/CMSF draft-01.
 
 ### Removed
 
-- The v0.2 LOCMAF decoder (`src/locmaf/v02/`) and its `senc` writer. LOCMAF v0.2
-  remains reachable at the `v0.11.0` tag.
+- The in-tree LOCMAF v0.2 decoder (available at the `v0.11.0` tag).
 
 ## [0.11.0] - 2026-06-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ WARP Player is a browser-based TypeScript implementation of a media player,
 using the MOQ Transport protocol via WebTransport. It supports MOQ Transport
 draft-14 and draft-16 (negotiated through WebTransport ALPN, can be forced
 from the UI) and uses the MSF/CMSF catalog format
-(draft-ietf-moq-msf-01 / draft-ietf-moq-cmsf-00) to discover media tracks.
+(draft-ietf-moq-msf-01 / draft-ietf-moq-cmsf-01) to discover media tracks.
 
 Playback runs through one of two interchangeable render pipelines selected
 per session:
@@ -128,7 +128,7 @@ The transport used is MOQ Transport, draft-14 or draft-16 (auto-negotiated
 via WebTransport ALPN strings `moq-00` and `moqt-16`).
 
 For the catalog, the specification used is MSF (draft-ietf-moq-msf-01)
-with CMSF (draft-ietf-moq-cmsf-00) for CMAF packaging. LOC packaging
+with CMSF (draft-ietf-moq-cmsf-01) for CMAF packaging. LOC packaging
 follows draft-mzanaty-moq-loc.
 
 The codebase is organized into several key modules:
@@ -269,7 +269,7 @@ The codebase is organized into several key modules:
 
 ## Technical Notes
 
-1. The implementation supports MOQ Transport draft-14 and draft-16, with the MSF/CMSF catalog format (draft-ietf-moq-msf-01 / draft-ietf-moq-cmsf-00) and LOC packaging (draft-mzanaty-moq-loc).
+1. The implementation supports MOQ Transport draft-14 and draft-16, with the MSF/CMSF catalog format (draft-ietf-moq-msf-01 / draft-ietf-moq-cmsf-01) and LOC packaging (draft-mzanaty-moq-loc).
 2. WebTransport is available in Chrome 87+, Edge 87+, Firefox, and Safari 26.4+. The WebCodecs render engine additionally requires WebCodecs (Chrome 94+, Edge 94+, Safari 16.4+, Firefox 130+).
 3. The client uses MSB (Most Significant Byte) 16-bit length fields for control messages.
 4. Media data is delivered either as CMAF (ISO BMFF) — including the LOCMAF packaging, which is expanded back into CMAF chunks before MSE append — for the MSE pipeline, or as raw codec payloads (length-prefixed AVC/HEVC NALUs, raw AAC access units, raw Opus packets) for the WebCodecs pipeline.
@@ -287,7 +287,7 @@ The codebase is organized into several key modules:
 ### MSF/CMSF Catalog Format
 
 - Catalog parsing follows draft-ietf-moq-msf-01 with CMSF
-  (draft-ietf-moq-cmsf-00) for CMAF packaging
+  (draft-ietf-moq-cmsf-01) for CMAF packaging
 - Tracks identify their payload format via the `packaging` field
   (`"cmaf"`, `"locmaf"`, `"loc"`, ...). LOCMAF tracks additionally
   advertise `locmafVersion`, which the receiver gates on.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,43 +1,64 @@
 # Configuration
 
-The WARP Player can be configured after build by editing the `config.json` file in the distribution directory.
+The WARP Player can be configured after build by editing the `config.json` file
+in the distribution directory (`dist/config.json`) — no rebuild required. The
+same file lives at `src/config.json` for the built-in defaults.
 
 ## Configuration File
-
-The `config.json` file supports the following options:
 
 ```json
 {
   "defaultServerUrl": "https://moqlivemock.demo.osaas.io/moq",
-  "minimalBuffer": 200,
-  "targetLatency": 300
+  "fingerprintUrl": "",
+  "bufferProfiles": {
+    "base": { "minimalBuffer": 200, "targetLatency": 300 },
+    "rules": []
+  }
 }
 ```
 
 ### Options
 
-- **defaultServerUrl**: The default MOQ server URL that appears in the connection input field
-- **minimalBuffer**: The minimal buffer threshold in milliseconds (default: 200ms). Below this threshold, playback quality may suffer
-- **targetLatency**: The target end-to-end latency in milliseconds (default: 300ms). Must be greater than minimalBuffer
+- **defaultServerUrl**: The default MOQ server URL shown in the connection input field.
+- **fingerprintUrl**: Optional URL for fetching a self-signed certificate
+  fingerprint (see [FINGERPRINT.md](FINGERPRINT.md)). Leave empty to disable.
+- **bufferProfiles**: Buffer/latency defaults, resolved per render engine and
+  browser (see below). Omit the whole object to use the built-in default.
 
-## Usage
+## Buffer profiles
 
-1. After building the application (`npm run build`), locate the `config.json` file in the `dist` directory
-2. Edit the file with your preferred settings
-3. The application will load these settings on startup
-
-If the configuration file is not found or cannot be loaded, the application will use built-in defaults.
-
-## Example
-
-To change the default server and adjust buffer parameters for lower latency:
+Buffer/latency targets depend on the render engine actually chosen for a session
+(MSE for CMAF/LOCMAF, WebCodecs for LOC) and the browser, because their latency
+floors differ. `bufferProfiles` is a `base` plus an ordered list of `rules`:
 
 ```json
-{
-  "defaultServerUrl": "https://your-server.example.com:443/moq",
-  "minimalBuffer": 150,
-  "targetLatency": 250
+"bufferProfiles": {
+  "base": { "minimalBuffer": 200, "targetLatency": 300 },
+  "rules": [
+    { "browser": "safari", "engine": "mse", "minimalBuffer": 500, "targetLatency": 600 }
+  ]
 }
 ```
 
-Note: Setting targetLatency too low may result in more frequent buffer underruns. The targetLatency must always be greater than minimalBuffer.
+- **minimalBuffer** (ms): buffered media required before playback starts; the
+  control loop keeps the buffer at or above this. **targetLatency** must be
+  greater than it.
+- **targetLatency** (ms): the end-to-end latency the control loop steers toward
+  after playback starts.
+- Resolution: start from `base`, then apply every matching rule in order (later
+  wins). A rule matches when its `engine` (`mse` | `webcodecs`) and `browser`
+  (`safari` | `other`) equal the session's — omit either field to match any.
+
+The resolved profile is applied when the engine is determined at Start and shown
+in the buffer input fields. Editing those fields in the UI overrides the profile
+for that session.
+
+The built-in default is `base` 200/300 ms with no rules — stable across all
+engines and browsers. Add a rule only to tune a specific combination (e.g. raise
+Safari + MSE if needed). If `config.json` is missing or unreadable, the built-in
+default is used.
+
+## Usage
+
+1. After `npm run build`, edit `dist/config.json`.
+2. Reload the app; settings load on startup.

--- a/README.md
+++ b/README.md
@@ -27,15 +27,46 @@ This project implements a media player that:
 1. Establishes a WebTransport connection to a MOQ server
 2. Negotiates MOQ Transport draft-14 or draft-16 with the server
 3. Subscribes to and parses MSF/CMSF catalogs for available media
-   ([draft-ietf-moq-msf-00], [draft-ietf-moq-cmsf-00])
+   ([draft-ietf-moq-msf-01], [draft-ietf-moq-cmsf-01])
 4. Subscribes to selected media tracks through the MOQ transport protocol
 5. Renders media through one of two interchangeable pipelines:
-   - **MSE** for CMAF (`packaging: "cmaf" or "locmaf"`), with optional EME for protected content
+   - **MSE** for CMAF (`packaging: "cmaf"`) and LOCMAF
+     (`packaging: "locmaf"`, [draft-einarsson-moq-locmaf]), with optional EME
+     for protected content
    - **WebCodecs** for LOC (`packaging: "loc"`, [draft-mzanaty-moq-loc]), clear content only
 6. Provides adaptive buffer management for a smooth playback experience
 7. This player is intended to work towards the [moqlivemock][moqlivemock]
    publisher and uses the CMSF ContentProtection signaling
    ([moq-wg/cmsf](https://github.com/moq-wg/cmsf)) for DRM
+
+## Catalog and Packaging
+
+Media is discovered through an MSF/CMSF catalog and delivered in one of three
+packagings:
+
+- **CMAF** (`packaging: "cmaf"`) — standard fragmented MP4, played through MSE.
+- **LOCMAF** (`packaging: "locmaf"`, [draft-einarsson-moq-locmaf]) — a compact
+  CMAF packaging (wire version 0.3) that trims per-object overhead on the wire.
+  Objects are reconstructed into standard CMAF chunks before MSE append, so
+  LOCMAF and CMAF share the same init data and render path. Decoding mirrors the
+  reusable [`Eyevinn/locmaf`](https://github.com/Eyevinn/locmaf) reference
+  implementation; only LOCMAF packaging version `0.3` is accepted.
+- **LOC** (`packaging: "loc"`, [draft-mzanaty-moq-loc]) — raw codec frames,
+  decoded directly by the WebCodecs pipeline (clear content only).
+
+Catalogs follow **MSF [draft-ietf-moq-msf-01]** with **CMSF
+[draft-ietf-moq-cmsf-01]** for CMAF packaging. The catalog `version` string must
+be `"draft-01"`. Initialization data lives in a catalog-level `initDataList`,
+and each track references an entry by `initRef` — so a CMAF track and its LOCMAF
+counterpart share one init-data entry. Content protection (Widevine, PlayReady,
+FairPlay, and ClearKey) is signaled through the CMSF ContentProtection catalog
+fields; draft-ietf-moq-cmsf-01 is the revision that carries the `initData` and
+DRM/ContentProtection catalog fields this player relies on.
+
+Catalog documents can be checked against the draft-01 schema with the
+[msf-catalog-validator](https://github.com/Eyevinn/msf-catalog-validator), which
+validates MSF/CMSF draft-01 catalogs including the `locmaf` packaging and
+`locmafVersion`.
 
 ## Requirements
 
@@ -220,7 +251,8 @@ See [CONFIG.md](CONFIG.md) for detailed configuration options.
 - MOQ client implementation supporting draft-14 and draft-16
   (auto-negotiated via WebTransport ALPN; can be forced from the UI)
 - MSF/CMSF catalog support for discovering available media streams
-  ([draft-ietf-moq-msf-00], [draft-ietf-moq-cmsf-00])
+  ([draft-ietf-moq-msf-01], [draft-ietf-moq-cmsf-01])
+- CMAF, LOCMAF (compact CMAF, [draft-einarsson-moq-locmaf]), and LOC packaging
 - Catalog retrieval via SUBSCRIBE plus a relative joining FETCH by default, so
   playback starts from the latest catalog group aligned to the live edge; a
   "Catalog retrieval" selector (joining | subscribe | fetch) is exposed in the
@@ -264,7 +296,8 @@ catalog and the user's "Render engine" choice in the UI:
 
 The `Auto` engine choice resolves at subscribe time:
 
-- All-CMAF tracks → MSE
+- CMAF and/or LOCMAF tracks → MSE (they share the MSE-CMAF family, so a CMAF
+  video and a LOCMAF audio may be selected together)
 - All-LOC tracks (clear) → WebCodecs
 - Any encrypted track → MSE (WebCodecs cannot play encrypted content
   because production browsers do not expose Encrypted WebCodecs)
@@ -287,27 +320,31 @@ The player uses a sophisticated two-parameter control system to maintain optimal
 ### Parameters
 
 1. **Minimal Buffer** (default: 200ms)
-   - The safety threshold below which playback quality may suffer
-   - Prevents buffer underruns and playback stalls
+   - The safety threshold below which playback quality may suffer, and the
+     buffer level required before playback starts
 2. **Target Latency** (default: 300ms)
-   - The desired end-to-end latency for live streaming
+   - The desired end-to-end latency the controller steers toward once playing
    - Must be greater than the minimal buffer value
+
+Both parameters are resolved per **render engine × browser** from the
+`bufferProfiles` table in `config.json` (default 200/300 ms everywhere) and can
+be overridden live from the UI inputs — see [CONFIG.md](CONFIG.md).
 
 ### Control Logic
 
-The playback rate is adjusted based on a priority system:
+A fixed-cadence (250ms) control loop adjusts the playback rate by priority; the
+250ms timer keeps the loop responsive regardless of how often the browser fires
+`timeupdate` (Safari fires it sparsely). Playback starts once the minimal buffer
+is filled, then:
 
 1. **Priority 1 - Buffer Safety**: If buffer level < minimal buffer
-   - Reduce playback rate to 0.97x to build up buffer
-   - This takes precedence over latency control
-
+   - Reduce playback rate to build up buffer; takes precedence over latency
 2. **Priority 2 - Latency Control**: If buffer level ≥ minimal buffer
-   - If latency > target: Increase playback rate (up to 1.02x) to reduce latency
-   - If latency < target: Decrease playback rate (down to 0.98x) to maintain target latency
-   - This prevents drifting too close to the live edge
-
-3. **Normal Playback**: When within acceptable ranges
-   - Playback rate returns to 1.0x
+   - If latency > target: speed up to reduce latency (ceiling 1.02x, higher on
+     Safari whose media clock runs slightly slow). A large excursion instead
+     triggers a resync seek toward the live edge.
+   - If latency < target: slow down to hold the target and avoid the live edge
+3. **Normal Playback**: return to 1.0x when within the target range
 
 ### Visual Indicators
 
@@ -390,6 +427,7 @@ Read our blogs and articles here:
 Want to know more about Eyevinn, contact us at info@eyevinn.se!
 
 [moqlivemock]: https://github.com/Eyevinn/moqlivemock
-[draft-ietf-moq-msf-00]: https://datatracker.ietf.org/doc/html/draft-ietf-moq-msf-00
-[draft-ietf-moq-cmsf-00]: https://datatracker.ietf.org/doc/html/draft-ietf-moq-cmsf-00
+[draft-ietf-moq-msf-01]: https://datatracker.ietf.org/doc/html/draft-ietf-moq-msf-01
+[draft-ietf-moq-cmsf-01]: https://datatracker.ietf.org/doc/html/draft-ietf-moq-cmsf-01
+[draft-einarsson-moq-locmaf]: https://datatracker.ietf.org/doc/draft-einarsson-moq-locmaf/
 [draft-mzanaty-moq-loc]: https://datatracker.ietf.org/doc/html/draft-mzanaty-moq-loc

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ warp-player/
 │   │   ├── aac.ts        # AAC AudioSpecificConfig from catalog metadata
 │   │   ├── opus.ts       # Opus ID-header (OpusHead) from catalog metadata
 │   │   └── extensions.ts # LOC extension-header parsing (capture timestamps)
-|   ├── locmaf/           # LOCMAF helper functions
-│   │   ├── locmaf.ts     # Parsing of LOCMAF and reconstruction of CMAF
+│   ├── locmaf/           # LOCMAF (compact CMAF packaging) for the MSE pipeline
+│   │   ├── locmaf.ts     # Version-gating wrapper (LOCMAF v0.3 only)
+│   │   ├── vi64.ts       # MOQT (draft-18 §1.4.1) varints + zigzag
+│   │   └── v03/          # v0.3 codec: decoder + canonical CMAF reconstruction
 │   ├── pipeline/         # Pluggable render pipelines
 │   │   ├── index.ts                # IPlaybackPipeline + capability matrix
 │   │   ├── msePipeline.ts          # MSE/CMAF pipeline (with optional EME)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -4,6 +4,7 @@
  * Handles the browser UI interactions and connects to the Player component
  * for MOQ/WARP streaming and MSE playback.
  */
+import { BufferProfiles, DEFAULT_BUFFER_PROFILES } from "./bufferProfile";
 import { LoggerFactory, LogLevel } from "./logger";
 import { Player } from "./player";
 import { DraftVersion } from "./transport/client";
@@ -36,15 +37,28 @@ const logger = LoggerFactory.getInstance().getLogger("Browser");
 interface Config {
   defaultServerUrl?: string;
   fingerprintUrl?: string;
-  minimalBuffer?: number;
-  targetLatency?: number;
+  // Per-(engine × browser) buffer/latency profile table. Omit to use the
+  // built-in default (Safari+MSE 500/800ms, everything else 200/300ms).
+  bufferProfiles?: BufferProfiles;
 }
 
 let config: Config = {
   defaultServerUrl: "https://moqlivemock.demo.osaas.io/moq",
-  minimalBuffer: 200,
-  targetLatency: 300,
 };
+
+// Hand the player its buffer profile table, keep the input fields in sync with
+// whatever profile it applies at Start, and seed the current (base) values
+// without marking them as a manual override.
+function wireBufferProfile(p: Player): void {
+  p.setBufferProfiles(config.bufferProfiles ?? null);
+  p.setBufferParamsCallback((minimalBufferMs, targetLatencyMs) => {
+    minimalBufferInput.value = minimalBufferMs.toString();
+    targetLatencyInput.value = targetLatencyMs.toString();
+  });
+  const min = parseInt(minimalBufferInput.value, 10) || 200;
+  const target = parseInt(targetLatencyInput.value, 10) || 300;
+  p.setBufferParameters(min, target, /* userInitiated */ false);
+}
 
 // Load configuration from external file
 async function loadConfig(): Promise<void> {
@@ -195,12 +209,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     logger.info("Server URL loaded from config.json");
   }
 
-  if (config.minimalBuffer) {
-    minimalBufferInput.value = config.minimalBuffer.toString();
-  }
-  if (config.targetLatency) {
-    targetLatencyInput.value = config.targetLatency.toString();
-  }
+  // Seed the inputs with the profile base; the effective per-engine values are
+  // applied (and pushed back to these fields) when playback starts.
+  const baseProfile = (config.bufferProfiles ?? DEFAULT_BUFFER_PROFILES).base;
+  minimalBufferInput.value = baseProfile.minimalBuffer.toString();
+  targetLatencyInput.value = baseProfile.targetLatency.toString();
 
   // Add event listeners
   connectBtn.addEventListener("click", connect);
@@ -261,12 +274,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
-  // Set initial buffer parameters from config or defaults
-  const initialMinimalBuffer =
-    parseInt(minimalBufferInput.value) || config.minimalBuffer || 200;
-  const initialTargetLatency =
-    parseInt(targetLatencyInput.value) || config.targetLatency || 300;
-  player.setBufferParameters(initialMinimalBuffer, initialTargetLatency);
+  // Wire the per-engine buffer profile and seed the current (base) values.
+  wireBufferProfile(player);
 
   // Add event listener for minimal buffer changes
   minimalBufferInput.addEventListener("change", () => {
@@ -670,10 +679,8 @@ async function connect() {
     }
   });
 
-  // Set buffer parameters from input fields
-  const minimalBuffer = parseInt(minimalBufferInput.value) || 200;
-  const targetLatency = parseInt(targetLatencyInput.value) || 300;
-  player.setBufferParameters(minimalBuffer, targetLatency);
+  // Re-wire the buffer profile for the fresh player instance.
+  wireBufferProfile(player);
 
   // Disable connect button and enable disconnect button
   connectBtn.disabled = true;

--- a/src/buffer/mediaSegmentBuffer.ts
+++ b/src/buffer/mediaSegmentBuffer.ts
@@ -53,7 +53,11 @@ export class MediaSegmentBuffer {
 
     // Set default options and merge with provided options
     this.options = {
-      maxBufferSize: 30, // Default to 30 segments max
+      // 64 segments max: with per-frame objects (~40ms video / ~21ms audio)
+      // this holds ~2.5s of video / ~1.3s of audio, comfortably above target
+      // latencies up to ~1s. 30 was too few for a small-object audio track to
+      // reach an 800ms target, which deadlocked the playback-start gate.
+      maxBufferSize: 64,
       onSegmentReady: () => {
         // No-op by default - will be overridden if provided in options
       },

--- a/src/bufferProfile.test.ts
+++ b/src/bufferProfile.test.ts
@@ -1,0 +1,59 @@
+import {
+  BufferProfiles,
+  DEFAULT_BUFFER_PROFILES,
+  resolveBufferProfile,
+} from "./bufferProfile";
+
+describe("resolveBufferProfile (built-in default)", () => {
+  it("uses the 200/300 base for every engine/browser combination", () => {
+    const base = { minimalBuffer: 200, targetLatency: 300 };
+    expect(resolveBufferProfile("mse", "safari")).toEqual(base);
+    expect(resolveBufferProfile("webcodecs", "safari")).toEqual(base);
+    expect(resolveBufferProfile("mse", "other")).toEqual(base);
+    expect(resolveBufferProfile("webcodecs", "other")).toEqual(base);
+  });
+});
+
+describe("resolveBufferProfile (custom table)", () => {
+  it("applies later matching rules over earlier ones and over base", () => {
+    const profiles: BufferProfiles = {
+      base: { minimalBuffer: 100, targetLatency: 200 },
+      rules: [
+        { engine: "mse", minimalBuffer: 400, targetLatency: 700 },
+        { browser: "safari", engine: "mse", targetLatency: 900 },
+      ],
+    };
+    // MSE on non-Safari: only the first rule matches.
+    expect(resolveBufferProfile("mse", "other", profiles)).toEqual({
+      minimalBuffer: 400,
+      targetLatency: 700,
+    });
+    // MSE on Safari: both rules match; the second overrides targetLatency only.
+    expect(resolveBufferProfile("mse", "safari", profiles)).toEqual({
+      minimalBuffer: 400,
+      targetLatency: 900,
+    });
+    // WebCodecs: no rule matches, base wins.
+    expect(resolveBufferProfile("webcodecs", "safari", profiles)).toEqual({
+      minimalBuffer: 100,
+      targetLatency: 200,
+    });
+  });
+
+  it("falls back to base when there are no rules", () => {
+    const profiles: BufferProfiles = {
+      base: { minimalBuffer: 250, targetLatency: 450 },
+    };
+    expect(resolveBufferProfile("mse", "safari", profiles)).toEqual({
+      minimalBuffer: 250,
+      targetLatency: 450,
+    });
+  });
+
+  it("DEFAULT_BUFFER_PROFILES base is 200/300", () => {
+    expect(DEFAULT_BUFFER_PROFILES.base).toEqual({
+      minimalBuffer: 200,
+      targetLatency: 300,
+    });
+  });
+});

--- a/src/bufferProfile.ts
+++ b/src/bufferProfile.ts
@@ -1,0 +1,66 @@
+// Per-(engine × browser) buffer/latency defaults.
+//
+// The MSE pipeline and the WebCodecs pipeline have very different latency
+// floors, and Safari's MSE clock is slower and prefers more lead buffer than
+// Chrome's. Rather than a single global default, resolve the buffer target from
+// the render engine actually chosen for the session and the browser.
+//
+// The table is a `base` plus an ordered list of `rules`. Each rule optionally
+// matches an `engine` and/or a `browser`; a rule with a field omitted matches
+// any value for that field. Rules are applied in order and later matches win,
+// so list the most specific rule last. The whole table can be supplied (or
+// extended) from config.json — see DEFAULT_BUFFER_PROFILES for the built-in.
+
+import { Engine } from "./pipeline";
+
+export type BrowserKind = "safari" | "other";
+
+export interface BufferValues {
+  minimalBuffer: number;
+  targetLatency: number;
+}
+
+export interface BufferRule {
+  engine?: Engine; // "mse" | "webcodecs"; omit to match any engine
+  browser?: BrowserKind; // "safari" | "other"; omit to match any browser
+  minimalBuffer?: number;
+  targetLatency?: number;
+}
+
+export interface BufferProfiles {
+  base: BufferValues;
+  rules?: BufferRule[];
+}
+
+// Built-in default used when config.json does not supply `bufferProfiles`.
+// 200/300ms works across all engines and browsers now that the latency
+// controller samples on a fixed cadence. The rules list is the tuning hook:
+// add e.g. { browser: "safari", engine: "mse", targetLatency: 600 } here or in
+// config.json if a particular combination needs a different target.
+export const DEFAULT_BUFFER_PROFILES: BufferProfiles = {
+  base: { minimalBuffer: 200, targetLatency: 300 },
+  rules: [],
+};
+
+/** Resolve the buffer values for a given engine + browser from a profile table. */
+export function resolveBufferProfile(
+  engine: Engine,
+  browser: BrowserKind,
+  profiles: BufferProfiles = DEFAULT_BUFFER_PROFILES,
+): BufferValues {
+  let minimalBuffer = profiles.base.minimalBuffer;
+  let targetLatency = profiles.base.targetLatency;
+  for (const rule of profiles.rules ?? []) {
+    const engineMatches = rule.engine == null || rule.engine === engine;
+    const browserMatches = rule.browser == null || rule.browser === browser;
+    if (engineMatches && browserMatches) {
+      if (typeof rule.minimalBuffer === "number") {
+        minimalBuffer = rule.minimalBuffer;
+      }
+      if (typeof rule.targetLatency === "number") {
+        targetLatency = rule.targetLatency;
+      }
+    }
+  }
+  return { minimalBuffer, targetLatency };
+}

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,9 @@
 {
   "defaultServerUrl": "https://localhost:4443/moq",
   "fingerprintUrl": "",
-  "minimalBuffer": 200,
-  "targetLatency": 300,
-  "comment": "This configuration file can be modified after build to change default settings"
+  "bufferProfiles": {
+    "base": { "minimalBuffer": 200, "targetLatency": 300 },
+    "rules": []
+  },
+  "comment": "bufferProfiles resolves minimalBuffer/targetLatency (ms) from the render engine (mse|webcodecs) and browser (safari|other). Start from base, then apply each matching rule in order (later wins); omit engine/browser in a rule to match any. Example rule to raise Safari MSE latency: { \"browser\": \"safari\", \"engine\": \"mse\", \"minimalBuffer\": 500, \"targetLatency\": 600 }. Remove bufferProfiles entirely to use the built-in default."
 }

--- a/src/pipeline/index.test.ts
+++ b/src/pipeline/index.test.ts
@@ -119,8 +119,16 @@ describe("defaultEngineForTracks", () => {
     ).toBe("mse");
   });
 
-  it("rejects mixed packagings", () => {
+  it("allows a cmaf/locmaf mix (same MSE-CMAF family)", () => {
+    expect(defaultEngineForTracks(track("cmaf"), track("locmaf"))).toBe("mse");
+    expect(defaultEngineForTracks(track("locmaf"), track("cmaf"))).toBe("mse");
+  });
+
+  it("rejects mixed packagings across engine families", () => {
     expect(() => defaultEngineForTracks(track("cmaf"), track("loc"))).toThrow(
+      /mixed packagings/i,
+    );
+    expect(() => defaultEngineForTracks(track("locmaf"), track("loc"))).toThrow(
       /mixed packagings/i,
     );
   });
@@ -138,13 +146,10 @@ describe("resolveEngine", () => {
     expect(resolveEngine("webcodecs", track("loc"), null)).toBe("webcodecs");
   });
 
-  it("rejects mixed regular cmaf and locmaf selections", () => {
-    expect(() =>
-      defaultEngineForTracks(track("cmaf"), track("locmaf")),
-    ).toThrow(/mixed packagings/i);
-    expect(() => resolveEngine("mse", track("cmaf"), track("locmaf"))).toThrow(
-      /mixed packagings/i,
-    );
+  it("allows a cmaf/locmaf selection (same MSE-CMAF family)", () => {
+    expect(resolveEngine("auto", track("cmaf"), track("locmaf"))).toBe("mse");
+    expect(resolveEngine("mse", track("cmaf"), track("locmaf"))).toBe("mse");
+    expect(resolveEngine("mse", track("locmaf"), track("cmaf"))).toBe("mse");
   });
 
   it("rejects explicit choices that can't play the selection", () => {

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -202,22 +202,26 @@ export function defaultEngineForTracks(
   if (packagings.size === 0) {
     return "mse";
   }
-  if (packagings.size > 1) {
-    throw new Error(
-      `Mixed packagings not supported: ${Array.from(packagings).join(", ")}`,
-    );
+  // cmaf and locmaf are the same engine family — both play through MSE, with
+  // LOCMAF reconstructed to CMAF before it reaches the buffer — so a CMAF video
+  // paired with a LOCMAF audio (or vice versa) is fine. Only a mix that spans
+  // engine families (e.g. loc + cmaf) is unsupported.
+  const list = Array.from(packagings);
+  const allMseCmaf = list.every(isMseCmafPackaging);
+  const allLoc = list.every((p) => p === "loc");
+  if (!allMseCmaf && !allLoc) {
+    throw new Error(`Mixed packagings not supported: ${list.join(", ")}`);
   }
   if (anyEncrypted) {
     return "mse";
   }
-  const [packaging] = packagings;
-  if (packaging === "loc") {
+  if (allLoc) {
     return "webcodecs";
   }
-  if (isMseCmafPackaging(packaging)) {
+  if (allMseCmaf) {
     return "mse";
   }
-  throw new Error(`Unsupported track packaging: ${packaging}`);
+  throw new Error(`Unsupported track packaging: ${list.join(", ")}`);
 }
 
 /**

--- a/src/player.ts
+++ b/src/player.ts
@@ -6,6 +6,11 @@ import {
 
 import { MediaBuffer, MediaSegmentBuffer, MediaTrackInfo } from "./buffer";
 import {
+  BufferProfiles,
+  DEFAULT_BUFFER_PROFILES,
+  resolveBufferProfile,
+} from "./bufferProfile";
+import {
   LocmafTrackState,
   decompressMoofWithTrackInfo,
   initializeLocmafTrack,
@@ -145,8 +150,27 @@ export class Player {
   private audioObjectsReceived = 0;
   private minimalBufferMs = 200; // Minimal buffer threshold in milliseconds
   private targetLatencyMs = 300; // Target latency in milliseconds
+  // Per-(engine × browser) buffer defaults, resolved at playback start once the
+  // render engine is known. Supplied from config.json; falls back to built-in.
+  private bufferProfiles: BufferProfiles = DEFAULT_BUFFER_PROFILES;
+  // Set once the user edits the buffer inputs — suppresses the auto profile so a
+  // manual value is never clobbered at the next Start.
+  private bufferParamsUserOverride = false;
+  // Notifies the UI when an engine profile changes the effective buffer values,
+  // so the input fields can reflect what is actually in use.
+  private bufferParamsCallback:
+    | ((minimalBufferMs: number, targetLatencyMs: number) => void)
+    | null = null;
   private minBufferLevel: number = Infinity; // Track minimum buffer level between segments
   private lastSegmentAppendTime: number = 0; // Track when we last appended a segment
+  // Latency catch-up authority. Chrome's media clock tracks wall-clock tightly,
+  // so a gentle 1.02x is enough. Safari's MSE clock runs ~1.5-2% slow, so it
+  // needs more authority to hold target latency (set in the constructor).
+  private maxCatchupRate = 1.02; // ceiling for the latency catch-up playback rate
+  private catchupBaseGain = 0.03; // proportional gain for latency catch-up
+  // Drives checkBufferHealth on a fixed cadence (MSE only). timeupdate fires
+  // too sparsely on Safari (~1/s) to control latency responsively.
+  private mseControlTimer: ReturnType<typeof setInterval> | null = null;
 
   // Error handling and recovery
   private recoveryInProgress = false;
@@ -208,6 +232,14 @@ export class Player {
     // MSE state owner. Created up front so getter delegates always have a
     // target; dispose() returns it to a clean state on disconnect.
     this.msePipeline = new MsePipeline(this.logger);
+
+    // Safari's MSE playback clock runs slow and holds a deeper decode pipeline,
+    // so the default 1.02x catch-up cannot pull latency back to target. Give the
+    // controller more authority on Safari (see CHANGELOG). Chrome is unchanged.
+    if (this.isSafari()) {
+      this.maxCatchupRate = 1.12;
+      this.catchupBaseGain = 0.1;
+    }
 
     // Log initialization
     this.logger.info("Player initialized");
@@ -281,16 +313,23 @@ export class Player {
    * Set the buffer control parameters
    * @param minimalBufferMs Minimal buffer level in milliseconds
    * @param targetLatencyMs Target latency in milliseconds
+   * @param userInitiated When true (default), marks the values as a manual
+   *   override so the per-engine auto profile no longer clobbers them at Start.
    */
   public setBufferParameters(
     minimalBufferMs: number,
     targetLatencyMs: number,
+    userInitiated = true,
   ): void {
     if (targetLatencyMs <= minimalBufferMs) {
       this.logger.warn(
         `Target latency (${targetLatencyMs}ms) must be greater than minimal buffer (${minimalBufferMs}ms). Ignoring.`,
       );
       return;
+    }
+
+    if (userInitiated) {
+      this.bufferParamsUserOverride = true;
     }
 
     const oldMinBuffer = this.minimalBufferMs;
@@ -302,6 +341,48 @@ export class Player {
     this.logger.info(
       `Buffer parameters changed - Minimal buffer: ${oldMinBuffer}ms → ${minimalBufferMs}ms, Target latency: ${oldTargetLatency}ms → ${targetLatencyMs}ms`,
     );
+  }
+
+  /**
+   * Supply the per-(engine × browser) buffer profile table (from config.json).
+   * Passing null/undefined keeps the built-in default.
+   */
+  public setBufferProfiles(profiles: BufferProfiles | null | undefined): void {
+    if (profiles && profiles.base) {
+      this.bufferProfiles = profiles;
+    }
+  }
+
+  /**
+   * Set a callback invoked when an engine profile changes the effective buffer
+   * values, so the UI can reflect what is actually in use.
+   */
+  public setBufferParamsCallback(
+    callback: (minimalBufferMs: number, targetLatencyMs: number) => void,
+  ): void {
+    this.bufferParamsCallback = callback;
+  }
+
+  /**
+   * Apply the buffer profile for the resolved render engine, unless the user has
+   * manually overridden the values. Called at Start once the engine is known.
+   */
+  private applyEngineBufferProfile(engine: "mse" | "webcodecs"): void {
+    if (this.bufferParamsUserOverride) {
+      return;
+    }
+    const browser = this.isSafari() ? "safari" : "other";
+    const { minimalBuffer, targetLatency } = resolveBufferProfile(
+      engine,
+      browser,
+      this.bufferProfiles,
+    );
+    this.minimalBufferMs = minimalBuffer;
+    this.targetLatencyMs = targetLatency;
+    this.logger.info(
+      `[BufferProfile] engine=${engine} browser=${browser} -> minimal ${minimalBuffer}ms / target ${targetLatency}ms`,
+    );
+    this.bufferParamsCallback?.(minimalBuffer, targetLatency);
   }
 
   /**
@@ -1392,6 +1473,7 @@ export class Player {
    * Stop synchronized playback and clean up event listeners
    */
   private stopSynchronizedPlayback(): void {
+    this.stopMseControlLoop();
     const videoEl = document.getElementById("videoPlayer") as HTMLVideoElement;
     if (videoEl) {
       // Stop playback
@@ -1996,8 +2078,63 @@ export class Player {
   }
 
   /**
+   * Start the fixed-cadence MSE latency-control loop. Driven by a timer rather
+   * than the media element's timeupdate event, which fires too sparsely and
+   * irregularly on Safari (~1/s) to control latency responsively.
+   */
+  private startMseControlLoop(): void {
+    if (this.mseControlTimer) {
+      clearInterval(this.mseControlTimer);
+    }
+    this.mseControlTimer = setInterval(() => {
+      if (!this.playbackStarted) {
+        return;
+      }
+      const videoEl = document.getElementById(
+        "videoPlayer",
+      ) as HTMLVideoElement | null;
+      if (!videoEl) {
+        return;
+      }
+      const { video, audio } = this.computeBufferAhead(videoEl);
+      this.checkBufferHealth(video, audio);
+    }, 250);
+  }
+
+  /** Stop the MSE latency-control loop. */
+  private stopMseControlLoop(): void {
+    if (this.mseControlTimer) {
+      clearInterval(this.mseControlTimer);
+      this.mseControlTimer = null;
+    }
+  }
+
+  /** Buffered seconds ahead of the playhead for each active SourceBuffer. */
+  private computeBufferAhead(videoEl: HTMLVideoElement): {
+    video: number;
+    audio: number;
+  } {
+    const t = videoEl.currentTime;
+    const ahead = (sb: SourceBuffer | null): number => {
+      if (!sb) {
+        return 0;
+      }
+      for (let i = 0; i < sb.buffered.length; i++) {
+        if (t >= sb.buffered.start(i) && t < sb.buffered.end(i)) {
+          return sb.buffered.end(i) - t;
+        }
+      }
+      return 0;
+    };
+    return {
+      video: ahead(this.videoSourceBuffer),
+      audio: ahead(this.audioSourceBuffer),
+    };
+  }
+
+  /**
    * Check buffer health and control playback rate based on minimal buffer and target latency
-   * This is called during the monitorSync process
+   * This is called on a fixed cadence by the MSE control loop
    */
   private checkBufferHealth(
     videoBufferAhead: number,
@@ -2031,6 +2168,33 @@ export class Player {
     // For buffer control, use the current buffer levels, not the historical minimum
     // The minBufferLevel tracking is for monitoring purposes only
     const effectiveMinBuffer = Math.min(videoBufferAhead, audioBufferAhead);
+
+    // Steady-state resync: if we have fallen far behind the target (e.g. Safari's
+    // slow media clock accumulating a large offset), a <=1.12x nudge would take
+    // many seconds to recover. Seek toward the live edge instead. Guarded so it
+    // only fires on egregious excursions and only when there is enough buffer
+    // ahead to land safely, so healthy Chrome playback never triggers it.
+    const resyncMarginSec = 1.0;
+    if (
+      !this.playbackStalled &&
+      !this.recoveryInProgress &&
+      currentLatencySec > targetLatencySec + resyncMarginSec &&
+      effectiveMinBuffer > targetLatencySec + 0.2
+    ) {
+      const seekTarget =
+        videoEl.currentTime + effectiveMinBuffer - targetLatencySec;
+      this.logger.info(
+        `[BufferHealth] Latency ${currentLatencyMs.toFixed(0)}ms >> target ${
+          this.targetLatencyMs
+        }ms; resyncing playhead ${videoEl.currentTime.toFixed(
+          2,
+        )} -> ${seekTarget.toFixed(2)} (live edge - target)`,
+      );
+      videoEl.currentTime = seekTarget;
+      videoEl.playbackRate = 1.0;
+      this.updatePlaybackRateDisplay();
+      return;
+    }
 
     // Check if either buffer is critically low
     const videoCritical =
@@ -2132,12 +2296,15 @@ export class Player {
       const latencyError =
         (currentLatencyMs - this.targetLatencyMs) / this.targetLatencyMs;
 
-      // Non-linear gain: starts at 3% for large errors, reduces as we approach target
-      const baseGain = 0.03;
+      // Non-linear gain: full gain for large errors, reduces as we approach target
+      const baseGain = this.catchupBaseGain;
       const gainReduction = Math.exp(-Math.abs(latencyError) * 10); // Exponential reduction
       const effectiveGain = baseGain * (1 - gainReduction * 0.8); // Reduce gain by up to 80% as we approach target
 
-      const newRate = Math.min(1.02, 1.0 + latencyError * effectiveGain);
+      const newRate = Math.min(
+        this.maxCatchupRate,
+        1.0 + latencyError * effectiveGain,
+      );
 
       if (Math.abs(videoEl.playbackRate - newRate) >= 0.001) {
         // Lower threshold for small adjustments
@@ -2502,6 +2669,11 @@ export class Player {
       );
       return;
     }
+
+    // Now the render engine is known, apply its buffer/latency profile (e.g.
+    // Safari + MSE wants 500/800ms, WebCodecs wants 200/300ms). Skipped if the
+    // user has manually set the buffer inputs.
+    this.applyEngineBufferProfile(engine);
 
     if (engine === "webcodecs") {
       if (!videoTrack) {
@@ -3514,14 +3686,18 @@ export class Player {
                 this.videoMediaSegmentBuffer.getBufferDuration();
               const bufferDurationMs = bufferDurationSec * 1000;
 
-              if (bufferDurationMs >= this.targetLatencyMs) {
+              // Start once we have the minimal buffer, not the full target
+              // latency: the control loop steers latency to the target after
+              // playback begins. Gating on target could exceed what a
+              // small-object track's buffer can hold and deadlock the start.
+              if (bufferDurationMs >= this.minimalBufferMs) {
                 this.videoBufferReady = true;
                 this.logger.info(
                   `[Video] Buffer ready with ${bufferDurationMs.toFixed(
                     0,
                   )}ms duration (${
                     this.videoObjectsReceived
-                  } objects), target latency: ${this.targetLatencyMs}ms`,
+                  } objects), minimal buffer: ${this.minimalBufferMs}ms`,
                 );
 
                 // Check if we can start playback (depends on audio buffer state too)
@@ -4057,14 +4233,17 @@ export class Player {
             this.audioMediaSegmentBuffer.getBufferDuration();
           const bufferDurationMs = bufferDurationSec * 1000;
 
-          if (bufferDurationMs >= this.targetLatencyMs) {
+          // Start on the minimal buffer, not the full target latency (see the
+          // video path above) — otherwise a small-object audio track can never
+          // reach a high target and playback never starts.
+          if (bufferDurationMs >= this.minimalBufferMs) {
             this.audioBufferReady = true;
             this.logger.debug(
               `[Audio] Buffer ready with ${bufferDurationMs.toFixed(
                 0,
               )}ms duration (${
                 this.audioObjectsReceived
-              } objects), target latency: ${this.targetLatencyMs}ms`,
+              } objects), minimal buffer: ${this.minimalBufferMs}ms`,
             );
 
             // Check if we can start playback (depends on video buffer state too)
@@ -4314,6 +4493,7 @@ export class Player {
         .play()
         .then(() => {
           this.playbackStarted = true;
+          this.startMseControlLoop();
           this.logger.info(
             `[Sync] Synchronized playback started at ${playbackStartTime.toFixed(
               2,
@@ -4397,8 +4577,9 @@ export class Player {
         );
       }
 
-      // Check buffer health and attempt recovery if needed
-      this.checkBufferHealth(videoBufferAhead, audioBufferAhead);
+      // Buffer-health / latency control now runs on a fixed-cadence timer
+      // (startMseControlLoop) rather than the sparse, browser-dependent
+      // timeupdate cadence. monitorSync keeps the UI + A/V-sync duties.
 
       // Only perform sync adjustment if both audio and video are active
       // AND if the buffer health check didn't already adjust the playback rate

--- a/src/warpcatalog.test.ts
+++ b/src/warpcatalog.test.ts
@@ -19,7 +19,7 @@ describe("WarpCatalogManager draft-01 init data", () => {
         name: "video_locmaf",
         namespace: "cmsf/clear",
         packaging: "locmaf",
-        locmafVersion: "0.2",
+        locmafVersion: "0.3",
         role: "video",
         initRef: "init-video",
       },

--- a/src/warpcatalog.ts
+++ b/src/warpcatalog.ts
@@ -1,7 +1,7 @@
 /**
  * MSF/CMSF catalog interface definitions and helper functions.
  * Based on draft-ietf-moq-msf-01 (MOQT Streaming Format) and
- * draft-ietf-moq-cmsf-00 (CMAF MOQT Streaming Format).
+ * draft-ietf-moq-cmsf-01 (CMAF MOQT Streaming Format).
  */
 import { ILogger, LoggerFactory } from "./logger";
 
@@ -56,7 +56,7 @@ export interface InitDataEntry {
 
 /**
  * MSF/CMSF track interface definition.
- * Conforms to draft-ietf-moq-msf-00 and draft-ietf-moq-cmsf-00.
+ * Conforms to draft-ietf-moq-msf-01 and draft-ietf-moq-cmsf-01.
  */
 export interface WarpTrack {
   /** Track name. Required. */


### PR DESCRIPTION
Cuts the **v0.12.0** release for warp-player and stabilizes Safari MSE latency.

The LOCMAF v0.3 and joining-FETCH catalog work already landed on `main` (#150); this PR adds the release metadata plus the Safari latency fixes developed while testing that build.

### Release
- `CHANGELOG.md` `[0.12.0]` cut; `package.json` → `0.12.0`.

### Safari MSE latency stabilization
- Drive the buffer-health/latency controller on a fixed **250 ms** timer instead of the media element's `timeupdate` event, which fires too sparsely on Safari (~1/s) to control latency responsively. This is the fix that lets Safari hold 200/300 ms like Chrome.
- Add a steady-state **resync seek** toward the live edge for large latency excursions (guarded so healthy Chrome playback never triggers it).
- Give Safari more catch-up authority (ceiling 1.12×, higher gain); Chrome keeps 1.02×.

### Tunable buffer profiles
- Resolve `minimalBuffer`/`targetLatency` per **(engine × browser)** from a `bufferProfiles` table in `config.json` (a `base` plus ordered `rules`). Built-in default is 200/300 ms everywhere with no per-combination rule; add a rule (e.g. Safari+MSE 500/600 ms) to tune a specific case. Applied when the engine is resolved at Start and pushed back to the input fields; manual edits override for the session.

### Playback-start fix
- Start playback on the **minimal buffer**, not the full target latency, and raise the segment-buffer cap **30 → 64** objects. Gating start on target latency deadlocked small-object tracks (a ~21 ms/object AAC track capped at 30 segments ≈ 640 ms could never reach a higher target).

### CMAF + LOCMAF mix
- Allow a CMAF video paired with a LOCMAF audio (or vice versa) — both are the same MSE-CMAF family (LOCMAF reconstructs to CMAF). Only cross-family mixes (e.g. LOC + CMAF) are rejected.

All tests pass (`npm test`), typecheck and production build clean.
