### PR TITLE
feat(webcodecs): add AV1 video support to the LOC pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ per session:
   draft's canonical reconstruction) before being appended to the
   `SourceBuffer`.
 - **WebCodecs / LOC** for `packaging: "loc"` tracks (draft-mzanaty-moq-loc),
-  clear content only, supporting AVC and HEVC video plus AAC and Opus audio.
+  clear content only, supporting AVC, HEVC, and AV1 video plus AAC and Opus
+  audio.
 
 Both pipelines implement a common `IPlaybackPipeline` interface so the
 buffer-control loop, latency reporting, mute toggle, and namespace selector
@@ -94,6 +95,7 @@ warp-player/
 │   ├── loc/              # LOC payload helpers for the WebCodecs pipeline
 │   │   ├── avc.ts        # AVC NALU walker, AVCDecoderConfigurationRecord
 │   │   ├── hevc.ts       # HEVC NALU walker, HEVCDecoderConfigurationRecord
+│   │   ├── av1.ts        # AV1 OBU walker, sequence-header / keyframe detection
 │   │   ├── aac.ts        # AAC AudioSpecificConfig from catalog metadata
 │   │   ├── opus.ts       # Opus ID-header (OpusHead) builder
 │   │   └── extensions.ts # LOC extension-header parsing (capture timestamps)
@@ -153,7 +155,9 @@ The codebase is organized into several key modules:
 4. **LOC Layer (WebCodecs)**:
    - Located in `src/loc/`
    - Walks length-prefixed NALUs for AVC/HEVC and synthesizes
-     `VideoDecoderConfig.description` (avcC / hvcC) on parameter-set changes
+     `VideoDecoderConfig.description` (avcC / hvcC) on parameter-set changes;
+     walks raw AV1 OBUs (self-delimiting, LEB128 sizes) and detects keyframes
+     via the in-band sequence-header OBU (AV1 needs no `description`)
    - Synthesizes `AudioDecoderConfig.description` for AAC (AudioSpecificConfig)
      and Opus (OpusHead) from catalog metadata
    - Parses MoQ Object extension headers to extract LOC capture timestamps
@@ -237,6 +241,10 @@ The codebase is organized into several key modules:
     - `avc.ts` / `hevc.ts` — walk length-prefixed NALUs, extract parameter
       sets, build `VideoDecoderConfig.description` (avcC / hvcC), and
       detect IDR / IRAP keyframes
+    - `av1.ts` — walk raw self-delimiting OBUs, detect keyframes via the
+      in-band sequence-header OBU, and extract the sequence header for
+      decoder (re)configuration; AV1 feeds the whole temporal unit to the
+      decoder with no `description`
     - `aac.ts` — build AudioSpecificConfig from catalog `samplerate`,
       `channels`, and `mp4a.OO.A` codec strings
     - `opus.ts` — build the `OpusHead` ID Header from catalog metadata
@@ -272,7 +280,7 @@ The codebase is organized into several key modules:
 1. The implementation supports MOQ Transport draft-14 and draft-16, with the MSF/CMSF catalog format (draft-ietf-moq-msf-01 / draft-ietf-moq-cmsf-01) and LOC packaging (draft-mzanaty-moq-loc).
 2. WebTransport is available in Chrome 87+, Edge 87+, Firefox, and Safari 26.4+. The WebCodecs render engine additionally requires WebCodecs (Chrome 94+, Edge 94+, Safari 16.4+, Firefox 130+).
 3. The client uses MSB (Most Significant Byte) 16-bit length fields for control messages.
-4. Media data is delivered either as CMAF (ISO BMFF) — including the LOCMAF packaging, which is expanded back into CMAF chunks before MSE append — for the MSE pipeline, or as raw codec payloads (length-prefixed AVC/HEVC NALUs, raw AAC access units, raw Opus packets) for the WebCodecs pipeline.
+4. Media data is delivered either as CMAF (ISO BMFF) — including the LOCMAF packaging, which is expanded back into CMAF chunks before MSE append — for the MSE pipeline, or as raw codec payloads (length-prefixed AVC/HEVC NALUs, raw AV1 OBU temporal units, raw AAC access units, raw Opus packets) for the WebCodecs pipeline.
 5. The client includes proper handling of bidirectional control streams for subscribing to content.
 6. The player should work fine towards https://github.com/Eyevinn/moqlivemock/cmd/mlmpub as a source.
 7. Encrypted content always flows through the MSE engine; production browsers do not expose Encrypted WebCodecs.
