### PR TITLE
feat(cc608): extract CTA-608 captions on the WebCodecs LOC path

### DIFF
--- a/src/loc/cta608.test.ts
+++ b/src/loc/cta608.test.ts
@@ -1,0 +1,455 @@
+import { CC608_COLS, Cc608Sink, Cc608Snapshot } from "../cc608/types";
+import { ILogger } from "../logger";
+
+import {
+  CTA608_PROBE_SAMPLES,
+  LocCta608Extractor,
+  codecCanCarryCta608,
+} from "./cta608";
+
+/* ------------------------------------------------------------------ */
+/* Test doubles                                                        */
+/* ------------------------------------------------------------------ */
+
+const noop = (): void => undefined;
+
+function nullLogger(): ILogger {
+  return {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    fatal: noop,
+    getCategory: () => "test",
+    setLevel: noop,
+  };
+}
+
+interface Push {
+  timeMs: number;
+  screen: Cc608Snapshot | null;
+}
+
+class RecordingSink implements Cc608Sink {
+  readonly pushes: Push[] = [];
+  push(timeMs: number, screen: Cc608Snapshot | null): void {
+    this.pushes.push({ timeMs, screen });
+  }
+  /** Pushes that carry a screen (i.e. not overlay clears). */
+  get screens(): Push[] {
+    return this.pushes.filter((p) => p.screen !== null);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Synthetic LOC video samples                                         */
+/* ------------------------------------------------------------------ */
+
+/** CTA-608 control codes on channel 1, field 1 (unparitied). */
+const RCL: CcPair = [0x14, 0x20]; // Resume Caption Loading (pop-on)
+const ENM: CcPair = [0x14, 0x2e]; // Erase Non-displayed Memory
+const EDM: CcPair = [0x14, 0x2c]; // Erase Displayed Memory
+const EOC: CcPair = [0x14, 0x2f]; // End Of Caption (flip)
+/** PAC: row 15, white, no underline / with underline. */
+const PAC_R15: CcPair = [0x14, 0x60];
+const PAC_R15_UNDERLINE: CcPair = [0x14, 0x61];
+
+type CcPair = [number, number];
+
+/** Wrap raw NAL bytes in a 4-byte length prefix. */
+function lengthPrefixed(nal: number[]): number[] {
+  const n = nal.length;
+  return [
+    (n >>> 24) & 0xff,
+    (n >>> 16) & 0xff,
+    (n >>> 8) & 0xff,
+    n & 0xff,
+    ...nal,
+  ];
+}
+
+/**
+ * Build a CTA-608 SEI NAL unit (registered ITU-T T.35 user data, ATSC A/53
+ * cc_data) carrying `pairs` on field 1 (cc_type 0).
+ */
+function cta608SeiNal(pairs: CcPair[], codec: "avc" | "hevc"): number[] {
+  const cc: number[] = [];
+  for (const [d1, d2] of pairs) {
+    cc.push(0xfc, d1, d2); // marker bits + cc_valid + cc_type 0 (field 1)
+  }
+  const payload = [
+    0xb5, // itu_t_t35_country_code = 181 (USA)
+    0x00,
+    0x31, // itu_t_t35_provider_code = 49
+    0x47,
+    0x41,
+    0x39,
+    0x34, // user_identifier "GA94"
+    0x03, // user_data_type_code = cc_data
+    0xc0 | pairs.length, // process_cc_data_flag + cc_count
+    0xff, // em_data
+    ...cc,
+    0xff, // marker bits
+  ];
+  const header = codec === "avc" ? [0x06] : [0x4e, 0x01]; // AVC SEI / HEVC prefix SEI
+  return [
+    ...header,
+    0x04, // payloadType = user_data_registered_itu_t_t35
+    payload.length,
+    ...payload,
+    0x80, // rbsp_trailing_bits
+  ];
+}
+
+/** A non-SEI coded-slice NAL, so the walker has to skip something. */
+function sliceNal(codec: "avc" | "hevc"): number[] {
+  return codec === "avc"
+    ? [0x65, 0x88, 0x84, 0x21, 0x0a]
+    : [0x02, 0x01, 0xd0, 0x09, 0x7e];
+}
+
+/** One LOC video object: length-prefixed slice + optional 608 SEI. */
+function sample(pairs: CcPair[] | null, codec: "avc" | "hevc"): Uint8Array {
+  const bytes = [...lengthPrefixed(sliceNal(codec))];
+  if (pairs && pairs.length > 0) {
+    bytes.push(...lengthPrefixed(cta608SeiNal(pairs, codec)));
+  }
+  return new Uint8Array(bytes);
+}
+
+/** Text of a snapshot row, trailing padding trimmed. */
+function rowText(screen: Cc608Snapshot, index: number): string {
+  return screen.rows[index].cells
+    .map((c) => c.uchar)
+    .join("")
+    .replace(/\s+$/, "");
+}
+
+function makeExtractor(
+  sink: Cc608Sink,
+  codec: string,
+  extra: Partial<{ enabled: () => boolean; probeSamples: number }> = {},
+): LocCta608Extractor {
+  return new LocCta608Extractor({
+    sink,
+    logger: nullLogger(),
+    codec,
+    ...extra,
+  });
+}
+
+const CODECS: Array<{ label: string; codec: string; kind: "avc" | "hevc" }> = [
+  { label: "AVC", codec: "avc1.4D401F", kind: "avc" },
+  { label: "HEVC", codec: "hvc1.1.6.L93.B0", kind: "hevc" },
+];
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("codecCanCarryCta608", () => {
+  it("accepts AVC and HEVC and rejects everything else", () => {
+    expect(codecCanCarryCta608("avc1.4D401F")).toBe(true);
+    expect(codecCanCarryCta608("avc3.4D401F")).toBe(true);
+    expect(codecCanCarryCta608("hvc1.1.6.L93.B0")).toBe(true);
+    expect(codecCanCarryCta608("hev1.1.6.L93.B0")).toBe(true);
+    expect(codecCanCarryCta608("av01.0.04M.08")).toBe(false);
+    expect(codecCanCarryCta608("vp09.00.10.08")).toBe(false);
+    expect(codecCanCarryCta608(undefined)).toBe(false);
+    expect(codecCanCarryCta608("")).toBe(false);
+  });
+});
+
+describe.each(CODECS)("LocCta608Extractor ($label)", ({ codec, kind }) => {
+  /** A pop-on caption "HI" on row 15, spread over three samples. */
+  function feedPopOnCaption(ext: LocCta608Extractor, startUs = 0): number {
+    const frameUs = 40_000;
+    ext.addVideoSample(startUs, sample([RCL, ENM], kind));
+    ext.addVideoSample(
+      startUs + frameUs,
+      sample([PAC_R15, [0x48, 0x49]], kind),
+    );
+    ext.addVideoSample(startUs + 2 * frameUs, sample([EOC], kind));
+    return startUs + 2 * frameUs;
+  }
+
+  it("emits the caption on the sample that completes the flip", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    const flipUs = feedPopOnCaption(ext);
+
+    expect(sink.screens).toHaveLength(1);
+    const push = sink.screens[0];
+    // Timestamped from the sample carrying the EOC, in ms — not from
+    // newCue's (unusable) start/end times.
+    expect(push.timeMs).toBeCloseTo(flipUs / 1000, 6);
+    const screen = push.screen as Cc608Snapshot;
+    expect(screen.rows).toHaveLength(1);
+    // Row 15 in 608 numbering is index 14.
+    expect(screen.rows[0].row).toBe(14);
+    expect(rowText(screen, 0)).toBe("HI");
+  });
+
+  it("clears the overlay while no caption is displayed", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    ext.addVideoSample(0, sample([RCL, ENM], kind));
+
+    expect(sink.pushes).toHaveLength(1);
+    expect(sink.pushes[0]).toEqual({ timeMs: 0, screen: null });
+  });
+
+  it("dedupes an unchanged screen across subsequent samples", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    feedPopOnCaption(ext);
+    const pushesAfterFlip = sink.pushes.length;
+
+    // Ten further frames with no cc_data at all: the screen is unchanged,
+    // so nothing new must reach the sink.
+    for (let i = 1; i <= 10; i++) {
+      ext.addVideoSample(120_000 + i * 40_000, sample(null, kind));
+    }
+    expect(sink.pushes).toHaveLength(pushesAfterFlip);
+  });
+
+  it("pushes a clear when the caption is erased", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    feedPopOnCaption(ext);
+    ext.addVideoSample(200_000, sample([EDM], kind));
+    // The clear lands on the EDM sample itself. Cc608Source captures only the
+    // cues raised *during* cueSplitAtTime, so cml's own late newCue — which
+    // hands over the screen that was just erased — cannot mask the fact that
+    // the live screen is now empty.
+    const afterEdm = sink.pushes.length;
+
+    // A further empty sample must not push again: the null is deduped.
+    ext.addVideoSample(240_000, sample(null, kind));
+    expect(sink.pushes).toHaveLength(afterEdm);
+
+    const last = sink.pushes[sink.pushes.length - 1];
+    expect(last.screen).toBeNull();
+    expect(last.timeMs).toBeCloseTo(200, 6);
+  });
+
+  it("re-emits a screen that returns after a clear", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    feedPopOnCaption(ext);
+    ext.addVideoSample(200_000, sample([EDM], kind));
+    feedPopOnCaption(ext, 240_000);
+
+    expect(sink.screens).toHaveLength(2);
+    expect(rowText(sink.screens[1].screen as Cc608Snapshot, 0)).toBe("HI");
+  });
+
+  it("keeps exactly CC608_COLS cells per row (cml's Row is 100 wide)", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    feedPopOnCaption(ext);
+
+    const screen = sink.screens[0].screen as Cc608Snapshot;
+    expect(CC608_COLS).toBe(32);
+    expect(screen.rows[0].cells).toHaveLength(CC608_COLS);
+  });
+
+  it("treats a default-styled space as an empty cell", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    // Two spaces (0x20 0x20) in the default pen: cml's isEmpty() cannot tell
+    // them from untouched cells, so the row is not recorded and the screen
+    // stays empty.
+    ext.addVideoSample(0, sample([RCL, ENM], kind));
+    ext.addVideoSample(40_000, sample([PAC_R15, [0x20, 0x20]], kind));
+    ext.addVideoSample(80_000, sample([EOC], kind));
+
+    expect(sink.screens).toHaveLength(0);
+  });
+
+  it("records a row whose only content is the pen stamped by setPAC", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    // A PAC with underline stamps a non-default pen onto the cell under the
+    // cursor before any character is written, so the row becomes non-empty
+    // even though nothing was typed.
+    ext.addVideoSample(0, sample([RCL, ENM], kind));
+    ext.addVideoSample(40_000, sample([PAC_R15_UNDERLINE], kind));
+    ext.addVideoSample(80_000, sample([EOC], kind));
+
+    expect(sink.screens).toHaveLength(1);
+    const screen = sink.screens[0].screen as Cc608Snapshot;
+    expect(screen.rows[0].row).toBe(14);
+    expect(screen.rows[0].cells[0]).toEqual({
+      uchar: " ",
+      pen: {
+        foreground: "white",
+        background: "black",
+        underline: true,
+        italics: false,
+        flash: false,
+      },
+    });
+    expect(rowText(screen, 0)).toBe("");
+  });
+
+  it("copies the screen instead of retaining cml's reused CaptionScreen", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    feedPopOnCaption(ext);
+    const first = sink.screens[0].screen as Cc608Snapshot;
+
+    // A second, different caption. The library hands out the same mutated
+    // CaptionScreen object, so a retained reference would now read "OK".
+    ext.addVideoSample(200_000, sample([EDM], kind));
+    ext.addVideoSample(240_000, sample([RCL, ENM], kind));
+    ext.addVideoSample(280_000, sample([PAC_R15, [0x4f, 0x4b]], kind));
+    ext.addVideoSample(320_000, sample([EOC], kind));
+
+    expect(rowText(sink.screens[1].screen as Cc608Snapshot, 0)).toBe("OK");
+    expect(rowText(first, 0)).toBe("HI");
+  });
+
+  it("drops 608 state on reset so a stale caption cannot be flipped", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec);
+    // Preload a caption into non-displayed memory, then hit a discontinuity
+    // before the EOC arrives — the mid-group join case.
+    ext.addVideoSample(0, sample([RCL, ENM], kind));
+    ext.addVideoSample(40_000, sample([PAC_R15, [0x48, 0x49]], kind));
+    ext.reset();
+    ext.addVideoSample(80_000, sample([EOC], kind));
+
+    expect(sink.screens).toHaveLength(0);
+  });
+
+  it("resets first-sight detection so a dormant track is re-probed", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, codec, { probeSamples: 5 });
+    for (let i = 0; i < 5; i++) {
+      ext.addVideoSample(i * 40_000, sample(null, kind));
+    }
+    expect(ext.scanning).toBe(false);
+
+    ext.reset();
+    expect(ext.scanning).toBe(true);
+    feedPopOnCaption(ext, 400_000);
+    expect(sink.screens).toHaveLength(1);
+  });
+});
+
+describe("LocCta608Extractor gating", () => {
+  it("never scans an AV1 track", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, "av01.0.04M.08");
+    expect(ext.scanning).toBe(false);
+    // AV1 objects are raw OBUs, not length-prefixed NALUs — scanning them
+    // would be meaningless as well as wasteful.
+    ext.addVideoSample(0, sample([RCL, ENM], "avc"));
+    ext.addVideoSample(40_000, sample([PAC_R15, [0x48, 0x49]], "avc"));
+    ext.addVideoSample(80_000, sample([EOC], "avc"));
+    expect(sink.pushes).toHaveLength(0);
+  });
+
+  it("goes dormant on a track with no captions", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, "avc1.4D401F", { probeSamples: 3 });
+    for (let i = 0; i < 3; i++) {
+      expect(ext.scanning).toBe(true);
+      ext.addVideoSample(i * 40_000, sample(null, "avc"));
+    }
+    expect(ext.scanning).toBe(false);
+
+    // Captions appearing after the probe window are ignored — no per-frame
+    // scanning cost remains on a track deemed uncaptioned.
+    const before = sink.pushes.length;
+    ext.addVideoSample(120_000, sample([RCL, ENM], "avc"));
+    ext.addVideoSample(160_000, sample([PAC_R15, [0x48, 0x49]], "avc"));
+    ext.addVideoSample(200_000, sample([EOC], "avc"));
+    expect(sink.pushes).toHaveLength(before);
+  });
+
+  it("stays awake as long as captions keep arriving", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, "avc1.4D401F", { probeSamples: 2 });
+    ext.addVideoSample(0, sample([RCL, ENM], "avc"));
+    ext.addVideoSample(40_000, sample([PAC_R15, [0x48, 0x49]], "avc"));
+    ext.addVideoSample(80_000, sample([EOC], "avc"));
+    expect(ext.scanning).toBe(true);
+    expect(sink.screens).toHaveLength(1);
+  });
+
+  it("uses a probe window covering several seconds by default", () => {
+    expect(CTA608_PROBE_SAMPLES).toBeGreaterThanOrEqual(100);
+  });
+
+  it("does nothing while the CC toggle is off, and re-probes when it flips on", () => {
+    const sink = new RecordingSink();
+    let on = false;
+    const ext = makeExtractor(sink, "avc1.4D401F", { enabled: () => on });
+
+    expect(ext.scanning).toBe(false);
+    ext.addVideoSample(0, sample([RCL, ENM], "avc"));
+    ext.addVideoSample(40_000, sample([PAC_R15, [0x48, 0x49]], "avc"));
+    ext.addVideoSample(80_000, sample([EOC], "avc"));
+    expect(sink.pushes).toHaveLength(0);
+
+    on = true;
+    expect(ext.scanning).toBe(true);
+    ext.addVideoSample(120_000, sample([RCL, ENM], "avc"));
+    ext.addVideoSample(160_000, sample([PAC_R15, [0x4f, 0x4b]], "avc"));
+    ext.addVideoSample(200_000, sample([EOC], "avc"));
+    expect(sink.screens).toHaveLength(1);
+    expect(rowText(sink.screens[0].screen as Cc608Snapshot, 0)).toBe("OK");
+  });
+
+  it("clears the overlay once when the CC toggle is turned off", () => {
+    const sink = new RecordingSink();
+    let on = true;
+    const ext = makeExtractor(sink, "avc1.4D401F", { enabled: () => on });
+    ext.addVideoSample(0, sample([RCL, ENM], "avc"));
+    ext.addVideoSample(40_000, sample([PAC_R15, [0x48, 0x49]], "avc"));
+    ext.addVideoSample(80_000, sample([EOC], "avc"));
+    expect(sink.screens).toHaveLength(1);
+
+    on = false;
+    ext.addVideoSample(120_000, sample(null, "avc"));
+    ext.addVideoSample(160_000, sample(null, "avc"));
+    const clears = sink.pushes.filter((p) => p.screen === null);
+    expect(clears[clears.length - 1].timeMs).toBeCloseTo(120, 6);
+    expect(sink.pushes[sink.pushes.length - 1].screen).toBeNull();
+    // Only one clear for the toggle-off, not one per frame.
+    expect(sink.pushes.filter((p) => p.timeMs === 160).length).toBe(0);
+  });
+
+  it("ignores empty payloads", () => {
+    const sink = new RecordingSink();
+    const ext = makeExtractor(sink, "avc1.4D401F");
+    ext.addVideoSample(0, new Uint8Array(0));
+    expect(sink.pushes).toHaveLength(0);
+  });
+});
+
+describe("AVC and HEVC agree", () => {
+  it("produces identical snapshots for the same cc_data", () => {
+    const avcSink = new RecordingSink();
+    const hevcSink = new RecordingSink();
+    const avc = makeExtractor(avcSink, "avc1.4D401F");
+    const hevc = makeExtractor(hevcSink, "hvc1.1.6.L93.B0");
+
+    const script: Array<CcPair[] | null> = [
+      [RCL, ENM],
+      [PAC_R15, [0x48, 0x49]],
+      [EOC],
+      null,
+      [EDM],
+    ];
+    script.forEach((pairs, i) => {
+      avc.addVideoSample(i * 40_000, sample(pairs, "avc"));
+      hevc.addVideoSample(i * 40_000, sample(pairs, "hevc"));
+    });
+
+    expect(hevcSink.pushes).toEqual(avcSink.pushes);
+    expect(avcSink.screens).toHaveLength(1);
+  });
+});

