### PR TITLE
feat(overlay): add the timed-text overlay seam and CTA-608 renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Timed-text overlay seam (`src/overlay`): a snapshot timeline with `push`
+  (open-ended state) and `addCue` (intervals) channels, resolved by search
+  against the picture clock, plus a CTA-608 renderer that paints screens on
+  the true 32x15 grid.
+- `IPlaybackPipeline.getPresentationTimeMs()` — the presentation time of the
+  picture on screen, implemented by both render engines.
+
 ## [0.12.0] - 2026-07-06
 
 See the README for details on the catalog, packaging, and buffer control.

--- a/src/index.html
+++ b/src/index.html
@@ -122,6 +122,17 @@
         margin-bottom: 2rem;
       }
 
+      /* Timed-text / graphics overlay. Spans the whole player section; the
+         renderers lay out inside the computed picture rect, never the
+         element box. Below the engine legend, above the media. */
+      .caption-overlay {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        overflow: hidden;
+        z-index: 4;
+      }
+
       .engine-legend {
         position: absolute;
         top: 0.5rem;
@@ -719,6 +730,11 @@
           muted
           playsinline
         ></video>
+        <div
+          id="captionOverlay"
+          class="caption-overlay"
+          aria-hidden="true"
+        ></div>
         <div id="engineLegend" class="engine-legend" aria-live="polite"></div>
         <div class="controls-section">
           <button id="startBtn" class="btn btn-primary" disabled>

--- a/src/overlay/domOverlayLayer.test.ts
+++ b/src/overlay/domOverlayLayer.test.ts
@@ -1,0 +1,262 @@
+import { CC608_COLS, type Cc608Cell, type Cc608Snapshot } from "../cc608/types";
+
+import { DomOverlayLayer } from "./overlayLayer";
+import { Cta608Renderer, computeGrid } from "./renderers/cta608";
+import { asDom, FakeCanvas, FakeDocument, FakeElement } from "./testFakeDom";
+
+import type { MediaRect, OverlayRenderer, PresentationMs } from "./index";
+
+/** Records what the layer asked it to paint. */
+class RecordingRenderer implements OverlayRenderer<unknown> {
+  mounts = 0;
+  unmounts = 0;
+  readonly calls: Array<{
+    state: unknown;
+    rect: MediaRect;
+    nowMs: PresentationMs;
+  }> = [];
+  root: FakeElement | null = null;
+
+  mount(root: HTMLElement): void {
+    this.mounts++;
+    this.root = asDom<FakeElement>(root);
+  }
+
+  render(state: unknown, rect: MediaRect, nowMs: PresentationMs): void {
+    this.calls.push({ state, rect, nowMs });
+  }
+
+  unmount(): void {
+    this.unmounts++;
+  }
+}
+
+interface Harness {
+  layer: DomOverlayLayer;
+  container: FakeElement;
+  surface: FakeCanvas;
+  setClockValue(ms: number | null): void;
+}
+
+function makeHarness(): Harness {
+  const doc = new FakeDocument();
+  const container = doc.createElement("div");
+  container.setBox(0, 0, 1280, 800);
+
+  const surface = new FakeCanvas(doc);
+  surface.width = 1920;
+  surface.height = 1080;
+  // 16:9 surface at the top of a taller container (controls sit below).
+  surface.setBox(0, 0, 1280, 720);
+
+  let clockValue: number | null = null;
+  // A no-op scheduler: tick() is driven explicitly so the tests are
+  // deterministic and need no rAF.
+  const layer = new DomOverlayLayer(asDom<HTMLElement>(container), {
+    requestFrame: () => 1,
+    cancelFrame: () => undefined,
+  });
+  layer.setSurface(asDom<HTMLCanvasElement>(surface));
+  layer.setClock(() => clockValue);
+
+  return {
+    layer,
+    container,
+    surface,
+    setClockValue: (ms) => {
+      clockValue = ms;
+    },
+  };
+}
+
+describe("DomOverlayLayer", () => {
+  it("mounts a renderer into its own subtree of the container", () => {
+    const h = makeHarness();
+    const renderer = new RecordingRenderer();
+    h.layer.attach("cc608", renderer, "state");
+
+    expect(renderer.mounts).toBe(1);
+    expect(h.container.children).toHaveLength(1);
+    expect(renderer.root).toBe(h.container.children[0]);
+    expect(h.container.children[0].dataset.overlayRenderer).toBe("cc608");
+    expect(h.container.children[0].style.pointerEvents).toBe("none");
+  });
+
+  it("renders on change only, not on every tick", () => {
+    const h = makeHarness();
+    const renderer = new RecordingRenderer();
+    const channel = h.layer.attach<string>("cc608", renderer, "state");
+
+    h.setClockValue(1000);
+    channel.push(1000, "screen-1");
+    h.layer.tick();
+    h.layer.tick();
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(1);
+    expect(renderer.calls[0].state).toBe("screen-1");
+
+    h.setClockValue(1500); // same resolved screen — no repaint
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(1);
+
+    channel.push(2000, "screen-2");
+    h.setClockValue(2000);
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(2);
+    expect(renderer.calls[1].state).toBe("screen-2");
+  });
+
+  it("lays out inside the picture rect, not the container box", () => {
+    const h = makeHarness();
+    const renderer = new RecordingRenderer();
+    h.layer.attach("cc608", renderer, "state");
+    h.setClockValue(0);
+    h.layer.tick();
+
+    // Container is 1280x800, surface 1280x720 with 16:9 content: the picture
+    // fills the surface box and does not extend over the controls below it.
+    expect(renderer.calls[0].rect).toEqual({ x: 0, y: 0, w: 1280, h: 720 });
+  });
+
+  it("repaints when the picture rect changes", () => {
+    const h = makeHarness();
+    const renderer = new RecordingRenderer();
+    const channel = h.layer.attach<string>("cc608", renderer, "state");
+    h.setClockValue(1000);
+    channel.push(0, "screen");
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(1);
+
+    h.surface.setBox(0, 0, 640, 360);
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(2);
+    expect(renderer.calls[1].rect).toEqual({ x: 0, y: 0, w: 640, h: 360 });
+  });
+
+  it("renders nothing while the clock has no picture yet", () => {
+    const h = makeHarness();
+    const renderer = new RecordingRenderer();
+    const channel = h.layer.attach<string>("cc608", renderer, "state");
+    channel.push(1000, "screen");
+    h.setClockValue(null);
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(1);
+    expect(renderer.calls[0].state).toBeNull();
+  });
+
+  it("clears channel state and re-mounts on reset()", () => {
+    const h = makeHarness();
+    const renderer = new RecordingRenderer();
+    const channel = h.layer.attach<string>("cc608", renderer, "state");
+    h.setClockValue(1000);
+    channel.push(0, "stale-screen");
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(1);
+
+    h.layer.reset();
+    expect(renderer.unmounts).toBe(1);
+    expect(renderer.mounts).toBe(2);
+
+    // A stale caption from before a namespace switch must not come back.
+    h.layer.tick();
+    expect(renderer.calls[renderer.calls.length - 1].state).toBeNull();
+  });
+
+  it("stops painting while disabled and repaints on re-enable", () => {
+    const h = makeHarness();
+    const renderer = new RecordingRenderer();
+    const channel = h.layer.attach<string>("cc608", renderer, "state");
+    h.setClockValue(1000);
+    channel.push(0, "screen");
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(1);
+
+    h.layer.setEnabled(false);
+    expect(h.layer.isEnabled()).toBe(false);
+    expect(h.container.style.display).toBe("none");
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(1);
+
+    h.layer.setEnabled(true);
+    h.layer.tick();
+    expect(renderer.calls).toHaveLength(2);
+    expect(h.container.style.display).toBe("");
+  });
+
+  it("unmounts and removes the subtree on detach and dispose", () => {
+    const h = makeHarness();
+    const renderer = new RecordingRenderer();
+    h.layer.attach("cc608", renderer, "state");
+    h.layer.detach("cc608");
+    expect(renderer.unmounts).toBe(1);
+    expect(h.container.children).toHaveLength(0);
+
+    const other = new RecordingRenderer();
+    h.layer.attach("cc608", other, "state");
+    h.layer.dispose();
+    expect(other.unmounts).toBe(1);
+    expect(h.container.children).toHaveLength(0);
+    // Disposed layers are inert.
+    h.layer.tick();
+    expect(other.calls).toHaveLength(0);
+  });
+});
+
+/* --- the CTA-608 renderer against the layer ----------------------------- */
+
+function snapshotWith(
+  text: string,
+  col: number,
+  rowIndex: number,
+): Cc608Snapshot {
+  const cells: Cc608Cell[] = Array.from({ length: CC608_COLS }, () => ({
+    uchar: " ",
+    pen: {
+      foreground: "white",
+      background: "black",
+      underline: false,
+      italics: false,
+      flash: false,
+    },
+  }));
+  for (let i = 0; i < text.length; i++) {
+    cells[col + i] = { uchar: text[i], pen: cells[col + i].pen };
+  }
+  return { rows: [{ row: rowIndex, cells }] };
+}
+
+describe("Cta608Renderer through the layer", () => {
+  it("emits one positioned box per style run and clears on an empty screen", () => {
+    const h = makeHarness();
+    const renderer = new Cta608Renderer();
+    const channel = h.layer.attach<Cc608Snapshot>("cc608", renderer, "state");
+    const root = h.container.children[0];
+
+    h.setClockValue(1000);
+    channel.push(0, snapshotWith("HELLO", 10, 14));
+    h.layer.tick();
+
+    expect(root.children).toHaveLength(1);
+    const box = root.children[0];
+    const grid = computeGrid({ x: 0, y: 0, w: 1280, h: 720 });
+    expect(box.style.left).toBe(`${grid.x + 10 * grid.cellW}px`);
+    expect(box.style.top).toBe(`${grid.y + 14 * grid.cellH}px`);
+    expect(box.style.width).toBe(`${5 * grid.cellW}px`);
+    expect(box.style.height).toBe(`${grid.cellH}px`);
+    // The box IS the background.
+    expect(box.style.background).toBe("#000000");
+    expect(box.style.overflow).toBe("hidden");
+
+    const inner = box.children[0];
+    expect(inner.textContent).toBe("HELLO");
+    expect(inner.style.transformOrigin).toBe("left top");
+    expect(inner.style.whiteSpace).toBe("pre");
+    expect(inner.style.color).toBe("#ffffff");
+
+    // A null push clears the overlay from that time onward.
+    channel.push(2000, null);
+    h.setClockValue(2000);
+    h.layer.tick();
+    expect(root.children).toHaveLength(0);
+  });
+});

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -1,0 +1,129 @@
+// The overlay seam — the single contract between anything that produces
+// timed presentation state (CTA-608, WebVTT, IMSC-1, ograf) and anything
+// that paints it over the picture.
+//
+// Settled in Eyevinn/warp-player#159. The shape in one paragraph:
+//
+//   A *channel* is how a source feeds the seam. It comes in two modes.
+//   "state" channels (`push`) carry open-ended state that is superseded by
+//   the next push — CTA-608 has no end times, so this is its only option.
+//   "cues" channels (`addCue`) carry intervals, and the seam composes
+//   overlapping cues into an active set. Both normalise onto one internal
+//   snapshot timeline that is resolved **by search** at the playhead, so
+//   pauses, rate changes, seeks and discontinuities need no special case.
+//
+//   The clock is the *picture clock* — the presentation time of the frame
+//   actually on screen (`IPlaybackPipeline.getPresentationTimeMs()`). It
+//   freezes on a stall, so both render engines behave identically.
+//
+//   A *renderer* owns a DOM subtree and is called on change only, never per
+//   frame. It lays out inside the `MediaRect` — the letterboxed picture box
+//   inside the active surface — and never inside the element box.
+
+/** Presentation time in ms on the media timeline (UTC-epoch under mlmpub). */
+export type PresentationMs = number;
+
+/**
+ * The picture box inside the overlay container, in CSS pixels relative to
+ * the container's top-left corner. Derived from the active surface's
+ * intrinsic size under `object-fit: contain`, so it excludes letterbox and
+ * pillarbox bars.
+ */
+export interface MediaRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Channel modes. See the file header. */
+export type ChannelMode = "state" | "cues";
+
+/**
+ * Open-ended state: each push supersedes the previous one from `fromMs`
+ * onward. `null` clears. Used by CTA-608 and (in future) ograf.
+ */
+export interface StateChannel<T> {
+  readonly mode: "state";
+  push(fromMs: PresentationMs, payload: T | null): void;
+  clear(): void;
+}
+
+/**
+ * Interval cues: the seam composes overlapping cues into the active set at
+ * every change point. Used by WebVTT and IMSC-1.
+ */
+export interface CueChannel<T> {
+  readonly mode: "cues";
+  addCue(startMs: PresentationMs, endMs: PresentationMs, payload: T): void;
+  clear(): void;
+}
+
+export type Channel<T> = StateChannel<T> | CueChannel<T>;
+
+/** Resolved state handed to a "state" renderer. */
+export type StateOf<T> = T | null;
+/** Resolved state handed to a "cues" renderer. */
+export type CuesOf<T> = readonly T[];
+
+/**
+ * A renderer owns one DOM subtree under the overlay and touches nothing
+ * outside it.
+ */
+export interface OverlayRenderer<S> {
+  /** Called once on attach, and again after `OverlayLayer.reset()`. */
+  mount(root: HTMLElement): void;
+  /**
+   * Called when the resolved state changes or the media rect changes.
+   * **Not** per frame. A renderer needing continuous animation runs its own
+   * rAF inside its own subtree.
+   *
+   * `nowMs` lets a renderer position itself correctly when a snapshot
+   * activates mid-interval.
+   */
+  render(state: S, rect: MediaRect, nowMs: PresentationMs): void;
+  /** Called on detach/dispose. Must leave the root empty. */
+  unmount(): void;
+}
+
+export interface OverlayLayer {
+  /** Attach a renderer fed by an open-ended state channel. */
+  attach<T>(
+    id: string,
+    renderer: OverlayRenderer<StateOf<T>>,
+    mode: "state",
+  ): StateChannel<T>;
+  /** Attach a renderer fed by an interval-cue channel. */
+  attach<T>(
+    id: string,
+    renderer: OverlayRenderer<CuesOf<T>>,
+    mode: "cues",
+  ): CueChannel<T>;
+
+  detach(id: string): void;
+
+  /** Bind to whichever surface the active pipeline draws into. */
+  setSurface(surface: HTMLVideoElement | HTMLCanvasElement | null): void;
+
+  /** Wire the picture clock, normally `() => pipeline.getPresentationTimeMs()`. */
+  setClock(clock: (() => PresentationMs | null) | null): void;
+
+  /**
+   * Show or hide the whole overlay without losing channel state. The
+   * entry point the CC toggle (#165) drives.
+   */
+  setEnabled(enabled: boolean): void;
+
+  /** True when the overlay is currently showing. */
+  isEnabled(): boolean;
+
+  /**
+   * Drop every channel timeline and re-mount renderers to an empty state.
+   * Called on engine switch, namespace switch, track switch and pipeline
+   * dispose. Parser reset is the *source's* business — the seam has no parser.
+   */
+  reset(): void;
+
+  /** Unmount renderers, drop the DOM subtrees, stop the resolution loop. */
+  dispose(): void;
+}

--- a/src/overlay/mediaRect.test.ts
+++ b/src/overlay/mediaRect.test.ts
@@ -1,0 +1,73 @@
+import { computeMediaRect, rectsEqual } from "./mediaRect";
+
+describe("computeMediaRect", () => {
+  const box = { x: 0, y: 0, w: 1100, h: 619 };
+
+  it("fills the box when the media aspect matches it", () => {
+    const rect = computeMediaRect({ x: 0, y: 0, w: 1600, h: 900 }, 1920, 1080);
+    expect(rect).toEqual({ x: 0, y: 0, w: 1600, h: 900 });
+  });
+
+  it("pillarboxes a 4:3 picture in a 16:9 box", () => {
+    const rect = computeMediaRect(box, 640, 480);
+    // Full height, width = h * 4/3, centred horizontally.
+    expect(rect.h).toBeCloseTo(619, 6);
+    expect(rect.w).toBeCloseTo((619 * 4) / 3, 6);
+    expect(rect.y).toBeCloseTo(0, 6);
+    expect(rect.x).toBeCloseTo((1100 - (619 * 4) / 3) / 2, 6);
+    // Bars are symmetric.
+    expect(rect.x + rect.w).toBeCloseTo(1100 - rect.x, 6);
+  });
+
+  it("letterboxes a 21:9 picture in a 16:9 box", () => {
+    const rect = computeMediaRect(box, 2560, 1080);
+    expect(rect.w).toBeCloseTo(1100, 6);
+    expect(rect.h).toBeCloseTo(1100 / (2560 / 1080), 6);
+    expect(rect.x).toBeCloseTo(0, 6);
+    expect(rect.y).toBeCloseTo((619 - rect.h) / 2, 6);
+    expect(rect.y + rect.h).toBeCloseTo(619 - rect.y, 6);
+  });
+
+  it("keeps the surface offset inside the overlay container", () => {
+    // The overlay container spans the whole player section, so the surface
+    // box is offset within it; the picture rect must carry that offset.
+    const rect = computeMediaRect({ x: 12, y: 34, w: 1100, h: 619 }, 640, 480);
+    const centred = computeMediaRect(box, 640, 480);
+    expect(rect.x).toBeCloseTo(centred.x + 12, 6);
+    expect(rect.y).toBeCloseTo(centred.y + 34, 6);
+    expect(rect.w).toBeCloseTo(centred.w, 6);
+    expect(rect.h).toBeCloseTo(centred.h, 6);
+  });
+
+  it("falls back to the element box when the intrinsic size is unknown", () => {
+    // A <video> before metadata, or a canvas that has not been sized yet.
+    expect(computeMediaRect(box, 0, 0)).toEqual(box);
+    expect(computeMediaRect(box, 1920, 0)).toEqual(box);
+    expect(computeMediaRect(box, NaN, 1080)).toEqual(box);
+  });
+
+  it("returns a zero rect for an unlaid-out box", () => {
+    expect(computeMediaRect({ x: 0, y: 0, w: 0, h: 0 }, 1920, 1080)).toEqual({
+      x: 0,
+      y: 0,
+      w: 0,
+      h: 0,
+    });
+  });
+});
+
+describe("rectsEqual", () => {
+  const a = { x: 1, y: 2, w: 3, h: 4 };
+
+  it("compares within a sub-pixel epsilon", () => {
+    expect(rectsEqual(a, { ...a })).toBe(true);
+    expect(rectsEqual(a, { ...a, w: 3.0001 })).toBe(true);
+    expect(rectsEqual(a, { ...a, w: 3.5 })).toBe(false);
+  });
+
+  it("treats null as its own value", () => {
+    expect(rectsEqual(null, null)).toBe(true);
+    expect(rectsEqual(a, null)).toBe(false);
+    expect(rectsEqual(null, a)).toBe(false);
+  });
+});

--- a/src/overlay/mediaRect.ts
+++ b/src/overlay/mediaRect.ts
@@ -1,0 +1,148 @@
+// Geometry for the overlay: where the *picture* actually is.
+//
+// The overlay container spans the whole `.player-section`, but captions have
+// to be laid out against the letterboxed picture inside the active surface —
+// a 4:3 stream in a 16:9 element must not put its caption grid over the
+// pillarbox bars. Both surfaces we bind to (`<video>` for MSE, `<canvas>`
+// for WebCodecs) render their content with `object-fit: contain`, so the
+// picture box follows from the intrinsic size alone.
+
+import type { MediaRect } from "./index";
+
+/** The surfaces a pipeline can draw into. */
+export type OverlaySurface = HTMLVideoElement | HTMLCanvasElement;
+
+/** A box in the overlay container's coordinate space. */
+export interface Box {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * `object-fit: contain` — the picture rect inside an element box.
+ *
+ * `box` is the element's border box expressed in the overlay container's
+ * coordinate space. `intrinsicW`/`intrinsicH` are the media's natural
+ * dimensions; when either is unknown (0, NaN, or before the first frame)
+ * the whole element box is returned, which is the right answer for a
+ * surface that has not sized itself yet.
+ */
+export function computeMediaRect(
+  box: Box,
+  intrinsicW: number,
+  intrinsicH: number,
+): MediaRect {
+  const boxW = Math.max(0, box.w);
+  const boxH = Math.max(0, box.h);
+  if (
+    !Number.isFinite(intrinsicW) ||
+    !Number.isFinite(intrinsicH) ||
+    intrinsicW <= 0 ||
+    intrinsicH <= 0 ||
+    boxW <= 0 ||
+    boxH <= 0
+  ) {
+    return { x: box.x, y: box.y, w: boxW, h: boxH };
+  }
+
+  const mediaAspect = intrinsicW / intrinsicH;
+  const boxAspect = boxW / boxH;
+  let w: number;
+  let h: number;
+  if (mediaAspect > boxAspect) {
+    // Wider than the box: full width, letterboxed top and bottom.
+    w = boxW;
+    h = boxW / mediaAspect;
+  } else {
+    // Taller than the box: full height, pillarboxed left and right.
+    h = boxH;
+    w = boxH * mediaAspect;
+  }
+  return {
+    x: box.x + (boxW - w) / 2,
+    y: box.y + (boxH - h) / 2,
+    w,
+    h,
+  };
+}
+
+/** Intrinsic media dimensions of a surface, or 0x0 when not yet known. */
+export function surfaceIntrinsicSize(surface: OverlaySurface): {
+  w: number;
+  h: number;
+} {
+  // Duck-typed rather than `instanceof HTMLCanvasElement` so this module can
+  // be imported (and unit-tested) outside a DOM.
+  if ("videoWidth" in surface) {
+    return { w: surface.videoWidth, h: surface.videoHeight };
+  }
+  return { w: surface.width, h: surface.height };
+}
+
+/**
+ * The picture rect of `surface`, in `container`'s coordinate space.
+ * Returns null when the surface is not laid out (zero-sized or detached).
+ */
+export function getMediaRect(
+  surface: OverlaySurface,
+  container: HTMLElement,
+): MediaRect | null {
+  const surfaceBox = surface.getBoundingClientRect();
+  if (surfaceBox.width <= 0 || surfaceBox.height <= 0) {
+    return null;
+  }
+  const containerBox = container.getBoundingClientRect();
+  const box: Box = {
+    x: surfaceBox.left - containerBox.left,
+    y: surfaceBox.top - containerBox.top,
+    w: surfaceBox.width,
+    h: surfaceBox.height,
+  };
+  const intrinsic = surfaceIntrinsicSize(surface);
+  return computeMediaRect(box, intrinsic.w, intrinsic.h);
+}
+
+/** True when two rects are equal to within a sub-pixel epsilon. */
+export function rectsEqual(
+  a: MediaRect | null,
+  b: MediaRect | null,
+  epsilon = 0.01,
+): boolean {
+  if (a === null || b === null) {
+    return a === b;
+  }
+  return (
+    Math.abs(a.x - b.x) < epsilon &&
+    Math.abs(a.y - b.y) < epsilon &&
+    Math.abs(a.w - b.w) < epsilon &&
+    Math.abs(a.h - b.h) < epsilon
+  );
+}
+
+/**
+ * Recompute-on-resize plumbing. Observes both the surface and the container
+ * (the surface can stay the same size while the container moves) and calls
+ * `onResize` whenever either changes. Returns a disposer.
+ *
+ * Falls back to a window `resize` listener where ResizeObserver is missing.
+ */
+export function observeSurfaceSize(
+  surface: OverlaySurface,
+  container: HTMLElement,
+  onResize: () => void,
+): () => void {
+  if (typeof ResizeObserver === "function") {
+    const observer = new ResizeObserver(() => onResize());
+    observer.observe(surface);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+  const handler = (): void => onResize();
+  window.addEventListener("resize", handler);
+  return () => window.removeEventListener("resize", handler);
+}

--- a/src/overlay/overlayLayer.test.ts
+++ b/src/overlay/overlayLayer.test.ts
@@ -1,0 +1,184 @@
+import {
+  CueChannelImpl,
+  SnapshotTimeline,
+  StateChannelImpl,
+} from "./overlayLayer";
+
+describe("SnapshotTimeline", () => {
+  it("resolves the latest point at or before the playhead", () => {
+    const timeline = new SnapshotTimeline<string | null>(null);
+    timeline.set(1000, "a");
+    timeline.set(2000, "b");
+    timeline.set(3000, "c");
+
+    expect(timeline.resolve(999)).toBeNull();
+    expect(timeline.resolve(1000)).toBe("a"); // boundary is inclusive
+    expect(timeline.resolve(1999)).toBe("a");
+    expect(timeline.resolve(2000)).toBe("b");
+    expect(timeline.resolve(9999)).toBe("c");
+  });
+
+  it("keeps points ordered regardless of insertion order", () => {
+    const timeline = new SnapshotTimeline<string | null>(null);
+    timeline.set(3000, "c");
+    timeline.set(1000, "a");
+    timeline.set(2000, "b");
+    expect(timeline.resolve(2500)).toBe("b");
+    expect(timeline.resolve(1500)).toBe("a");
+    expect(timeline.size).toBe(3);
+  });
+
+  it("replaces rather than duplicates a point at the same time", () => {
+    const timeline = new SnapshotTimeline<string | null>(null);
+    timeline.set(1000, "a");
+    timeline.set(1000, "a2");
+    expect(timeline.size).toBe(1);
+    expect(timeline.resolve(1000)).toBe("a2");
+  });
+
+  it("resolves by search, so a backwards jump needs no special case", () => {
+    const timeline = new SnapshotTimeline<string | null>(null);
+    for (let t = 0; t < 10_000; t += 1000) {
+      timeline.set(t, `s${t}`);
+    }
+    // Walk forward, jump back, walk forward again — every answer is exact.
+    expect(timeline.resolve(8500)).toBe("s8000");
+    expect(timeline.resolve(1500)).toBe("s1000");
+    expect(timeline.resolve(0)).toBe("s0");
+    expect(timeline.resolve(9999)).toBe("s9000");
+  });
+
+  it("resolves to the empty state when there is no picture yet", () => {
+    const timeline = new SnapshotTimeline<string | null>(null);
+    timeline.set(1000, "a");
+    expect(timeline.resolve(null)).toBeNull();
+    expect(timeline.resolve(NaN)).toBeNull();
+  });
+
+  it("retains the active point plus everything after it", () => {
+    const timeline = new SnapshotTimeline<string | null>(null);
+    timeline.set(0, "a");
+    timeline.set(1000, "b");
+    timeline.set(2000, "c");
+    timeline.set(3000, "d");
+
+    timeline.prune(2500);
+    // "c" is active at 2500 and must survive along with the future "d".
+    expect(timeline.size).toBe(2);
+    expect(timeline.resolve(2500)).toBe("c");
+    expect(timeline.resolve(3000)).toBe("d");
+    // Everything before the active point is gone.
+    expect(timeline.resolve(0)).toBeNull();
+  });
+
+  it("does not prune without a clock", () => {
+    const timeline = new SnapshotTimeline<string | null>(null);
+    timeline.set(0, "a");
+    timeline.set(1000, "b");
+    timeline.prune(null);
+    expect(timeline.size).toBe(2);
+  });
+
+  it("ignores non-finite times", () => {
+    const timeline = new SnapshotTimeline<string | null>(null);
+    timeline.set(NaN, "a");
+    timeline.set(Infinity, "b");
+    expect(timeline.size).toBe(0);
+  });
+});
+
+describe("StateChannelImpl", () => {
+  it("supersedes the previous payload from the push time onward", () => {
+    const channel = new StateChannelImpl<string>();
+    channel.push(1000, "screen-1");
+    channel.push(2000, "screen-2");
+
+    expect(channel.mode).toBe("state");
+    expect(channel.resolve(500)).toBeNull();
+    expect(channel.resolve(1500)).toBe("screen-1");
+    expect(channel.resolve(2500)).toBe("screen-2");
+  });
+
+  it("clears the overlay on a null push", () => {
+    const channel = new StateChannelImpl<string>();
+    channel.push(1000, "screen-1");
+    channel.push(2000, null);
+    expect(channel.resolve(1999)).toBe("screen-1");
+    expect(channel.resolve(2000)).toBeNull();
+  });
+
+  it("drops everything on clear()", () => {
+    const channel = new StateChannelImpl<string>();
+    channel.push(1000, "screen-1");
+    channel.clear();
+    expect(channel.size).toBe(0);
+    expect(channel.resolve(5000)).toBeNull();
+  });
+});
+
+describe("CueChannelImpl", () => {
+  it("resolves a single cue over its interval only", () => {
+    const channel = new CueChannelImpl<string>();
+    channel.addCue(1000, 2000, "one");
+
+    expect(channel.mode).toBe("cues");
+    expect(channel.resolve(999)).toEqual([]);
+    expect(channel.resolve(1000)).toEqual(["one"]);
+    expect(channel.resolve(1999)).toEqual(["one"]);
+    expect(channel.resolve(2000)).toEqual([]);
+  });
+
+  it("composes overlapping cues into the active set, ordered by start", () => {
+    const channel = new CueChannelImpl<string>();
+    channel.addCue(1000, 3000, "a");
+    channel.addCue(2000, 4000, "b");
+
+    expect(channel.resolve(1500)).toEqual(["a"]);
+    expect(channel.resolve(2500)).toEqual(["a", "b"]);
+    expect(channel.resolve(3500)).toEqual(["b"]);
+    expect(channel.resolve(4000)).toEqual([]);
+  });
+
+  it("composes cues added out of order", () => {
+    const channel = new CueChannelImpl<string>();
+    channel.addCue(2000, 4000, "b");
+    channel.addCue(1000, 3000, "a");
+    expect(channel.resolve(2500)).toEqual(["a", "b"]);
+  });
+
+  it("returns a reference-stable set inside one interval", () => {
+    // The layer decides "changed" by reference, so a stable interval must
+    // not produce a new array on every tick.
+    const channel = new CueChannelImpl<string>();
+    channel.addCue(1000, 2000, "one");
+    expect(channel.resolve(1200)).toBe(channel.resolve(1800));
+  });
+
+  it("ignores degenerate and non-finite cues", () => {
+    const channel = new CueChannelImpl<string>();
+    channel.addCue(1000, 1000, "zero-length");
+    channel.addCue(2000, 1000, "reversed");
+    channel.addCue(NaN, 1000, "nan");
+    expect(channel.size).toBe(0);
+  });
+
+  it("retains cues active now or later, drops the rest", () => {
+    const channel = new CueChannelImpl<string>();
+    channel.addCue(0, 1000, "past");
+    channel.addCue(1000, 3000, "active");
+    channel.addCue(5000, 6000, "future");
+
+    channel.prune(2000);
+    expect(channel.size).toBe(2);
+    expect(channel.resolve(2000)).toEqual(["active"]);
+    expect(channel.resolve(5500)).toEqual(["future"]);
+  });
+
+  it("drops everything on clear()", () => {
+    const channel = new CueChannelImpl<string>();
+    channel.addCue(1000, 2000, "one");
+    channel.clear();
+    expect(channel.size).toBe(0);
+    expect(channel.resolve(1500)).toEqual([]);
+  });
+});

--- a/src/overlay/overlayLayer.ts
+++ b/src/overlay/overlayLayer.ts
@@ -1,0 +1,491 @@
+// The overlay seam itself: channels, the snapshot timeline, resolution
+// against the picture clock, surface binding, and renderer hosting.
+//
+// See ./index.ts for the contract and Eyevinn/warp-player#159 for why it is
+// shaped this way. The two rules that drive the whole implementation:
+//
+//   1. Resolution is **by search**, never by assuming the clock advanced
+//      monotonically since the last tick. Seeks, rate changes, stalls and
+//      discontinuities then need no special case.
+//   2. Renderers are called **on change only** — when the resolved state or
+//      the media rect differs from what was last painted.
+
+import {
+  getMediaRect,
+  observeSurfaceSize,
+  rectsEqual,
+  type OverlaySurface,
+} from "./mediaRect";
+
+import type {
+  ChannelMode,
+  CueChannel,
+  CuesOf,
+  MediaRect,
+  OverlayLayer,
+  OverlayRenderer,
+  PresentationMs,
+  StateChannel,
+  StateOf,
+} from "./index";
+
+/** One point on a channel's timeline: the resolved state from `fromMs` on. */
+interface TimelineEntry<S> {
+  fromMs: PresentationMs;
+  payload: S;
+}
+
+/**
+ * An ordered list of (time, state) points, resolved by binary search.
+ *
+ * Both channel modes normalise onto this. Entries are kept sorted by
+ * `fromMs`; a push at an existing time replaces that entry rather than
+ * appending a duplicate, so a source that re-pushes at the same timestamp
+ * cannot grow the timeline without bound.
+ */
+export class SnapshotTimeline<S> {
+  private entries: TimelineEntry<S>[] = [];
+
+  constructor(private readonly emptyState: S) {}
+
+  /** Number of retained points. Test/diagnostic use. */
+  get size(): number {
+    return this.entries.length;
+  }
+
+  /** Insert or replace the point at `fromMs`. */
+  set(fromMs: PresentationMs, payload: S): void {
+    if (!Number.isFinite(fromMs)) {
+      return;
+    }
+    const idx = this.indexAtOrBefore(fromMs);
+    if (idx >= 0 && this.entries[idx].fromMs === fromMs) {
+      this.entries[idx] = { fromMs, payload };
+      return;
+    }
+    this.entries.splice(idx + 1, 0, { fromMs, payload });
+  }
+
+  /** Replace the whole timeline with an already-sorted list of points. */
+  replaceAll(entries: TimelineEntry<S>[]): void {
+    this.entries = entries.slice();
+  }
+
+  /**
+   * State at `nowMs`: the payload of the latest point at or before it.
+   * `null` (no picture yet) and a time before the first point both resolve
+   * to the empty state.
+   */
+  resolve(nowMs: PresentationMs | null): S {
+    if (nowMs === null || !Number.isFinite(nowMs)) {
+      return this.emptyState;
+    }
+    const idx = this.indexAtOrBefore(nowMs);
+    return idx < 0 ? this.emptyState : this.entries[idx].payload;
+  }
+
+  /**
+   * Retention: keep the point active at `nowMs` plus everything after it,
+   * drop everything strictly older. Sources extract well ahead of the
+   * playhead (MSE extracts at append time), so future points are retained
+   * by design.
+   */
+  prune(nowMs: PresentationMs | null): void {
+    if (nowMs === null || !Number.isFinite(nowMs)) {
+      return;
+    }
+    const idx = this.indexAtOrBefore(nowMs);
+    if (idx > 0) {
+      this.entries.splice(0, idx);
+    }
+  }
+
+  clear(): void {
+    this.entries = [];
+  }
+
+  /** Index of the last entry with `fromMs <= t`, or -1. Binary search. */
+  private indexAtOrBefore(t: PresentationMs): number {
+    let lo = 0;
+    let hi = this.entries.length - 1;
+    let found = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (this.entries[mid].fromMs <= t) {
+        found = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return found;
+  }
+}
+
+/** A "state" channel: open-ended state, superseded by the next push. */
+export class StateChannelImpl<T> implements StateChannel<T> {
+  readonly mode = "state" as const;
+  private readonly timeline = new SnapshotTimeline<StateOf<T>>(null);
+
+  push(fromMs: PresentationMs, payload: T | null): void {
+    this.timeline.set(fromMs, payload);
+  }
+
+  resolve(nowMs: PresentationMs | null): StateOf<T> {
+    return this.timeline.resolve(nowMs);
+  }
+
+  prune(nowMs: PresentationMs | null): void {
+    this.timeline.prune(nowMs);
+  }
+
+  clear(): void {
+    this.timeline.clear();
+  }
+
+  /** Retained timeline points. Test/diagnostic use. */
+  get size(): number {
+    return this.timeline.size;
+  }
+}
+
+interface Cue<T> {
+  startMs: PresentationMs;
+  endMs: PresentationMs;
+  payload: T;
+}
+
+const NO_CUES: readonly never[] = Object.freeze([]);
+
+/**
+ * A "cues" channel: intervals composed into an active set.
+ *
+ * Overlapping cues are the reason this lives in the seam rather than in
+ * each interval renderer. The materialised timeline holds one point per
+ * change point (every cue start and every cue end), whose payload is the
+ * set of cues active from that point on, ordered by start time.
+ */
+export class CueChannelImpl<T> implements CueChannel<T> {
+  readonly mode = "cues" as const;
+  private cues: Cue<T>[] = [];
+  private readonly timeline = new SnapshotTimeline<CuesOf<T>>(
+    NO_CUES as CuesOf<T>,
+  );
+
+  addCue(startMs: PresentationMs, endMs: PresentationMs, payload: T): void {
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+      return;
+    }
+    if (endMs <= startMs) {
+      return;
+    }
+    this.cues.push({ startMs, endMs, payload });
+    this.rebuild();
+  }
+
+  resolve(nowMs: PresentationMs | null): CuesOf<T> {
+    return this.timeline.resolve(nowMs);
+  }
+
+  /**
+   * Retention on an interval set: drop cues that ended at or before the
+   * playhead, then rematerialise. Nothing active now or later is lost.
+   */
+  prune(nowMs: PresentationMs | null): void {
+    if (nowMs === null || !Number.isFinite(nowMs)) {
+      return;
+    }
+    const kept = this.cues.filter((cue) => cue.endMs > nowMs);
+    if (kept.length !== this.cues.length) {
+      this.cues = kept;
+      this.rebuild();
+    }
+  }
+
+  clear(): void {
+    this.cues = [];
+    this.timeline.clear();
+  }
+
+  /** Retained cue count. Test/diagnostic use. */
+  get size(): number {
+    return this.cues.length;
+  }
+
+  private rebuild(): void {
+    const boundaries = new Set<number>();
+    for (const cue of this.cues) {
+      boundaries.add(cue.startMs);
+      boundaries.add(cue.endMs);
+    }
+    const sorted = Array.from(boundaries).sort((a, b) => a - b);
+    const entries: TimelineEntry<CuesOf<T>>[] = [];
+    for (const at of sorted) {
+      const active = this.cues
+        .filter((cue) => cue.startMs <= at && at < cue.endMs)
+        .sort((a, b) => a.startMs - b.startMs)
+        .map((cue) => cue.payload);
+      const payload: CuesOf<T> =
+        active.length === 0 ? (NO_CUES as CuesOf<T>) : active;
+      const previous = entries.length
+        ? entries[entries.length - 1].payload
+        : undefined;
+      // Collapse a boundary that changes nothing (a cue ending exactly where
+      // an identical-length one starts still produces two boundaries).
+      if (previous !== undefined && sameSet(previous, payload)) {
+        continue;
+      }
+      entries.push({ fromMs: at, payload });
+    }
+    this.timeline.replaceAll(entries);
+  }
+}
+
+function sameSet<T>(a: CuesOf<T>, b: CuesOf<T>): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Everything the layer needs to know about one attached renderer. */
+interface Attachment {
+  id: string;
+  root: HTMLElement;
+  renderer: OverlayRenderer<unknown>;
+  channel: StateChannelImpl<unknown> | CueChannelImpl<unknown>;
+  /** Last painted state, compared by reference to decide "on change only". */
+  lastState: unknown;
+  lastRect: MediaRect | null;
+  painted: boolean;
+}
+
+/** Injection seam so the resolution loop can be driven from a test. */
+export interface OverlayLayerOptions {
+  requestFrame?: (cb: () => void) => number;
+  cancelFrame?: (handle: number) => void;
+}
+
+/**
+ * The DOM implementation of the seam. `player.ts` owns exactly one of these
+ * for the session.
+ */
+export class DomOverlayLayer implements OverlayLayer {
+  private readonly attachments = new Map<string, Attachment>();
+  private surface: OverlaySurface | null = null;
+  private unobserve: (() => void) | null = null;
+  private clock: (() => PresentationMs | null) | null = null;
+  private rect: MediaRect | null = null;
+  private frameHandle: number | null = null;
+  private enabled = true;
+  private disposed = false;
+  private readonly requestFrame: (cb: () => void) => number;
+  private readonly cancelFrame: (handle: number) => void;
+
+  constructor(
+    private readonly container: HTMLElement,
+    options: OverlayLayerOptions = {},
+  ) {
+    this.requestFrame =
+      options.requestFrame ??
+      ((cb) => globalThis.requestAnimationFrame(() => cb()));
+    this.cancelFrame =
+      options.cancelFrame ?? ((h) => globalThis.cancelAnimationFrame(h));
+  }
+
+  attach<T>(
+    id: string,
+    renderer: OverlayRenderer<StateOf<T>>,
+    mode: "state",
+  ): StateChannel<T>;
+  attach<T>(
+    id: string,
+    renderer: OverlayRenderer<CuesOf<T>>,
+    mode: "cues",
+  ): CueChannel<T>;
+  attach(id: string, renderer: OverlayRenderer<any>, mode: ChannelMode): any {
+    this.detach(id);
+    const root = this.container.ownerDocument.createElement("div");
+    root.dataset.overlayRenderer = id;
+    root.style.position = "absolute";
+    root.style.inset = "0";
+    root.style.pointerEvents = "none";
+    this.container.appendChild(root);
+
+    const channel =
+      mode === "state"
+        ? new StateChannelImpl<unknown>()
+        : new CueChannelImpl<unknown>();
+    const attachment: Attachment = {
+      id,
+      root,
+      renderer: renderer as unknown as OverlayRenderer<unknown>,
+      channel,
+      lastState: undefined,
+      lastRect: null,
+      painted: false,
+    };
+    attachment.renderer.mount(root);
+    this.attachments.set(id, attachment);
+    this.startLoop();
+    return channel;
+  }
+
+  detach(id: string): void {
+    const attachment = this.attachments.get(id);
+    if (!attachment) {
+      return;
+    }
+    attachment.renderer.unmount();
+    attachment.root.remove();
+    this.attachments.delete(id);
+    if (this.attachments.size === 0) {
+      this.stopLoop();
+    }
+  }
+
+  setSurface(surface: OverlaySurface | null): void {
+    if (this.unobserve) {
+      this.unobserve();
+      this.unobserve = null;
+    }
+    this.surface = surface;
+    this.rect = null;
+    this.invalidate();
+    if (surface) {
+      this.unobserve = observeSurfaceSize(surface, this.container, () =>
+        this.invalidate(),
+      );
+    }
+  }
+
+  setClock(clock: (() => PresentationMs | null) | null): void {
+    this.clock = clock;
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (this.enabled === enabled) {
+      return;
+    }
+    this.enabled = enabled;
+    this.container.style.display = enabled ? "" : "none";
+    // Force a repaint on re-enable: the resolved state may be unchanged but
+    // the DOM was hidden while it moved.
+    this.invalidate();
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  reset(): void {
+    for (const attachment of this.attachments.values()) {
+      attachment.channel.clear();
+      attachment.renderer.unmount();
+      attachment.root.replaceChildren();
+      attachment.renderer.mount(attachment.root);
+      attachment.lastState = undefined;
+      attachment.lastRect = null;
+      attachment.painted = false;
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.stopLoop();
+    if (this.unobserve) {
+      this.unobserve();
+      this.unobserve = null;
+    }
+    for (const id of Array.from(this.attachments.keys())) {
+      this.detach(id);
+    }
+    this.surface = null;
+    this.clock = null;
+    this.rect = null;
+  }
+
+  /**
+   * Run one resolution pass. Public so a host without rAF (and the tests)
+   * can drive the seam explicitly.
+   */
+  tick(): void {
+    if (this.disposed || !this.enabled || this.attachments.size === 0) {
+      return;
+    }
+    const nowMs = this.clock ? this.clock() : null;
+    const rect = this.currentRect();
+    for (const attachment of this.attachments.values()) {
+      attachment.channel.prune(nowMs);
+      const state = attachment.channel.resolve(nowMs);
+      const stateChanged =
+        !attachment.painted || state !== attachment.lastState;
+      const rectChanged = !rectsEqual(rect, attachment.lastRect);
+      if (!stateChanged && !rectChanged) {
+        continue;
+      }
+      attachment.lastState = state;
+      attachment.lastRect = rect;
+      attachment.painted = true;
+      if (!rect) {
+        // No picture box to lay out against — leave the subtree empty.
+        attachment.root.replaceChildren();
+        continue;
+      }
+      attachment.renderer.render(state, rect, nowMs ?? 0);
+    }
+  }
+
+  /** Drop the cached rect so the next tick re-measures and repaints. */
+  private invalidate(): void {
+    this.rect = null;
+    for (const attachment of this.attachments.values()) {
+      attachment.lastRect = null;
+      attachment.painted = false;
+    }
+  }
+
+  private currentRect(): MediaRect | null {
+    if (!this.surface) {
+      return null;
+    }
+    // Re-measured every tick: cheap (two getBoundingClientRect calls) and it
+    // covers layout changes that no ResizeObserver reports, such as the
+    // surface moving because a sibling above it grew.
+    const rect = getMediaRect(this.surface, this.container);
+    if (rect && rectsEqual(rect, this.rect)) {
+      return this.rect;
+    }
+    this.rect = rect;
+    return rect;
+  }
+
+  private startLoop(): void {
+    if (this.frameHandle !== null || this.disposed) {
+      return;
+    }
+    const step = (): void => {
+      this.frameHandle = null;
+      this.tick();
+      if (!this.disposed && this.attachments.size > 0) {
+        this.frameHandle = this.requestFrame(step);
+      }
+    };
+    this.frameHandle = this.requestFrame(step);
+  }
+
+  private stopLoop(): void {
+    if (this.frameHandle !== null) {
+      this.cancelFrame(this.frameHandle);
+      this.frameHandle = null;
+    }
+  }
+}

--- a/src/overlay/renderers/cta608.test.ts
+++ b/src/overlay/renderers/cta608.test.ts
@@ -1,0 +1,353 @@
+import {
+  CC608_COLS,
+  type Cc608Cell,
+  type Cc608PenState,
+  type Cc608Row,
+  type Cc608Snapshot,
+} from "../../cc608/types";
+import type { MediaRect } from "../index";
+
+import {
+  computeGrid,
+  isEmptyCell,
+  layoutSnapshot,
+  rowSegments,
+  styleRuns,
+} from "./cta608";
+
+/* --- fixtures ---------------------------------------------------------- */
+
+const DEFAULT_PEN: Cc608PenState = {
+  foreground: "white",
+  background: "black",
+  underline: false,
+  italics: false,
+  flash: false,
+};
+
+function pen(overrides: Partial<Cc608PenState> = {}): Cc608PenState {
+  return { ...DEFAULT_PEN, ...overrides };
+}
+
+function blankCells(): Cc608Cell[] {
+  return Array.from({ length: CC608_COLS }, () => ({
+    uchar: " ",
+    pen: DEFAULT_PEN,
+  }));
+}
+
+/** Write `text` at `col` with `p`, mimicking cml's per-cell pen stamping. */
+function write(
+  cells: Cc608Cell[],
+  col: number,
+  text: string,
+  p: Cc608PenState = DEFAULT_PEN,
+): Cc608Cell[] {
+  for (let i = 0; i < text.length; i++) {
+    cells[col + i] = { uchar: text[i], pen: p };
+  }
+  return cells;
+}
+
+function row(index: number, cells: Cc608Cell[]): Cc608Row {
+  return { row: index, cells };
+}
+
+function screen(...rows: Cc608Row[]): Cc608Snapshot {
+  return { rows };
+}
+
+/** A 16:9 picture at the origin: whole numbers make the grid maths readable. */
+const RECT: MediaRect = { x: 0, y: 0, w: 1280, h: 720 };
+const GRID = computeGrid(RECT);
+
+/* --- geometry ---------------------------------------------------------- */
+
+describe("computeGrid", () => {
+  it("is the centred 80% of the picture, divided 32 x 15", () => {
+    expect(GRID.w).toBeCloseTo(1024, 6);
+    expect(GRID.h).toBeCloseTo(576, 6);
+    expect(GRID.x).toBeCloseTo(128, 6);
+    expect(GRID.y).toBeCloseTo(72, 6);
+    expect(GRID.cellW).toBeCloseTo(32, 6);
+    expect(GRID.cellH).toBeCloseTo(38.4, 6);
+  });
+
+  it("tracks a letterboxed picture rather than the element box", () => {
+    // 4:3 picture inside a 16:9 surface (the #160 verification case).
+    const rect: MediaRect = { x: 139, y: 0, w: 823, h: 617 };
+    const grid = computeGrid(rect);
+    expect(grid.x).toBeCloseTo(139 + 823 * 0.1, 6);
+    expect(grid.x).toBeCloseTo(221.3, 1);
+    // The leftmost caption box starts exactly on the safe-area edge.
+    const boxes = layoutSnapshot(
+      screen(row(14, write(blankCells(), 0, "X"))),
+      rect,
+    );
+    expect(boxes[0].left).toBeCloseTo(grid.x, 6);
+  });
+});
+
+/* --- cml emptiness ----------------------------------------------------- */
+
+describe("isEmptyCell", () => {
+  it("treats a default-styled space as empty", () => {
+    expect(isEmptyCell({ uchar: " ", pen: DEFAULT_PEN })).toBe(true);
+    expect(isEmptyCell(undefined)).toBe(true);
+  });
+
+  it("treats a styled space as non-empty", () => {
+    // This is the trap: cml cannot distinguish a written default-styled
+    // space from padding, but a *styled* space is unambiguous.
+    expect(isEmptyCell({ uchar: " ", pen: pen({ background: "red" }) })).toBe(
+      false,
+    );
+    expect(isEmptyCell({ uchar: " ", pen: pen({ underline: true }) })).toBe(
+      false,
+    );
+    expect(isEmptyCell({ uchar: "A", pen: DEFAULT_PEN })).toBe(false);
+  });
+});
+
+/* --- span fill and the max-gap guard ----------------------------------- */
+
+describe("rowSegments", () => {
+  it("spans first..last non-empty cell as one segment", () => {
+    // mlmpub's clock row: white-on-black text containing real spaces.
+    // Painting per non-empty cell would tear the background box at every
+    // space, because a default-styled space *is* isEmpty().
+    const cells = write(blankCells(), 4, "2026-08-02 11:22:33");
+    expect(rowSegments(cells)).toEqual([{ first: 4, last: 22 }]);
+  });
+
+  it("returns nothing for an untouched row", () => {
+    expect(rowSegments(blankCells())).toEqual([]);
+  });
+
+  it("keeps a gap of two empty cells inside one segment", () => {
+    const cells = write(blankCells(), 0, "AB");
+    write(cells, 4, "CD");
+    expect(rowSegments(cells)).toEqual([{ first: 0, last: 5 }]);
+  });
+
+  it("splits at a gap wider than the max", () => {
+    // A stray cell left by setPAC stamping the pen under the cursor: a
+    // naive first..last span would bar the whole row.
+    const cells = write(blankCells(), 0, "CAPTION");
+    write(cells, 28, " ", pen({ background: "red" }));
+    expect(rowSegments(cells)).toEqual([
+      { first: 0, last: 6 },
+      { first: 28, last: 28 },
+    ]);
+  });
+
+  it("honours a caller-supplied max gap", () => {
+    const cells = write(blankCells(), 0, "CAPTION");
+    write(cells, 28, " ", pen({ background: "red" }));
+    expect(rowSegments(cells, 100)).toEqual([{ first: 0, last: 28 }]);
+  });
+});
+
+/* --- style runs -------------------------------------------------------- */
+
+describe("styleRuns", () => {
+  it("splits a segment on every pen change", () => {
+    const cells = blankCells();
+    write(cells, 0, "RED ", pen({ foreground: "red" }));
+    write(cells, 4, "GREEN ", pen({ foreground: "green" }));
+    write(cells, 10, "CYAN ", pen({ foreground: "cyan" }));
+    write(cells, 15, "YELLOW", pen({ foreground: "yellow" }));
+
+    const runs = styleRuns(cells, 0, 20);
+    expect(runs.map((r) => [r.col, r.len, r.text])).toEqual([
+      [0, 4, "RED "],
+      [4, 6, "GREEN "],
+      [10, 5, "CYAN "],
+      [15, 6, "YELLOW"],
+    ]);
+  });
+
+  it("keeps one run when the pen never changes", () => {
+    const cells = write(blankCells(), 3, "A B C");
+    const runs = styleRuns(cells, 3, 7);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].text).toBe("A B C");
+  });
+});
+
+/* --- layout ------------------------------------------------------------ */
+
+describe("layoutSnapshot", () => {
+  it("clears on an empty or absent screen", () => {
+    expect(layoutSnapshot(null, RECT)).toEqual([]);
+    expect(layoutSnapshot(screen(), RECT)).toEqual([]);
+    expect(layoutSnapshot(screen(row(0, blankCells())), RECT)).toEqual([]);
+  });
+
+  it("places a centred row on exact column boundaries", () => {
+    // "HELLO WORLD" (11 chars) centred: col 10..20.
+    const boxes = layoutSnapshot(
+      screen(row(14, write(blankCells(), 10, "HELLO WORLD"))),
+      RECT,
+    );
+    expect(boxes).toHaveLength(1);
+    const box = boxes[0];
+    expect(box.col).toBe(10);
+    expect(box.len).toBe(11);
+    expect(box.left).toBeCloseTo(GRID.x + 10 * GRID.cellW, 6);
+    expect(box.width).toBeCloseTo(11 * GRID.cellW, 6);
+    expect(box.top).toBeCloseTo(GRID.y + 14 * GRID.cellH, 6);
+    expect(box.height).toBeCloseTo(GRID.cellH, 6);
+    // The interior space is inside the box, so the background is contiguous.
+    expect(box.text).toBe("HELLO WORLD");
+  });
+
+  it("puts a left-positioned row on the safe-area left edge", () => {
+    const boxes = layoutSnapshot(
+      screen(row(0, write(blankCells(), 0, "LEFT"))),
+      RECT,
+    );
+    expect(boxes[0].left).toBeCloseTo(GRID.x, 6);
+    expect(boxes[0].top).toBeCloseTo(GRID.y, 6);
+  });
+
+  it("ends a right-positioned row exactly on the safe-area right edge", () => {
+    const boxes = layoutSnapshot(
+      screen(row(14, write(blankCells(), 27, "RIGHT"))),
+      RECT,
+    );
+    const box = boxes[0];
+    expect(box.left + box.width).toBeCloseTo(GRID.x + GRID.w, 6);
+    expect(box.top + box.height).toBeCloseTo(GRID.y + GRID.h, 6);
+  });
+
+  it("spans the full safe-area width for a 32-character row", () => {
+    const boxes = layoutSnapshot(
+      screen(row(7, write(blankCells(), 0, "X".repeat(CC608_COLS)))),
+      RECT,
+    );
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].left).toBeCloseTo(GRID.x, 6);
+    expect(boxes[0].width).toBeCloseTo(GRID.w, 6);
+  });
+
+  it("lays multi-run rows out edge to edge with no seams", () => {
+    const cells = blankCells();
+    write(cells, 0, "RED ", pen({ foreground: "red", background: "black" }));
+    write(cells, 4, "GREEN ", pen({ foreground: "green" }));
+    write(cells, 10, "CYAN ", pen({ foreground: "cyan" }));
+    write(cells, 15, "YELLOW", pen({ foreground: "yellow" }));
+
+    const boxes = layoutSnapshot(screen(row(12, cells)), RECT);
+    expect(boxes).toHaveLength(4);
+    expect(boxes.map((b) => b.color)).toEqual([
+      "#ff0000",
+      "#00ff00",
+      "#00ffff",
+      "#ffff00",
+    ]);
+    for (let i = 1; i < boxes.length; i++) {
+      // Backgrounds are structural: each box starts exactly where the
+      // previous one ends, so contiguity never depends on text measurement.
+      expect(boxes[i].left).toBeCloseTo(
+        boxes[i - 1].left + boxes[i - 1].width,
+        6,
+      );
+      expect(boxes[i].left).toBeCloseTo(GRID.x + boxes[i].col * GRID.cellW, 6);
+    }
+  });
+
+  it("carries colour, italics and underline onto the box", () => {
+    const cells = blankCells();
+    write(cells, 0, "IT", pen({ italics: true, foreground: "cyan" }));
+    write(cells, 2, "UL", pen({ underline: true }));
+    write(cells, 4, "BG", pen({ background: "magenta" }));
+    write(cells, 6, "TR", pen({ background: "transparent" }));
+
+    const boxes = layoutSnapshot(screen(row(3, cells)), RECT);
+    expect(boxes).toHaveLength(4);
+    expect(boxes[0]).toMatchObject({
+      text: "IT",
+      color: "#00ffff",
+      italics: true,
+      underline: false,
+      background: "#000000",
+    });
+    expect(boxes[1]).toMatchObject({
+      text: "UL",
+      underline: true,
+      italics: false,
+      color: "#ffffff",
+    });
+    expect(boxes[2].background).toBe("#ff00ff");
+    expect(boxes[3].background).toBe("transparent");
+  });
+
+  it("falls back safely on an unknown colour name", () => {
+    const cells = write(
+      blankCells(),
+      0,
+      "?",
+      pen({ foreground: "chartreuse", background: "chartreuse" }),
+    );
+    const boxes = layoutSnapshot(screen(row(0, cells)), RECT);
+    expect(boxes[0].color).toBe("#ffffff");
+    expect(boxes[0].background).toBe("transparent");
+  });
+
+  it("paints a stray PAC cell as its own box, not a bar across the row", () => {
+    const cells = write(blankCells(), 0, "CAPTION TEXT");
+    write(cells, 30, " ", pen({ background: "blue" }));
+
+    const boxes = layoutSnapshot(screen(row(14, cells)), RECT);
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].len).toBe(12);
+    expect(boxes[1]).toMatchObject({ col: 30, len: 1 });
+    expect(boxes[1].width).toBeCloseTo(GRID.cellW, 6);
+  });
+
+  it("ignores rows outside the 15-row grid", () => {
+    const cells = write(blankCells(), 0, "OFF");
+    expect(layoutSnapshot(screen(row(15, cells)), RECT)).toEqual([]);
+    expect(layoutSnapshot(screen(row(-1, cells)), RECT)).toEqual([]);
+  });
+
+  it("paints each roll-up step as a complete screen", () => {
+    // Roll-up arrives from the decoder as whole screens; the renderer is
+    // stateless and never merges or de-duplicates them (dash.js #5078).
+    const step = (lines: string[]): Cc608Snapshot =>
+      screen(
+        ...lines.map((text, i) =>
+          row(15 - lines.length + i, write(blankCells(), 0, text)),
+        ),
+      );
+
+    const first = layoutSnapshot(step(["LINE ONE"]), RECT);
+    expect(first.map((b) => b.row)).toEqual([14]);
+    expect(first.map((b) => b.text)).toEqual(["LINE ONE"]);
+
+    const second = layoutSnapshot(step(["LINE ONE", "LINE TWO"]), RECT);
+    expect(second.map((b) => b.row)).toEqual([13, 14]);
+    expect(second.map((b) => b.text)).toEqual(["LINE ONE", "LINE TWO"]);
+
+    const third = layoutSnapshot(
+      step(["LINE ONE", "LINE TWO", "LINE THREE"]),
+      RECT,
+    );
+    expect(third.map((b) => b.row)).toEqual([12, 13, 14]);
+    // Each step is laid out independently: row 14 moved up two rows and the
+    // vertical positions follow, with no state carried between paints.
+    expect(third[0].top).toBeCloseTo(GRID.y + 12 * GRID.cellH, 6);
+    expect(third[2].top).toBeCloseTo(GRID.y + 14 * GRID.cellH, 6);
+  });
+
+  it("scales with the picture rect on resize", () => {
+    const half: MediaRect = { x: 0, y: 0, w: 640, h: 360 };
+    const snapshot = screen(row(14, write(blankCells(), 4, "ABC")));
+    const big = layoutSnapshot(snapshot, RECT)[0];
+    const small = layoutSnapshot(snapshot, half)[0];
+    expect(small.left).toBeCloseTo(big.left / 2, 6);
+    expect(small.width).toBeCloseTo(big.width / 2, 6);
+    expect(small.height).toBeCloseTo(big.height / 2, 6);
+  });
+});

