### PR TITLE
chore(lint): ignore nested agent worktrees under .claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ logs
 # Local Claude configuration
 CLAUDE.local.md
 .claude/settings.local.json
+.claude/worktrees/
 
 # Playwright MCP scratch dir
 .playwright-mcp/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,9 @@ export default typescriptEslint.config(
       "dist/**",
       "node_modules/**",
       "references/**",
+      // Nested checkouts (agent worktrees) carry their own dist/ and
+      // node_modules/, which the patterns above only match at the root.
+      ".claude/**",
       "*.js",
       "!eslint.config.js",
     ],


### PR DESCRIPTION
`npm run lint` fails from a checkout that has agent worktrees under `.claude/worktrees/`, which makes the `pre-push` hook reject **every** push from the main checkout:

```
.claude/worktrees/agent-a0294d73474672890/dist/54.ea9ae20622b11d02db5e.js
  2:2      error  'self' is not defined       no-undef
  2:887    error  'navigator' is not defined  no-undef
  … hundreds more, all from bundled output
```

The `ignores` patterns in `eslint.config.js` are relative to the config file, so `dist/**` and `node_modules/**` match only at the repo root. A nested checkout brings its own `dist/` and `node_modules/`, and ESLint walks straight into them. Pushing from *inside* a worktree happens to work, because a worktree has no nested worktrees of its own.

`.claude/**` is added to the ignore list — nothing under there is ever repo source — and `.claude/worktrees/` joins the existing "Local Claude configuration" block in `.gitignore`, which is otherwise the only reason `git status` shows a 626 MB untracked directory.

`.gitignore` deliberately gets the narrow path rather than all of `.claude/`, so shared configuration (skills, agents) can still be committed later if it's ever wanted.

Verified: `eslint .` and `tsc --noEmit` both exit 0 from the main checkout with the three worktrees in place. No source or behaviour change.