@@ -338,9 +346,12 @@ directly with WebCodecs:
 - Capability matrix in `src/pipeline/index.ts` decides which engine can
   play a given (packaging, encryption) combination; Auto picks MSE for
   CMAF / encrypted content and WebCodecs for clear LOC content
-- Video codecs supported today: AVC (H.264) and HEVC (H.265). Parameter
-  sets are extracted from each access unit; the decoder is reconfigured
-  whenever VPS / SPS / PPS bytes change
+- Video codecs supported today: AVC (H.264), HEVC (H.265), and AV1.
+  For AVC/HEVC parameter sets are extracted from each access unit and the
+  decoder is reconfigured whenever VPS / SPS / PPS bytes change. AV1 objects
+  are raw OBU temporal units fed to the decoder unchanged (no `description`);
+  keyframes are detected by the in-band sequence-header OBU, which also
+  drives reconfiguration when it changes
 - Audio codecs supported today: AAC-LC and Opus. AudioSpecificConfig
   (AAC) and OpusHead (Opus) are synthesized from the catalog metadata
   and passed as `AudioDecoderConfig.description`

--- a/src/loc/av1.test.ts
+++ b/src/loc/av1.test.ts
@@ -1,0 +1,171 @@
+import {
+  Av1ParseError,
+  OBU_FRAME,
+  OBU_METADATA,
+  OBU_SEQUENCE_HEADER,
+  OBU_TEMPORAL_DELIMITER,
+  extractSequenceHeaderObu,
+  payloadIsKey,
+  walkObus,
+} from "./av1";
+
+// Encode an unsigned LEB128 value (AV1 §4.10.5).
+function leb128(size: number): number[] {
+  const bytes: number[] = [];
+  let v = size;
+  do {
+    let b = v & 0x7f;
+    v = Math.floor(v / 128);
+    if (v > 0) {
+      b |= 0x80;
+    }
+    bytes.push(b);
+  } while (v > 0);
+  return bytes;
+}
+
+// Build a self-delimiting OBU (obu_has_size_field == 1) of the given type.
+function obu(
+  type: number,
+  body: number[] = [],
+  opts: { extension?: boolean } = {},
+): Uint8Array {
+  const extension = opts.extension ?? false;
+  // bit7 forbidden=0 | bits6..3 type | bit2 extension_flag | bit1 has_size | bit0 reserved=0
+  const first = (type << 3) | (extension ? 0x04 : 0) | 0x02;
+  const header = [first];
+  if (extension) {
+    header.push(0x00); // temporal_id / spatial_id / reserved = 0
+  }
+  return new Uint8Array([...header, ...leb128(body.length), ...body]);
+}
+
+// Build an OBU without a size field (obu_has_size_field == 0) — only valid as
+// the final OBU in a temporal unit.
+function obuNoSize(type: number, body: number[] = []): Uint8Array {
+  const first = type << 3; // has_size_field = 0, no extension
+  return new Uint8Array([first, ...body]);
+}
+
+// Concatenate OBUs into a temporal unit.
+function tu(...obus: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const o of obus) {
+    total += o.length;
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const o of obus) {
+    out.set(o, off);
+    off += o.length;
+  }
+  return out;
+}
+
+describe("walkObus", () => {
+  it("returns an empty list for an empty payload", () => {
+    expect(walkObus(new Uint8Array())).toEqual([]);
+  });
+
+  it("splits a single OBU", () => {
+    const out = walkObus(obu(OBU_FRAME, [1, 2, 3]));
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe(OBU_FRAME);
+    // data includes the header + size byte + body.
+    expect(Array.from(out[0].data)).toEqual([
+      (OBU_FRAME << 3) | 0x02,
+      3,
+      1,
+      2,
+      3,
+    ]);
+  });
+
+  it("splits a keyframe temporal unit preserving OBU order", () => {
+    const out = walkObus(
+      tu(obu(OBU_SEQUENCE_HEADER, [0xaa]), obu(OBU_FRAME, [0xbb, 0xcc])),
+    );
+    expect(out.map((o) => o.type)).toEqual([OBU_SEQUENCE_HEADER, OBU_FRAME]);
+  });
+
+  it("parses an OBU carrying the extension header byte", () => {
+    const out = walkObus(obu(OBU_FRAME, [0x10, 0x20], { extension: true }));
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe(OBU_FRAME);
+    // header (1) + extension (1) + leb size (1) + body (2) = 5 bytes.
+    expect(out[0].data).toHaveLength(5);
+  });
+
+  it("handles a multi-byte LEB128 obu_size", () => {
+    const body = new Array(200).fill(0x5a);
+    const out = walkObus(obu(OBU_FRAME, body));
+    expect(out).toHaveLength(1);
+    // 200 needs two LEB128 bytes (0xc8 0x01), so total = 1 + 2 + 200.
+    expect(out[0].data).toHaveLength(203);
+  });
+
+  it("treats a final OBU with no size field as running to the end", () => {
+    const out = walkObus(
+      tu(obu(OBU_SEQUENCE_HEADER, [0x01]), obuNoSize(OBU_FRAME, [7, 8, 9, 10])),
+    );
+    expect(out.map((o) => o.type)).toEqual([OBU_SEQUENCE_HEADER, OBU_FRAME]);
+    expect(Array.from(out[1].data)).toEqual([OBU_FRAME << 3, 7, 8, 9, 10]);
+  });
+
+  it("throws when the forbidden bit is set", () => {
+    expect(() => walkObus(new Uint8Array([0x80]))).toThrow(Av1ParseError);
+  });
+
+  it("throws when an OBU size runs past the end", () => {
+    // has_size_field OBU claiming 10 bytes but only 2 follow.
+    const bad = new Uint8Array([(OBU_FRAME << 3) | 0x02, 10, 0x00, 0x00]);
+    expect(() => walkObus(bad)).toThrow(Av1ParseError);
+  });
+
+  it("throws on a truncated extension header", () => {
+    // extension_flag set but no extension byte present.
+    const bad = new Uint8Array([(OBU_FRAME << 3) | 0x04]);
+    expect(() => walkObus(bad)).toThrow(Av1ParseError);
+  });
+});
+
+describe("payloadIsKey", () => {
+  it("returns true when a sequence-header OBU is present", () => {
+    expect(
+      payloadIsKey(tu(obu(OBU_SEQUENCE_HEADER, [0]), obu(OBU_FRAME, [1]))),
+    ).toBe(true);
+  });
+
+  it("returns false for a delta temporal unit (no sequence header)", () => {
+    expect(payloadIsKey(tu(obu(OBU_FRAME, [1, 2, 3])))).toBe(false);
+    expect(
+      payloadIsKey(tu(obu(OBU_TEMPORAL_DELIMITER), obu(OBU_FRAME, [1]))),
+    ).toBe(false);
+  });
+
+  it("returns false for an empty payload", () => {
+    expect(payloadIsKey(new Uint8Array())).toBe(false);
+  });
+});
+
+describe("extractSequenceHeaderObu", () => {
+  it("returns the sequence-header OBU bytes when present", () => {
+    const sh = obu(OBU_SEQUENCE_HEADER, [0x0a, 0x0b]);
+    const out = extractSequenceHeaderObu(tu(sh, obu(OBU_FRAME, [0xff])));
+    expect(Array.from(out)).toEqual(Array.from(sh));
+  });
+
+  it("concatenates multiple sequence-header OBUs", () => {
+    const sh1 = obu(OBU_SEQUENCE_HEADER, [0x01]);
+    const sh2 = obu(OBU_SEQUENCE_HEADER, [0x02]);
+    const out = extractSequenceHeaderObu(tu(sh1, sh2, obu(OBU_FRAME, [0])));
+    expect(Array.from(out)).toEqual([...Array.from(sh1), ...Array.from(sh2)]);
+  });
+
+  it("returns an empty array when no sequence header is present", () => {
+    const out = extractSequenceHeaderObu(
+      tu(obu(OBU_METADATA, [0x1]), obu(OBU_FRAME, [0x2])),
+    );
+    expect(out).toHaveLength(0);
+  });
+});