--- a/src/overlay/renderers/cta608.ts
+++ b/src/overlay/renderers/cta608.ts
@@ -1,0 +1,424 @@
+// CTA-608 → DOM on the true 32×15 grid.
+//
+// Technique settled by prototype and measurement in Eyevinn/warp-player#160
+// (variant D of four that were built and compared):
+//
+//   per-run boxes at exact widths + ONE probe-derived scaleX per paint
+//
+//   once per paint:
+//     fontSize = cellH * 0.82
+//     advance  = probe(font, fontSize)    // offsetWidth of "MMMMMMMMMM" / 10
+//     scale    = cellW / advance
+//   per style run:
+//     box.left  = safe.x + col * cellW;   box.width  = len * cellW
+//     box.top   = safe.y + row * cellH;   box.height = cellH
+//     box.background = pen.background     // the box IS the background
+//     inner.transform = scaleX(scale)
+//
+// Column positions are *never* measured — they are arithmetic — so they stay
+// exact under any font. dash.js #5078's whole-row scaleX was rejected: it
+// holds only under a uniform glyph advance and drifted −0.54 cell under Arial.
+// A CSS grid with one node per cell was rejected at 466 nodes / 1.20 ms
+// against this technique's 30 nodes / 0.40 ms.
+//
+// Two cml-608 traps this file exists to survive:
+//
+//   * `StyledUnicodeChar.isEmpty()` is `uchar === " " && penState.isDefault()`,
+//     and `isDefault()` means white-on-black. A *written* space in default-
+//     styled text is therefore indistinguishable from untouched padding, so
+//     painting per non-empty cell tears the background box at every space —
+//     exactly mlmpub's white-on-black clock row. Rule: paint the whole span
+//     from a row's first to its last non-empty cell.
+//   * `setPAC` stamps a pen onto the cell under the cursor before any
+//     character is written, so a PAC *creates* a non-empty cell that can sit
+//     far from the caption. A naive first..last span then bars the whole row.
+//     Guard: split the span at gaps of more than MAX_EMPTY_GAP empty cells.
+
+import {
+  CC608_COLS,
+  CC608_ROWS,
+  type Cc608Cell,
+  type Cc608PenState,
+  type Cc608Snapshot,
+} from "../../cc608/types";
+import type { MediaRect, OverlayRenderer, PresentationMs } from "../index";
+
+/** CTA-608 safe area: the centred 80% of the picture. */
+export const SAFE_AREA_FRACTION = 0.8;
+
+/** Glyph height as a fraction of the cell height. */
+export const FONT_SIZE_RATIO = 0.82;
+
+/**
+ * A span is split when more than this many consecutive empty cells appear.
+ * Guards the stray cell a non-indent PAC leaves behind.
+ */
+export const MAX_EMPTY_GAP = 2;
+
+/**
+ * Monospace stack. Positions do not depend on it, but glyphs only *fill*
+ * their cells under a uniform advance; a proportional fallback degrades
+ * typographically and nothing else.
+ */
+export const CC608_FONT_STACK =
+  'ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", Menlo, Monaco, Consolas, "Courier New", monospace';
+
+/** cml colour names → CSS. */
+const FOREGROUND_COLORS: Record<string, string> = {
+  white: "#ffffff",
+  green: "#00ff00",
+  blue: "#0000ff",
+  cyan: "#00ffff",
+  red: "#ff0000",
+  yellow: "#ffff00",
+  magenta: "#ff00ff",
+  black: "#000000",
+};
+
+const BACKGROUND_COLORS: Record<string, string> = {
+  ...FOREGROUND_COLORS,
+  transparent: "transparent",
+};
+
+export function foregroundCss(name: string): string {
+  return FOREGROUND_COLORS[name] ?? FOREGROUND_COLORS.white;
+}
+
+export function backgroundCss(name: string): string {
+  return BACKGROUND_COLORS[name] ?? "transparent";
+}
+
+/** The 32×15 caption grid over the safe area of a picture rect. */
+export interface Cc608Grid {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  cellW: number;
+  cellH: number;
+}
+
+/** The safe-area grid for a picture rect. */
+export function computeGrid(rect: MediaRect): Cc608Grid {
+  const w = rect.w * SAFE_AREA_FRACTION;
+  const h = rect.h * SAFE_AREA_FRACTION;
+  return {
+    x: rect.x + (rect.w - w) / 2,
+    y: rect.y + (rect.h - h) / 2,
+    w,
+    h,
+    cellW: w / CC608_COLS,
+    cellH: h / CC608_ROWS,
+  };
+}
+
+/**
+ * cml's emptiness test, reproduced on the snapshot: a cell is empty only if
+ * it is a space *and* fully default-styled (white on black, no decoration).
+ */
+export function isEmptyCell(cell: Cc608Cell | undefined): boolean {
+  if (!cell) {
+    return true;
+  }
+  const pen = cell.pen;
+  return (
+    cell.uchar === " " &&
+    pen.foreground === "white" &&
+    pen.background === "black" &&
+    !pen.underline &&
+    !pen.italics &&
+    !pen.flash
+  );
+}
+
+/** A painted stretch of a row, inclusive of both ends. */
+export interface Cc608Segment {
+  first: number;
+  last: number;
+}
+
+/**
+ * The painted segments of a row: first..last non-empty cell as ONE segment
+ * (so default-styled spaces inside the caption keep their background), split
+ * wherever more than MAX_EMPTY_GAP consecutive empty cells appear.
+ */
+export function rowSegments(
+  cells: Cc608Cell[],
+  maxGap: number = MAX_EMPTY_GAP,
+): Cc608Segment[] {
+  const painted: number[] = [];
+  for (let col = 0; col < CC608_COLS; col++) {
+    if (!isEmptyCell(cells[col])) {
+      painted.push(col);
+    }
+  }
+  if (painted.length === 0) {
+    return [];
+  }
+  const segments: Cc608Segment[] = [];
+  let first = painted[0];
+  let prev = painted[0];
+  for (let i = 1; i < painted.length; i++) {
+    const col = painted[i];
+    if (col - prev - 1 > maxGap) {
+      segments.push({ first, last: prev });
+      first = col;
+    }
+    prev = col;
+  }
+  segments.push({ first, last: prev });
+  return segments;
+}
+
+/** True when two pen states paint identically. */
+export function samePen(a: Cc608PenState, b: Cc608PenState): boolean {
+  return (
+    a.foreground === b.foreground &&
+    a.background === b.background &&
+    a.underline === b.underline &&
+    a.italics === b.italics &&
+    a.flash === b.flash
+  );
+}
+
+/** A maximal stretch of cells sharing one pen state. */
+export interface Cc608Run {
+  col: number;
+  len: number;
+  text: string;
+  pen: Cc608PenState;
+}
+
+/** Split `[first..last]` into runs of identical pen state. */
+export function styleRuns(
+  cells: Cc608Cell[],
+  first: number,
+  last: number,
+): Cc608Run[] {
+  const runs: Cc608Run[] = [];
+  let current: Cc608Run | null = null;
+  for (let col = first; col <= last; col++) {
+    const cell = cells[col];
+    if (!cell) {
+      continue;
+    }
+    if (current && samePen(current.pen, cell.pen)) {
+      current.text += cell.uchar;
+      current.len += 1;
+      continue;
+    }
+    current = { col, len: 1, text: cell.uchar, pen: cell.pen };
+    runs.push(current);
+  }
+  return runs;
+}
+
+/** One absolutely-positioned run box, fully resolved to CSS pixels. */
+export interface Cc608Box {
+  row: number;
+  col: number;
+  len: number;
+  text: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  color: string;
+  background: string;
+  italics: boolean;
+  underline: boolean;
+}
+
+/**
+ * Turn a snapshot into positioned run boxes. Pure arithmetic — no DOM, no
+ * measurement — which is why the column geometry is unit-testable and why it
+ * cannot drift with the font.
+ */
+export function layoutSnapshot(
+  snapshot: Cc608Snapshot | null,
+  rect: MediaRect,
+  maxGap: number = MAX_EMPTY_GAP,
+): Cc608Box[] {
+  if (!snapshot || snapshot.rows.length === 0) {
+    return [];
+  }
+  const grid = computeGrid(rect);
+  const boxes: Cc608Box[] = [];
+  for (const { row, cells } of snapshot.rows) {
+    if (row < 0 || row >= CC608_ROWS) {
+      continue;
+    }
+    for (const segment of rowSegments(cells, maxGap)) {
+      for (const run of styleRuns(cells, segment.first, segment.last)) {
+        boxes.push({
+          row,
+          col: run.col,
+          len: run.len,
+          text: run.text,
+          left: grid.x + run.col * grid.cellW,
+          top: grid.y + row * grid.cellH,
+          width: run.len * grid.cellW,
+          height: grid.cellH,
+          color: foregroundCss(run.pen.foreground),
+          background: backgroundCss(run.pen.background),
+          italics: run.pen.italics,
+          underline: run.pen.underline,
+        });
+      }
+    }
+  }
+  return boxes;
+}
+
+const PROBE_TEXT = "MMMMMMMMMM";
+
+/**
+ * Measures the mean glyph advance of a font at a size, using one hidden
+ * span. Cached on (font, fontSize) because the only thing that changes it is
+ * a resize, which changes cellH and therefore fontSize.
+ */
+class AdvanceProbe {
+  private span: HTMLSpanElement | null = null;
+  private cacheKey = "";
+  private cachedAdvance = 0;
+
+  constructor(private readonly doc: Document) {}
+
+  measure(font: string, fontSizePx: number): number {
+    const key = `${font}@${fontSizePx}`;
+    if (key === this.cacheKey) {
+      return this.cachedAdvance;
+    }
+    if (!this.span) {
+      const span = this.doc.createElement("span");
+      span.style.cssText =
+        "position:absolute;visibility:hidden;white-space:pre;left:-9999px;top:0;";
+      span.setAttribute("aria-hidden", "true");
+      this.doc.body.appendChild(span);
+      this.span = span;
+    }
+    this.span.style.fontFamily = font;
+    this.span.style.fontSize = `${fontSizePx}px`;
+    this.span.textContent = PROBE_TEXT;
+    this.cachedAdvance = this.span.offsetWidth / PROBE_TEXT.length;
+    this.cacheKey = key;
+    return this.cachedAdvance;
+  }
+
+  dispose(): void {
+    this.span?.remove();
+    this.span = null;
+    this.cacheKey = "";
+    this.cachedAdvance = 0;
+  }
+}
+
+export interface Cta608RendererOptions {
+  /** Font stack for the caption glyphs. Must be monospace to fill cells. */
+  fontFamily?: string;
+  /** Split spans at gaps wider than this many empty cells. */
+  maxEmptyGap?: number;
+}
+
+/**
+ * Paints a `Cc608Snapshot` as positioned DOM. Stateless with respect to
+ * caption modes: pop-on, roll-up and paint-on all arrive as complete screens
+ * from the decoder, so each screen is painted whole. Screens are never
+ * merged or de-duplicated here (dash.js #5078's first lesson).
+ */
+export class Cta608Renderer implements OverlayRenderer<Cc608Snapshot | null> {
+  private root: HTMLElement | null = null;
+  private probe: AdvanceProbe | null = null;
+  private readonly fontFamily: string;
+  private readonly maxEmptyGap: number;
+
+  constructor(options: Cta608RendererOptions = {}) {
+    this.fontFamily = options.fontFamily ?? CC608_FONT_STACK;
+    this.maxEmptyGap = options.maxEmptyGap ?? MAX_EMPTY_GAP;
+  }
+
+  mount(root: HTMLElement): void {
+    this.root = root;
+    root.style.position = "absolute";
+    root.style.inset = "0";
+    root.style.pointerEvents = "none";
+    root.style.fontFamily = this.fontFamily;
+    this.probe = new AdvanceProbe(root.ownerDocument);
+  }
+
+  render(
+    snapshot: Cc608Snapshot | null,
+    rect: MediaRect,
+    _nowMs: PresentationMs,
+  ): void {
+    const root = this.root;
+    if (!root) {
+      return;
+    }
+    const boxes = layoutSnapshot(snapshot, rect, this.maxEmptyGap);
+    if (boxes.length === 0) {
+      root.replaceChildren();
+      return;
+    }
+
+    const grid = computeGrid(rect);
+    const fontSize = grid.cellH * FONT_SIZE_RATIO;
+    const advance = this.probe?.measure(this.fontFamily, fontSize) ?? 0;
+    // One scale for the whole paint, so letterforms stay uniform across runs
+    // — which per-run fitting (prototype variant C) does not achieve.
+    const scale = advance > 0 ? grid.cellW / advance : 1;
+
+    const doc = root.ownerDocument;
+    const fragment = doc.createDocumentFragment();
+    for (const box of boxes) {
+      fragment.appendChild(this.buildBox(doc, box, fontSize, scale));
+    }
+    root.replaceChildren(fragment);
+  }
+
+  unmount(): void {
+    this.root?.replaceChildren();
+    this.probe?.dispose();
+    this.probe = null;
+    this.root = null;
+  }
+
+  private buildBox(
+    doc: Document,
+    box: Cc608Box,
+    fontSize: number,
+    scale: number,
+  ): HTMLElement {
+    const el = doc.createElement("div");
+    el.style.position = "absolute";
+    // The box IS the background: its width is len * cellW by construction, so
+    // contiguity never depends on a text measurement.
+    el.style.overflow = "hidden";
+    el.style.left = `${box.left}px`;
+    el.style.top = `${box.top}px`;
+    el.style.width = `${box.width}px`;
+    el.style.height = `${box.height}px`;
+    el.style.background = box.background;
+
+    const inner = doc.createElement("span");
+    inner.style.position = "absolute";
+    inner.style.left = "0";
+    inner.style.top = "0";
+    inner.style.whiteSpace = "pre";
+    inner.style.transformOrigin = "left top";
+    inner.style.transform = `scaleX(${scale})`;
+    inner.style.fontFamily = this.fontFamily;
+    inner.style.fontSize = `${fontSize}px`;
+    inner.style.lineHeight = `${box.height}px`;
+    inner.style.color = box.color;
+    if (box.italics) {
+      inner.style.fontStyle = "italic";
+    }
+    if (box.underline) {
+      inner.style.textDecoration = "underline";
+    }
+    inner.textContent = box.text;
+    el.appendChild(inner);
+    return el;
+  }
+}