--- a/src/loc/cta608.ts
+++ b/src/loc/cta608.ts
@@ -1,0 +1,219 @@
+// CTA-608 extraction gate for the WebCodecs / LOC video path.
+//
+// LOC video objects are exactly what `extractCta608DataFromSample` expects:
+// 4-byte length-prefixed NALUs, one access unit per object, with AVC 1-byte
+// and HEVC 2-byte NAL headers handled by the same walker. So the only thing
+// this file adds on top of `Cc608Source` is the *gate*: deciding whether a
+// given sample is worth scanning at all.
+//
+// The gate has three layers, cheapest first:
+//
+//   1. Codec — AVC and HEVC only. AV1 carries no CTA-608 (cml has no
+//      metadata-OBU path either), so an AV1 track never scans a byte.
+//   2. `enabled` — an injected predicate, so the CC toggle (#165) can turn
+//      the whole thing off. When it returns false nothing is scanned, and the
+//      overlay is cleared once.
+//   3. First-sight detection — a bounded probe window at the start of a
+//      track. If no CTA-608 SEI shows up within it, the track is treated as
+//      uncaptioned and scanning stops entirely. The signal is the *presence
+//      of 608 SEI*, not the first displayed caption, so a captioned track
+//      whose first pop-on lands late still stays awake.
+//
+// Layer 3 is what makes extraction a genuine no-op on an uncaptioned track:
+// after the probe the per-sample cost is one boolean test. The probe re-arms
+// on `reset()` (track switch, discontinuity, dispose) and whenever the
+// `enabled` predicate flips from false back to true, so turning captions on
+// mid-session re-checks the stream.
+
+import { findCta608Nalus } from "@svta/cml-608";
+
+import { Cc608Source } from "../cc608/source";
+import { Cc608Sink } from "../cc608/types";
+import { ILogger } from "../logger";
+
+/**
+ * Number of samples scanned before an apparently uncaptioned track goes
+ * dormant. At 25–50 fps this is roughly 4–8 seconds of video, comfortably
+ * more than the gap between caption bursts on a live 608 service.
+ */
+export const CTA608_PROBE_SAMPLES = 200;
+
+/** Whether a catalog codec string can carry CTA-608 in SEI NAL units. */
+export function codecCanCarryCta608(codec: string | undefined | null): boolean {
+  if (!codec) {
+    return false;
+  }
+  const c = codec.toLowerCase();
+  return (
+    c.startsWith("avc1") ||
+    c.startsWith("avc3") ||
+    c.startsWith("hvc1") ||
+    c.startsWith("hev1")
+  );
+}
+
+export interface LocCta608ExtractorOptions {
+  /** Where snapshots are pushed. */
+  sink: Cc608Sink;
+  logger: ILogger;
+  /** Catalog codec string of the video track. */
+  codec: string | undefined | null;
+  /**
+   * Gate hook for the CC toggle (#165). Defaults to always-on. Read once per
+   * sample, so the caller can flip it at any time.
+   */
+  enabled?: () => boolean;
+  /** Test seam; defaults to CTA608_PROBE_SAMPLES. */
+  probeSamples?: number;
+}
+
+/**
+ * Per-session CTA-608 extractor for LOC video objects.
+ *
+ * One of these is owned by `WebCodecsLocPipeline`; it is fed every video
+ * sample and pushes screen snapshots into the sink.
+ */
+export class LocCta608Extractor {
+  private readonly source: Cc608Source;
+  private readonly sink: Cc608Sink;
+  private readonly logger: ILogger;
+  private readonly enabled: () => boolean;
+  private readonly probeSamples: number;
+  /** False for AV1 and anything else without SEI-carried 608. */
+  private readonly codecSupported: boolean;
+
+  /** Samples scanned since the probe window was armed. */
+  private probed = 0;
+  /** True once a CTA-608 SEI has been seen on this track. */
+  private sawCta608 = false;
+  /** True once the probe window expired without seeing cc_data. */
+  private dormant = false;
+  /** Last value returned by `enabled`, to detect an off -> on transition. */
+  private wasEnabled = true;
+  /** True while an overlay may be showing something. */
+  private pushedAnything = false;
+
+  constructor(options: LocCta608ExtractorOptions) {
+    this.sink = options.sink;
+    this.logger = options.logger;
+    this.enabled = options.enabled ?? (() => true);
+    this.probeSamples = options.probeSamples ?? CTA608_PROBE_SAMPLES;
+    this.codecSupported = codecCanCarryCta608(options.codec);
+    this.source = new Cc608Source(this.countingSink(), options.logger);
+    if (!this.codecSupported) {
+      this.logger.debug(
+        `[cc608] CTA-608 extraction disabled for codec "${options.codec ?? "(none)"}"`,
+      );
+    }
+  }
+
+  /**
+   * Wrap the caller's sink so the extractor knows whether an overlay may be
+   * showing something, without the caller having to report back.
+   */
+  private countingSink(): Cc608Sink {
+    return {
+      push: (timeMs, screen) => {
+        if (screen !== null) {
+          this.sawCta608 = true;
+          this.pushedAnything = true;
+        } else {
+          this.pushedAnything = false;
+        }
+        this.sink.push(timeMs, screen);
+      },
+    };
+  }
+
+  /** True when the next sample would actually be scanned. */
+  get scanning(): boolean {
+    return this.codecSupported && !this.dormant && this.enabled();
+  }
+
+  /**
+   * Feed one LOC video object.
+   *
+   * @param timestampUs - presentation time in microseconds (the LOC capture
+   *   timestamp, or the pipeline's derived fallback).
+   * @param payload - the object payload: 4-byte length-prefixed NALUs.
+   */
+  addVideoSample(timestampUs: number, payload: Uint8Array): void {
+    if (!this.codecSupported) {
+      return;
+    }
+
+    const isEnabled = this.enabled();
+    if (!isEnabled) {
+      if (this.wasEnabled) {
+        this.wasEnabled = false;
+        this.clearOverlay(timestampUs / 1000);
+      }
+      return;
+    }
+    if (!this.wasEnabled) {
+      // Captions were just turned back on: drop the stale parser state and
+      // re-arm the probe so a track that went dormant while they were off
+      // gets another look.
+      this.wasEnabled = true;
+      this.reset();
+    }
+
+    if (this.dormant) {
+      return;
+    }
+    if (payload.byteLength === 0) {
+      return;
+    }
+
+    const view = new DataView(
+      payload.buffer,
+      payload.byteOffset,
+      payload.byteLength,
+    );
+    this.source.addSample(timestampUs / 1_000_000, view, 0, payload.byteLength);
+
+    if (!this.sawCta608) {
+      if (this.hasCta608Sei(view, payload.byteLength)) {
+        this.sawCta608 = true;
+      } else if (++this.probed >= this.probeSamples) {
+        this.dormant = true;
+        this.logger.info(
+          `[cc608] no CTA-608 data in the first ${this.probeSamples} samples — ` +
+            "extraction disabled for this track",
+        );
+      }
+    }
+  }
+
+  /** Probe-window only: does this sample carry a CTA-608 SEI at all? */
+  private hasCta608Sei(view: DataView, size: number): boolean {
+    try {
+      return findCta608Nalus(view, 0, size).length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Drop all parser state and re-arm first-sight detection. Call on track
+   * switch, discontinuity (including a decoder reconfiguration), and dispose.
+   */
+  reset(): void {
+    this.source.reset();
+    this.rearm();
+  }
+
+  private rearm(): void {
+    this.probed = 0;
+    this.sawCta608 = false;
+    this.dormant = false;
+  }
+
+  private clearOverlay(timeMs: number): void {
+    if (!this.pushedAnything) {
+      return;
+    }
+    this.pushedAnything = false;
+    this.sink.push(timeMs, null);
+  }
+}

--- a/src/pipeline/webcodecsLocPipeline.ts
+++ b/src/pipeline/webcodecsLocPipeline.ts
@@ -18,6 +18,7 @@
 // AudioBufferSourceNode at the AudioContext-time computed from the same
 // wallclock anchor used by the video render loop.
 
+import { Cc608Sink } from "../cc608/types";
 import { buildAacConfigFromCatalog } from "../loc/aac";
 import {
   extractSequenceHeaderObu as extractAv1SequenceHeaderObu,
@@ -27,6 +28,7 @@ import {
   buildAvcDecoderConfigDescription,
   extractParameterSetsAndChunk as extractAvcParameterSetsAndChunk,
 } from "../loc/avc";
+import { LocCta608Extractor } from "../loc/cta608";
 import { getLocCaptureTimestampUs } from "../loc/extensions";
 import {
   buildHevcDecoderConfigDescription,
@@ -110,6 +112,15 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
 
   /** Counters surfaced via getLatencySnapshot. */
   private lastPresentedMs: number | null = null;
+
+  /**
+   * CTA-608 caption extraction. Null until a sink is attached — until then
+   * no video sample is scanned at all. `player.ts` attaches the overlay
+   * seam's channel here; the CC toggle drives `cc608Enabled`.
+   */
+  private cta608: LocCta608Extractor | null = null;
+  private cc608Sink: Cc608Sink | null = null;
+  private cc608Enabled = true;
 
   private bufferConfig: PipelineBufferConfig = {
     minimalBufferMs: 200,
@@ -289,6 +300,40 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     } else {
       this.routeAvcVideo(decoder, payload, timestampUs);
     }
+
+    // After the codec dispatch, so a parameter-set change has already reset
+    // the 608 parser before this sample's cc_data reaches it.
+    this.extractCta608(payload, timestampUs);
+  }
+
+  /**
+   * Attach (or detach) the CTA-608 caption sink. Until a sink is attached no
+   * video sample is scanned for captions at all.
+   */
+  setCc608Sink(sink: Cc608Sink | null): void {
+    this.cc608Sink = sink;
+    this.cta608 = null;
+  }
+
+  /** CC on/off, driven by the UI toggle. */
+  setCc608Enabled(enabled: boolean): void {
+    this.cc608Enabled = enabled;
+  }
+
+  private extractCta608(payload: Uint8Array, timestampUs: number): void {
+    const sink = this.cc608Sink;
+    if (!sink) {
+      return;
+    }
+    if (!this.cta608) {
+      this.cta608 = new LocCta608Extractor({
+        sink,
+        logger: this.logger,
+        codec: this.videoTrack?.codec,
+        enabled: () => this.cc608Enabled,
+      });
+    }
+    this.cta608.addVideoSample(timestampUs, payload);
   }
 
   private routeAvcVideo(
@@ -333,6 +378,10 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
         decoder.configure(config);
         this.lastSps = newSps;
         this.lastPps = newPps;
+        // A parameter-set change is the closest thing this pipeline has to a
+        // discontinuity signal; carrying 608 state across one risks showing a
+        // stale caption rather than none.
+        this.cta608?.reset();
         this.logger.info(
           `[WebCodecsLoc] VideoDecoder configured (codec=${codec}` +
             (catalogCodec !== codec
@@ -418,6 +467,9 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
         this.lastVps = newVps;
         this.lastSps = newSps;
         this.lastPps = newPps;
+        // See the AVC path: treat a parameter-set change as a discontinuity
+        // for caption state too.
+        this.cta608?.reset();
         this.logger.info(
           `[WebCodecsLoc] VideoDecoder configured (codec=${codec}` +
             (catalogCodec !== codec
@@ -657,6 +709,10 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     this.lastAv1SeqHeader = null;
     this.anchorWallMs = null;
     this.lastPresentedMs = null;
+
+    this.cta608?.reset();
+    this.cta608 = null;
+    this.cc608Sink = null;
   }
 
   /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Closes #161. Part of #157.

Extracts CTA-608 `cc_data` on the **WebCodecs LOC** path and pushes screen snapshots into the overlay seam's shape, per the contract settled in #158 / #159.

## What landed

**`src/cc608/` — the shared, container-agnostic caption source** (the file set #162 also owns; written to the agreed contract so the two branches merge cleanly)

- `types.ts` — `Cc608Snapshot` / `Cc608Row` / `Cc608Cell` / `Cc608PenState` / `Cc608Sink`, exactly as specified in the seam contract.
- `source.ts` — `Cc608Source`, implementing #159 §5:
  - `parser.addData(timeSec, fieldData[0])` — **seconds**, and CC1 on field 1 (`new Cta608Parser(1, handler, null)`).
  - `parser.cueSplitAtTime(timeSec)` — the public path that hands over the **live** screen, so a caption is pushed on the very sample that completes its flip instead of one screen (~1 s) later.
  - Nothing fired → the live screen is empty → `sink.push(timeMs, null)`.
  - `newCue`'s start/end are ignored (they are unusable: `cueSplitAtTime` resets `cueStartTime` every call); the sample's own presentation time is authoritative.
  - The `CaptionScreen` is deep-copied into a plain snapshot on every cue; the reference is never retained.

**`src/loc/cta608.ts` — the LOC-side gate**, three layers, cheapest first:

1. **Codec** — AVC/HEVC only. AV1 never scans a byte (no 608 carriage, no cml metadata-OBU path).
2. **`enabled` predicate** — injectable, so #165's CC toggle plugs straight in. Off means zero scanning, plus a single overlay clear.
3. **First-sight detection** — a bounded probe window (`CTA608_PROBE_SAMPLES = 200`, ~4–8 s). If no CTA-608 SEI appears within it the track goes dormant and the per-sample cost drops to one boolean test. The probe re-arms on `reset()` and whenever `enabled` flips false → true. Signal is the *presence of 608 SEI* (`findCta608Nalus`, probe window only), not the first displayed caption, so a captioned track whose first pop-on lands late still stays awake.

**`src/pipeline/webcodecsLocPipeline.ts` — the wiring**

- `setCc608Sink(sink)` / `setCc608Enabled(flag)`; the extractor is built lazily on first use and nothing is scanned until a sink is attached. `IPlaybackPipeline` and `PipelineSetupOptions` are untouched, so this does not collide with the MSE branch.
- Fed from `routeObject` **after** the codec dispatch, using the same `timestampUs` the decoder gets (`getLocCaptureTimestampUs`, LOC extension `0x06`, or the derived fallback).
- Lifecycle: reset on AVC/HEVC parameter-set change (the pipeline's closest discontinuity signal) and on `dispose()`; `Cc608Source.reset()` builds a fresh parser, so a mid-group join cannot flip a stale caption.

**Dependency**: `@svta/cml-608@^1.0.3`, plus `src/types/svta-cml-608.d.ts` (needed under `moduleResolution: "node"`) and a `NOTICE` entry. Jest and webpack need no configuration.

## Tests

`src/loc/cta608.test.ts` builds synthetic LOC video objects — 4-byte length-prefixed NALUs, a coded slice plus an ATSC A/53 `cc_data` SEI — and runs the whole matrix over **AVC and HEVC**, including a test asserting the two produce byte-identical push sequences. Coverage includes the three cml traps: rows are exactly 32 cells wide (cml's `Row` is 100), a default-styled space is indistinguishable from an untouched cell, and `setPAC` stamps a pen onto the cell under the cursor before anything is typed.

`npm run typecheck`, `npm run lint`, `npm test`, `npm run build`, `prettier --check` all green.

## Note for #164

The sample that *erases* the display still counts as "fired": cml's own late `newCue` hands over the screen that was just erased, which dedupes away, so the overlay clear lands on the **following** sample — one frame, ~20–40 ms. This follows #159 §5 literally ("no suppression logic is needed"); suppressing non-split cues would remove the lag if it ever matters.

Player-level wiring (attaching the overlay channel as the sink, the CC toggle) belongs to #164 / #165; on-screen verification to #166.