--- a/src/loc/av1.ts
+++ b/src/loc/av1.ts
@@ -1,0 +1,166 @@
+// AV1 helpers for the LOC payload path.
+//
+// LOC AV1 objects are raw AV1 temporal units: a sequence of self-delimiting
+// OBUs (obu_has_size_field == 1, LEB128 obu_size) — exactly the bytes of the
+// underlying fMP4 sample. Unlike AVC/HEVC there is NO 4-byte length prefix and
+// NO Annex-B start code, and the decoder configuration (the sequence-header
+// OBU) is not sent out of band: mlmpub leaves it in-band on each keyframe
+// temporal unit (SVT-AV1 / ffmpeg repeat it there). So the whole object
+// payload is fed to the VideoDecoder unchanged and VideoDecoderConfig needs no
+// `description`.
+//
+// References:
+//   - AV1 Bitstream & Decoding Process Specification §5.3.2 (obu_header),
+//     §4.10.5 (leb128)
+//   - AV1 Codec ISO Media File Format Binding §2.3 (a sample is an OBU
+//     temporal unit with no temporal-delimiter OBU)
+//   - WebCodecs AV1 registration: EncodedVideoChunk data is the AV1
+//     "low-overhead bitstream" temporal unit
+//   - moqlivemock/internal/media.go (AV1Data) for the wire layout we consume
+
+export const OBU_SEQUENCE_HEADER = 1;
+export const OBU_TEMPORAL_DELIMITER = 2;
+export const OBU_FRAME_HEADER = 3;
+export const OBU_TILE_GROUP = 4;
+export const OBU_METADATA = 5;
+export const OBU_FRAME = 6;
+export const OBU_REDUNDANT_FRAME_HEADER = 7;
+export const OBU_TILE_LIST = 8;
+export const OBU_PADDING = 15;
+
+export interface ObuView {
+  /** obu_type (bits 6..3 of the first header byte). */
+  type: number;
+  /** The full OBU including its header, size field, and payload. */
+  data: Uint8Array;
+}
+
+export class Av1ParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "Av1ParseError";
+  }
+}
+
+interface Leb128 {
+  value: number;
+  nextOffset: number;
+}
+
+/**
+ * Read an unsigned LEB128 value (AV1 §4.10.5). At most 8 bytes; each byte
+ * contributes 7 low bits, high bit is the continuation flag. Multiplication
+ * (rather than `<<`) is used for accumulation so shifts beyond 31 bits don't
+ * wrap under JavaScript's 32-bit bitwise operators.
+ */
+function readLeb128(buf: Uint8Array, offset: number): Leb128 {
+  let value = 0;
+  for (let i = 0; i < 8; i++) {
+    if (offset >= buf.length) {
+      throw new Av1ParseError(`truncated LEB128 at offset ${offset}`);
+    }
+    const byte = buf[offset++];
+    value += (byte & 0x7f) * 2 ** (i * 7);
+    if ((byte & 0x80) === 0) {
+      return { value, nextOffset: offset };
+    }
+  }
+  throw new Av1ParseError("LEB128 value not terminated within 8 bytes");
+}
+
+/**
+ * Split an AV1 temporal unit into its OBUs. Each OBU carries a 1- or 2-byte
+ * header; when obu_has_size_field is set (always, for the low-overhead
+ * bitstream mlmpub emits) it is followed by an LEB128 obu_size and that many
+ * payload bytes. A trailing OBU with obu_has_size_field == 0 (permitted only
+ * as the final OBU) is taken to run to the end of the buffer. Empty payload
+ * yields an empty array.
+ */
+export function walkObus(payload: Uint8Array): ObuView[] {
+  const result: ObuView[] = [];
+  let offset = 0;
+  while (offset < payload.length) {
+    const start = offset;
+    const b0 = payload[offset];
+    if ((b0 & 0x80) !== 0) {
+      throw new Av1ParseError(`obu_forbidden_bit set at offset ${offset}`);
+    }
+    const type = (b0 >> 3) & 0x0f;
+    const hasExtension = (b0 & 0x04) !== 0;
+    const hasSizeField = (b0 & 0x02) !== 0;
+    offset += 1;
+    if (hasExtension) {
+      if (offset >= payload.length) {
+        throw new Av1ParseError(
+          `truncated OBU extension header at offset ${offset}`,
+        );
+      }
+      offset += 1;
+    }
+    let obuSize: number;
+    if (hasSizeField) {
+      const leb = readLeb128(payload, offset);
+      obuSize = leb.value;
+      offset = leb.nextOffset;
+    } else {
+      // Only valid as the final OBU: it runs to the end of the buffer.
+      obuSize = payload.length - offset;
+    }
+    if (offset + obuSize > payload.length) {
+      throw new Av1ParseError(
+        `OBU of size ${obuSize} extends past end (offset ${offset}, payload ${payload.length})`,
+      );
+    }
+    offset += obuSize;
+    result.push({ type, data: payload.subarray(start, offset) });
+  }
+  return result;
+}
+
+/**
+ * True when the temporal unit carries a sequence-header OBU. mlmpub emits the
+ * sequence header only on keyframe temporal units (SVT-AV1 low-delay CBR, I/P
+ * only), mirroring how the publisher itself detects AV1 sync samples
+ * (moqlivemock/internal/media.go keyframeHasAV1SeqHeader). A keyframe is
+ * randomly accessible precisely because the sequence header travels with it,
+ * so a sequence-header OBU is a reliable keyframe marker for this content.
+ */
+export function payloadIsKey(payload: Uint8Array): boolean {
+  for (const obu of walkObus(payload)) {
+    if (obu.type === OBU_SEQUENCE_HEADER) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Return the concatenated sequence-header OBU(s) in the temporal unit, or an
+ * empty array if none are present. Used to detect a sequence-header change
+ * (e.g. a rendition/resolution switch) so the decoder can be reconfigured.
+ */
+export function extractSequenceHeaderObu(payload: Uint8Array): Uint8Array {
+  const parts: Uint8Array[] = [];
+  for (const obu of walkObus(payload)) {
+    if (obu.type === OBU_SEQUENCE_HEADER) {
+      parts.push(obu.data);
+    }
+  }
+  if (parts.length === 0) {
+    return new Uint8Array(0);
+  }
+  if (parts.length === 1) {
+    return new Uint8Array(parts[0]);
+  }
+  let total = 0;
+  for (const p of parts) {
+    total += p.length;
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}

--- a/src/pipeline/webcodecsLocPipeline.ts
+++ b/src/pipeline/webcodecsLocPipeline.ts
@@ -1,7 +1,10 @@
 // WebCodecs LOC playback pipeline.
 //
-// Phase 1: clear-AVC video.
-// Phase 2: clear-AAC and Opus audio, sharing the wallclock anchor with video.
+// Video: clear AVC, HEVC, and AV1. AVC/HEVC arrive as length-prefixed NALUs
+// with parameter sets carried in-band on keyframes; AV1 arrives as raw
+// self-delimiting OBU temporal units with the sequence header in-band on
+// keyframes. Audio: clear AAC and Opus, sharing the wallclock anchor with
+// video.
 //
 // Render strategy: a canvas is overlaid on the existing <video> element
 // (the video element is hidden while this pipeline is active, then restored
@@ -16,6 +19,10 @@
 // wallclock anchor used by the video render loop.
 
 import { buildAacConfigFromCatalog } from "../loc/aac";
+import {
+  extractSequenceHeaderObu as extractAv1SequenceHeaderObu,
+  payloadIsKey as av1PayloadIsKey,
+} from "../loc/av1";
 import {
   buildAvcDecoderConfigDescription,
   extractParameterSetsAndChunk as extractAvcParameterSetsAndChunk,
@@ -60,6 +67,8 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
   private lastVps: Uint8Array | null = null;
   private lastSps: Uint8Array | null = null;
   private lastPps: Uint8Array | null = null;
+  /** Last AV1 sequence-header OBU bytes used to configure the decoder. */
+  private lastAv1SeqHeader: Uint8Array | null = null;
 
   private audioDecoder: AudioDecoder | null = null;
   private audioContext: AudioContext | null = null;
@@ -273,7 +282,9 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     const captureUs = captureUsBig === null ? null : Number(captureUsBig);
     const timestampUs = captureUs ?? this.deriveTimestampUs(obj);
 
-    if (this.isHevcCodec()) {
+    if (this.isAv1Codec()) {
+      this.routeAv1Video(decoder, payload, timestampUs);
+    } else if (this.isHevcCodec()) {
       this.routeHevcVideo(decoder, payload, timestampUs);
     } else {
       this.routeAvcVideo(decoder, payload, timestampUs);
@@ -441,6 +452,77 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     }
   }
 
+  private routeAv1Video(
+    decoder: VideoDecoder,
+    payload: Uint8Array,
+    timestampUs: number,
+  ): void {
+    // AV1 LOC objects are raw OBU temporal units (self-delimiting, LEB128
+    // sizes) — no length prefix, no start codes, and no out-of-band config.
+    // Keyframe temporal units lead with a sequence-header OBU.
+    let isKey: boolean;
+    let seqHeader: Uint8Array;
+    try {
+      isKey = av1PayloadIsKey(payload);
+      seqHeader = isKey
+        ? extractAv1SequenceHeaderObu(payload)
+        : new Uint8Array(0);
+    } catch (e) {
+      this.logger.warn(
+        `[WebCodecsLoc] AV1 OBU parse failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      return;
+    }
+
+    if (isKey) {
+      const needsConfigure =
+        decoder.state === "unconfigured" ||
+        !this.bytesEqual(this.lastAv1SeqHeader, seqHeader);
+      if (needsConfigure) {
+        // AV1 needs no `description`: the sequence-header OBU travels in-band
+        // in every keyframe temporal unit, so the payload is self-describing.
+        // The catalog keeps the `av01…` codec string as-is (no avc3/hev1-style
+        // normalisation) — mlmpub does not rewrite it for LOC.
+        const codec = this.videoTrack?.codec ?? "av01.0.04M.08";
+        const config: VideoDecoderConfig = {
+          codec,
+          codedWidth: this.videoTrack?.width,
+          codedHeight: this.videoTrack?.height,
+          optimizeForLatency: true,
+        };
+        decoder.configure(config);
+        this.lastAv1SeqHeader = new Uint8Array(seqHeader);
+        this.logger.info(
+          `[WebCodecsLoc] VideoDecoder configured (codec=${codec})`,
+        );
+      }
+    }
+
+    if (decoder.state !== "configured") {
+      return;
+    }
+
+    // Feed the whole temporal unit unchanged: the sequence header on keyframes
+    // must stay in the chunk since no separate description carries it.
+    try {
+      decoder.decode(
+        new EncodedVideoChunk({
+          type: isKey ? "key" : "delta",
+          timestamp: timestampUs,
+          data: payload,
+        }),
+      );
+    } catch (e) {
+      this.logger.error(
+        `[WebCodecsLoc] decode failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
+  private isAv1Codec(): boolean {
+    return this.videoTrack?.codec?.toLowerCase().startsWith("av01") ?? false;
+  }
+
   private isHevcCodec(): boolean {
     const codec = this.videoTrack?.codec?.toLowerCase() ?? "";
     return codec.startsWith("hvc1") || codec.startsWith("hev1");
@@ -572,6 +654,7 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     this.lastVps = null;
     this.lastSps = null;
     this.lastPps = null;
+    this.lastAv1SeqHeader = null;
     this.anchorWallMs = null;
     this.lastPresentedMs = null;
   }


### PR DESCRIPTION
## Summary

Adds AV1 (`av01`) video support to warp-player's **WebCodecs / LOC** render pipeline. The publisher (mlmpub) already serves AV1 end-to-end over both LOC (`msf/clear`) and CMAF/LOCMAF (`cmsf/*`), so this is a player-side decode change only — no publisher changes required.

## What changed

- **`src/loc/av1.ts`** (new) — AV1 OBU parser: `walkObus` (parses `obu_header`, the optional extension byte, the LEB128 `obu_size`, and the final no-size-field OBU), `payloadIsKey` (keyframe = the temporal unit carries an `OBU_SEQUENCE_HEADER`), and `extractSequenceHeaderObu`. Modeled on `avc.ts` / `hevc.ts`.
- **`src/loc/av1.test.ts`** (new) — 15 unit tests.
- **`src/pipeline/webcodecsLocPipeline.ts`** — `isAv1Codec()` and `routeAv1Video()`, wired as a third arm in the video branch; new `lastAv1SeqHeader` state for reconfigure-on-change.
- **`CLAUDE.md`** — documentation updates.

## How AV1 differs from AVC/HEVC on the wire

Over LOC, each MoQ object is one raw AV1 temporal unit: self-delimiting OBUs (`obu_has_size_field=1`, LEB128 sizes) — **no 4-byte length prefix and no Annex-B start codes**. The sequence-header OBU rides in-band on each keyframe, so:

- the whole temporal unit is fed to `VideoDecoder` unchanged (no NALU/length conversion), and
- `VideoDecoderConfig` needs **no `description`** (the `av01…` codec string from the catalog is used verbatim, unlike the avc3→avc1 / hev1→hvc1 rewrite).

The **MSE / CMAF path is codec-agnostic** and needs no change — the `av01` string flows into `video/mp4; codecs="…"` and the browser parses the `av01` / `av1C` boxes.

## Testing

- `npm run typecheck`, `npm run lint`, `prettier --check`: clean.
- `npm test`: 244/244 pass (incl. 15 new).
- **Live browser (Chrome via Playwright)** against mlmpub `assets/test10s`, full matrix — all play with an advancing timeline and no decode errors:
  - `msf/clear` LOC → WebCodecs (canvas painting, frames advancing)
  - `cmsf/clear` CMAF → MSE
  - `cmsf/clear` LOCMAF → MSE
  - `cmsf/eccp-cenc` CMAF + ClearKey → MSE + EME
  - `cmsf/eccp-cenc` LOCMAF + ClearKey → MSE + EME