--- a/src/overlay/testFakeDom.ts
+++ b/src/overlay/testFakeDom.ts
@@ -1,0 +1,107 @@
+// A minimal element/document stand-in, enough to exercise the overlay's DOM
+// plumbing (attach / tick / reset / detach) under the "node" Jest
+// environment. Deliberately not jsdom: the overlay's geometry is CSS pixels
+// that jsdom does not lay out either, so a real DOM would buy nothing but a
+// dependency. Anything needing genuine layout — glyph advance measurement —
+// is verified live in the verification ticket.
+
+/** A stubbed element. `children` is the assertion surface. */
+export class FakeElement {
+  readonly style: Record<string, string> = {};
+  readonly dataset: Record<string, string> = {};
+  readonly children: FakeElement[] = [];
+  parent: FakeElement | null = null;
+  textContent = "";
+  /** No layout engine here, so the glyph probe measures 0 and scale is 1. */
+  readonly offsetWidth = 0;
+  private box = { left: 0, top: 0, width: 0, height: 0 };
+
+  constructor(
+    readonly tagName: string,
+    readonly ownerDocument: FakeDocument,
+  ) {}
+
+  appendChild(child: FakeElement): FakeElement {
+    child.parent = this;
+    this.children.push(child);
+    return child;
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    for (const child of this.children) {
+      child.parent = null;
+    }
+    this.children.length = 0;
+    for (const node of nodes) {
+      // A fragment splices its own children in, as the real API does.
+      if (node.tagName === "#fragment") {
+        for (const grandchild of node.children) {
+          this.appendChild(grandchild);
+        }
+        node.children.length = 0;
+        continue;
+      }
+      this.appendChild(node);
+    }
+  }
+
+  remove(): void {
+    const siblings = this.parent?.children;
+    if (siblings) {
+      const idx = siblings.indexOf(this);
+      if (idx >= 0) {
+        siblings.splice(idx, 1);
+      }
+    }
+    this.parent = null;
+  }
+
+  setAttribute(): void {
+    // no-op
+  }
+
+  setBox(left: number, top: number, width: number, height: number): void {
+    this.box = { left, top, width, height };
+  }
+
+  getBoundingClientRect(): {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } {
+    return { ...this.box };
+  }
+
+  /** Every descendant, depth first. */
+  descendants(): FakeElement[] {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+}
+
+export class FakeDocument {
+  readonly body = new FakeElement("body", this);
+
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName, this);
+  }
+
+  createDocumentFragment(): FakeElement {
+    return new FakeElement("#fragment", this);
+  }
+}
+
+/** A `<canvas>`-shaped surface with an intrinsic size and a laid-out box. */
+export class FakeCanvas extends FakeElement {
+  width = 0;
+  height = 0;
+
+  constructor(doc: FakeDocument) {
+    super("canvas", doc);
+  }
+}
+
+/** Cast helper: these stubs stand in for real DOM nodes in the overlay API. */
+export function asDom<T>(value: unknown): T {
+  return value as T;
+}

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -93,6 +93,17 @@ export interface IPlaybackPipeline {
   /** Snapshot for the rate-control loop. */
   getLatencySnapshot(): PipelineLatencySnapshot;
 
+  /**
+   * Presentation time of the picture currently on screen, in ms on the media
+   * timeline (UTC-epoch under mlmpub). null before the first frame is shown.
+   *
+   * This is the *picture* clock, not a wallclock-driven playhead: it freezes
+   * when playback stalls, so captions stay pinned to the frozen frame and
+   * both engines behave identically when things go wrong. The overlay seam
+   * (src/overlay) resolves its timelines against it.
+   */
+  getPresentationTimeMs(): number | null;
+
   /** Update the buffer/latency targets at runtime. */
   setBufferConfig(config: PipelineBufferConfig): void;
 

--- a/src/pipeline/msePipeline.ts
+++ b/src/pipeline/msePipeline.ts
@@ -160,6 +160,22 @@ export class MsePipeline implements IPlaybackPipeline {
     };
   }
 
+  /**
+   * Picture clock: `<video>.currentTime` in ms. null until the element has
+   * a frame to show, so the overlay renders nothing before playback starts
+   * and freezes with the picture during a rebuffer.
+   */
+  getPresentationTimeMs(): number | null {
+    const el = this.videoElement;
+    // 2 === HTMLMediaElement.HAVE_CURRENT_DATA; spelled out so this file
+    // stays importable outside a DOM.
+    if (!el || el.readyState < 2) {
+      return null;
+    }
+    const t = el.currentTime * 1000;
+    return Number.isFinite(t) ? t : null;
+  }
+
   getPlaybackRate(): number {
     return this.videoElement?.playbackRate ?? 1.0;
   }

--- a/src/pipeline/webcodecsLocPipeline.ts
+++ b/src/pipeline/webcodecsLocPipeline.ts
@@ -610,6 +610,23 @@ export class WebCodecsLocPipeline implements IPlaybackPipeline {
     };
   }
 
+  /**
+   * Picture clock: the presentation time of the last VideoFrame actually
+   * drawn to the canvas. Freezes when the frame queue starves, unlike the
+   * wallclock-driven playheadMs().
+   */
+  getPresentationTimeMs(): number | null {
+    return this.lastPresentedMs;
+  }
+
+  /**
+   * The canvas this pipeline draws into, so the overlay can bind to the
+   * surface that actually shows the picture. null before setup().
+   */
+  getCanvas(): HTMLCanvasElement | null {
+    return this.canvas;
+  }
+
   setBufferConfig(config: PipelineBufferConfig): void {
     this.bufferConfig = config;
   }

--- a/src/player.ts
+++ b/src/player.ts
@@ -12,7 +12,7 @@ import {
   resolveBufferProfile,
 } from "./bufferProfile";
 import { Cc608Source } from "./cc608/source";
-import type { Cc608Sink } from "./cc608/types";
+import type { Cc608Sink, Cc608Snapshot } from "./cc608/types";
 import {
   LocmafTrackState,
   decompressMoofWithTrackInfo,
@@ -20,6 +20,9 @@ import {
   isLocmafTrack,
 } from "./locmaf/locmaf";
 import { ILogger, LoggerFactory } from "./logger";
+import { StateChannel } from "./overlay";
+import { DomOverlayLayer } from "./overlay/overlayLayer";
+import { Cta608Renderer } from "./overlay/renderers/cta608";
 import { EngineChoice, IPlaybackPipeline, resolveEngine } from "./pipeline";
 import { MsePipeline } from "./pipeline/msePipeline";
 import { WebCodecsLocPipeline } from "./pipeline/webcodecsLocPipeline";
@@ -150,6 +153,15 @@ export class Player {
   private currentPipeline: IPlaybackPipeline | null = null;
 
   /**
+   * Timed-text / graphics overlay for the session (see src/overlay). One
+   * layer, reset on every engine / namespace / track switch. Null when the
+   * page has no overlay container.
+   */
+  private overlay: DomOverlayLayer | null = null;
+  /** CTA-608 channel on the overlay. Caption sources push snapshots here. */
+  private cc608Channel: StateChannel<Cc608Snapshot> | null = null;
+
+  /**
    * Re-render the Mute/Unmute button label from currentPipeline.getMuted().
    * Assigned by wireMuteButton(); call after every currentPipeline change so
    * the label reflects the active engine, not the previous one. Null until
@@ -268,6 +280,10 @@ export class Player {
       this.processWarpCatalog(catalog),
     );
 
+    // Timed-text overlay. Created up front and kept for the session; the
+    // surface and clock are (re)bound whenever a pipeline starts.
+    this.setupOverlay();
+
     // Create published namespaces section
     this.createPublishedNamespacesSection();
 
@@ -282,6 +298,86 @@ export class Player {
         this.ensureSelectableNamespace();
       });
     }
+  }
+
+  /* --- Overlay (src/overlay) -------------------------------------------- */
+
+  /**
+   * Build the session's overlay layer and attach the CTA-608 renderer.
+   * The renderer is attached once and lives for the session; reset() clears
+   * its timeline on every discontinuity.
+   */
+  private setupOverlay(): void {
+    const container = document.getElementById("captionOverlay");
+    if (!container) {
+      this.logger.warn("No #captionOverlay element; overlay disabled");
+      return;
+    }
+    this.overlay = new DomOverlayLayer(container);
+    this.cc608Channel = this.overlay.attach<Cc608Snapshot>(
+      "cc608",
+      new Cta608Renderer(),
+      "state",
+    );
+  }
+
+  /**
+   * Bind the overlay to the surface the given pipeline draws into and to its
+   * picture clock, then clear any state left over from the previous session.
+   *
+   * The clock is read through this.currentPipeline rather than being closed
+   * over, so an engine switch that replaces the pipeline cannot leave the
+   * overlay reading a disposed one.
+   */
+  private bindOverlay(surface: HTMLVideoElement | HTMLCanvasElement): void {
+    const overlay = this.overlay;
+    if (!overlay) {
+      return;
+    }
+    overlay.reset();
+    overlay.setSurface(surface);
+    overlay.setClock(
+      () => this.currentPipeline?.getPresentationTimeMs() ?? null,
+    );
+  }
+
+  /** Detach the overlay from the media and drop all caption state. */
+  private releaseOverlay(): void {
+    if (!this.overlay) {
+      return;
+    }
+    this.overlay.reset();
+    this.overlay.setSurface(null);
+    this.overlay.setClock(null);
+  }
+
+  /**
+   * Where a CTA-608 source pushes decoded screens. Snapshots are plain data
+   * — the overlay never holds a live cml object. Null when the page has no
+   * overlay container.
+   */
+  public getCc608Sink(): Cc608Sink | null {
+    const channel = this.cc608Channel;
+    if (!channel) {
+      return null;
+    }
+    return {
+      push: (timeMs: number, screen: Cc608Snapshot | null) =>
+        channel.push(timeMs, screen),
+    };
+  }
+
+  /**
+   * Show or hide the caption overlay. The entry point the CC toggle (#165)
+   * drives; caption state is retained while hidden.
+   */
+  public setCaptionsEnabled(enabled: boolean): void {
+    this.overlay?.setEnabled(enabled);
+  }
+
+  /** True when the caption overlay is showing. */
+  public getCaptionsEnabled(): boolean {
+    return this.overlay?.isEnabled() ?? false;
   }
 
   /**
@@ -561,6 +657,10 @@ export class Player {
     this.publishedNamespaces = [];
     this.selectedNamespace = null;
 
+    // Unbind the overlay from the media and drop caption state. The layer
+    // itself survives so a reconnect can rebind it.
+    this.releaseOverlay();
+
     // Notify connection state change
     if (this.onConnectionStateChange) {
       this.onConnectionStateChange(false);
@@ -568,6 +668,18 @@ export class Player {
 
     // Reset the flag
     this.isDisconnecting = false;
+  }
+
+  /**
+   * Session teardown: disconnect and drop everything owned for the page,
+   * including the overlay DOM and its resolution loop. The Player is not
+   * reusable afterwards.
+   */
+  dispose(): void {
+    this.disconnect();
+    this.overlay?.dispose();
+    this.overlay = null;
+    this.cc608Channel = null;
   }
 
   /**
@@ -713,6 +825,10 @@ export class Player {
     // Clear previous catalog and tracks display
     this.catalogManager.clearCatalog();
     this.tracksContainerEl.innerHTML = "";
+
+    // Captions from the previous namespace must not survive the switch — a
+    // stale screen showing an old timestamp is worse than no caption at all.
+    this.overlay?.reset();
 
     // Hide start/stop buttons until new tracks are loaded
     const startBtn = document.getElementById("startBtn") as HTMLButtonElement;
@@ -1536,6 +1652,9 @@ export class Player {
     this.refreshMuteLabel?.();
     this.activeDrmLabel = null;
     this.updateEngineLegend();
+
+    // The surface is gone with the pipeline; drop caption state with it.
+    this.releaseOverlay();
 
     // Reset error handling state
     this.recoveryInProgress = false;
@@ -2771,6 +2890,9 @@ export class Player {
     this.playbackStarted = true;
     this.updateEngineLegend();
 
+    // WebCodecs paints into its own canvas, overlaid on the <video>.
+    this.bindOverlay(pipeline.getCanvas() ?? videoEl);
+
     // The hidden <video> element doesn't fire timeupdate while WebCodecs is
     // active, so drive the metric-panel refresh ourselves.
     this.webcodecsMetricsTimer = setInterval(() => {
@@ -3552,6 +3674,9 @@ export class Player {
     this.currentPipeline = this.msePipeline;
     this.refreshMuteLabel?.();
     this.updateEngineLegend();
+
+    // MSE paints into the <video> element itself.
+    this.bindOverlay(videoEl);
 
     // Reset previous source if any
     videoEl.pause();


### PR DESCRIPTION
Implements #164 — the overlay layer and the CTA-608 renderer — following the
seam contract settled in #159 and the rendering technique settled in #160.

## The seam (`src/overlay/`)

`index.ts` holds the contract, `overlayLayer.ts` the implementation.

- **Two channel modes onto one snapshot timeline.** `push(fromMs, payload|null)`
  for open-ended state (608, ograf); `addCue(startMs, endMs, payload)` for
  intervals (WebVTT, IMSC-1), which the seam materialises into an active set at
  every change point so interval renderers never reimplement overlap handling.
- **Resolve by search.** `SnapshotTimeline` binary-searches for the latest point
  at or before the playhead, so seeks, rate changes, stalls and discontinuities
  need no special case.
- **Retention** keeps the entry active at the playhead plus everything after and
  drops the rest; the cue channel drops cues that ended before the playhead.
- **Render on change only** — when the resolved state (by reference) or the media
  rect differs from what was last painted. One rAF loop for the whole layer.
- **Geometry** (`mediaRect.ts`): the overlay is an absolutely-positioned sibling
  in `.player-section`, `pointer-events: none`, and `getMediaRect()` derives the
  letterboxed picture box under `object-fit: contain`, expressed in the overlay
  container's coordinate space. A `ResizeObserver` on both the surface and the
  container invalidates it.

## The clock

`IPlaybackPipeline` gains exactly one method, `getPresentationTimeMs()`:
`lastPresentedMs` on `WebCodecsLocPipeline`, `videoElement.currentTime * 1000`
on `MsePipeline` (null with no element or below `HAVE_CURRENT_DATA`). Being the
*picture* clock it freezes on a stall, so both engines behave identically.
`player.ts` wires `overlay.setClock(() => pipeline.getPresentationTimeMs())`.

## The CTA-608 renderer (`src/overlay/renderers/cta608.ts`)

Technique D from #160, unchanged: per-run boxes at exact widths
(`left = safe.x + col*cellW`, `width = len*cellW` — arithmetic, never measured)
plus **one** probe-derived `scaleX` per paint. Safe area is the centred 80% of
the picture, `cellW = safe.w/32`, `cellH = safe.h/15`. Run boxes *are* the
background, so contiguity cannot depend on a text measurement, and columns stay
exact under any font.

Both cml traps from #160 are encoded as behaviour and as tests: span-fill from a
row's first to its last non-empty cell (a default-styled space is
indistinguishable from padding, and per-cell painting tears the background), with
a max-gap split at more than 2 empty cells to contain the stray cell `setPAC`
leaves behind.

## Lifecycle

`reset()` on namespace switch, engine/pipeline start, and pipeline dispose;
`setSurface(null)` on disconnect; `Player.dispose()` for session teardown.
`Player.setCaptionsEnabled()` is the entry point for the CC toggle (#165) —
the button itself is out of scope here.

## Shared contract

`src/cc608/types.ts` is included byte-for-byte as specified so this branch merges
cleanly with #162, which owns the file.

## Tests

288 tests pass. New coverage: synthetic `Cc608Snapshot`s (centred, left- and
right-positioned rows, full 32-column row, colour/italic/underline, multi-run
rows painted edge to edge, roll-up sequence, empty-screen clearing, stray-cell
max-gap guard, unknown-colour fallback), geometry under letterboxed and
pillarboxed non-16:9 boxes, and the seam's resolve-by-search, retention and cue
composition. A small fake DOM (`testFakeDom.ts`) exercises the layer's
attach/tick/reset/detach and the renderer's emitted boxes without pulling in
jsdom — the glyph-advance probe needs a real layout engine, so that part is for
the verification ticket (#167).

`npm run typecheck`, `npm run lint`, `npm run pretty`, `npm test` and
`npm run build` are green.

Closes #164
