### PR TITLE
feat(cc608): add the CC toggle and connect the caption sink

### DIFF
--- a/src/cc608/gate.test.ts
+++ b/src/cc608/gate.test.ts
@@ -1,0 +1,73 @@
+import { resolveCaptionGate } from "./gate";
+
+describe("resolveCaptionGate", () => {
+  it("is inert with no engine playing (the teardown case)", () => {
+    expect(
+      resolveCaptionGate({ enabled: true, available: true, engine: null }),
+    ).toEqual({ active: false, mseSink: false, webcodecsSink: false });
+  });
+
+  it("installs the sink only on the MSE engine when MSE is playing", () => {
+    expect(
+      resolveCaptionGate({ enabled: true, available: true, engine: "mse" }),
+    ).toEqual({ active: true, mseSink: true, webcodecsSink: false });
+  });
+
+  it("installs the sink only on the WebCodecs engine when it is playing", () => {
+    expect(
+      resolveCaptionGate({
+        enabled: true,
+        available: true,
+        engine: "webcodecs",
+      }),
+    ).toEqual({ active: true, mseSink: false, webcodecsSink: true });
+  });
+
+  it("never installs a sink on both engines at once", () => {
+    for (const engine of ["mse", "webcodecs"] as const) {
+      const out = resolveCaptionGate({
+        enabled: true,
+        available: true,
+        engine,
+      });
+      expect(out.mseSink && out.webcodecsSink).toBe(false);
+    }
+  });
+
+  it("is inert when the user has captions off", () => {
+    expect(
+      resolveCaptionGate({ enabled: false, available: true, engine: "mse" }),
+    ).toEqual({ active: false, mseSink: false, webcodecsSink: false });
+  });
+
+  it("is inert when the track does not advertise CTA-608", () => {
+    // Intent is still true — it is remembered, just not acted on.
+    expect(
+      resolveCaptionGate({ enabled: true, available: false, engine: "mse" }),
+    ).toEqual({ active: false, mseSink: false, webcodecsSink: false });
+  });
+
+  it("is inert when neither intent nor availability holds", () => {
+    expect(
+      resolveCaptionGate({
+        enabled: false,
+        available: false,
+        engine: "webcodecs",
+      }),
+    ).toEqual({ active: false, mseSink: false, webcodecsSink: false });
+  });
+
+  it("activates exactly when intent, availability and an engine all hold", () => {
+    // Exhaustive over the truth table: active iff all three.
+    for (const enabled of [false, true]) {
+      for (const available of [false, true]) {
+        for (const engine of [null, "mse", "webcodecs"] as const) {
+          const out = resolveCaptionGate({ enabled, available, engine });
+          expect(out.active).toBe(enabled && available && engine !== null);
+          // A sink is installed iff active, and on exactly one engine.
+          expect(out.mseSink || out.webcodecsSink).toBe(out.active);
+        }
+      }
+    }
+  });
+});

--- a/src/cc608/gate.ts
+++ b/src/cc608/gate.ts
@@ -1,0 +1,56 @@
+// Where the CTA-608 caption sink goes, and whether extraction runs at all.
+//
+// Extracted from Player so the rule is a pure function with an explicit truth
+// table rather than a sequence of side effects buried in DOM-heavy code. The
+// player applies the result; this decides it.
+//
+// Two inputs are deliberately kept apart:
+//
+//   * `enabled` is the user's *intent* from the CC toggle. It persists across
+//     track and namespace switches, so a detour through an uncaptioned track
+//     does not silently discard the user's choice.
+//   * `available` is whether the selected video track advertises the CTA-608
+//     accessibility descriptor. It is a property of the stream.
+//
+// Captions are active only when both hold. The toggle gates **extraction as
+// well as rendering** — see `Player.applyCaptionState`.
+
+import { Engine } from "../pipeline";
+
+export interface CaptionGateInput {
+  /** The user's CC toggle intent. */
+  enabled: boolean;
+  /** Whether the selected video track advertises in-band CTA-608. */
+  available: boolean;
+  /** The engine currently playing, or null when nothing is playing. */
+  engine: Engine | null;
+}
+
+export interface CaptionGateOutput {
+  /**
+   * Captions should be decoded and painted. Drives the overlay's enabled
+   * state and both extractors' `setCc608Enabled`.
+   */
+  active: boolean;
+  /** Install the caption sink on the MSE path (Player owns that extractor). */
+  mseSink: boolean;
+  /** Install the caption sink on the WebCodecs pipeline's extractor. */
+  webcodecsSink: boolean;
+}
+
+/**
+ * Resolve the caption gate.
+ *
+ * A sink goes only to the engine that is actually playing: each extractor is
+ * fed exclusively by its own path, so installing on both would build a decoder
+ * that never receives a sample. With no engine, no sink is installed anywhere —
+ * which is also what teardown wants.
+ */
+export function resolveCaptionGate(input: CaptionGateInput): CaptionGateOutput {
+  const active = input.enabled && input.available && input.engine !== null;
+  return {
+    active,
+    mseSink: active && input.engine === "mse",
+    webcodecsSink: active && input.engine === "webcodecs",
+  };
+}

--- a/src/index.html
+++ b/src/index.html
@@ -746,6 +746,16 @@
           <button id="muteBtn" class="btn" type="button" disabled>
             <span aria-hidden="true">🔇</span> Unmute
           </button>
+          <button
+            id="ccBtn"
+            class="btn"
+            type="button"
+            disabled
+            aria-pressed="false"
+            title="This track does not advertise CTA-608 captions"
+          >
+            <span aria-hidden="true">💬</span> CC Off
+          </button>
           <div class="buffer-control">
             <label for="minimalBuffer">Minimal Buffer (ms):</label>
             <input

--- a/src/player.ts
+++ b/src/player.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_BUFFER_PROFILES,
   resolveBufferProfile,
 } from "./bufferProfile";
+import { resolveCaptionGate } from "./cc608/gate";
 import { Cc608Source } from "./cc608/source";
 import type { Cc608Sink, Cc608Snapshot } from "./cc608/types";
 import {
@@ -35,6 +36,7 @@ import {
   WarpCatalogManager,
   ContentProtection,
   DRMSystem,
+  trackHasCta608,
 } from "./warpcatalog";
 
 /**
@@ -129,9 +131,11 @@ export class Player {
    * user-facing on/off switch. Extraction is a strict no-op unless both are
    * in place and the video codec is one the SEI walker understands, so the
    * feature costs nothing until it is wired up and turned on.
+   *
+   * Both are driven by `applyCaptionState()`; nothing else should set them.
    */
   private cc608Sink: Cc608Sink | null = null;
-  private cc608Enabled = true;
+  private cc608Enabled = false;
   private cc608Source: Cc608Source | null = null;
 
   /** Active WebCodecs pipeline when LOC playback is engaged. */
@@ -160,6 +164,15 @@ export class Player {
   private overlay: DomOverlayLayer | null = null;
   /** CTA-608 channel on the overlay. Caption sources push snapshots here. */
   private cc608Channel: StateChannel<Cc608Snapshot> | null = null;
+  /**
+   * The user's captions on/off intent. Off by default (#165) and deliberately
+   * independent of availability, so it survives a switch through an
+   * uncaptioned track and is restored on the way back.
+   */
+  private captionsEnabled = false;
+  /** Notified whenever caption availability changes, so the CC button can follow. */
+  private captionAvailabilityListener: ((available: boolean) => void) | null =
+    null;
 
   /**
    * Re-render the Mute/Unmute button label from currentPipeline.getMuted().
@@ -339,10 +352,21 @@ export class Player {
     overlay.setClock(
       () => this.currentPipeline?.getPresentationTimeMs() ?? null,
     );
+
+    // Connect the active engine's extractor to the overlay. Both callers set
+    // currentPipeline and videoTrack before getting here, so this is the one
+    // place that knows which engine is live and what it is playing.
+    this.applyCaptionState();
   }
 
   /** Detach the overlay from the media and drop all caption state. */
   private releaseOverlay(): void {
+    // Tear the extractors down first: they must never outlive the sink they
+    // push into. This runs even without an overlay, so a page with no
+    // #captionOverlay still stops extraction on teardown.
+    this.setCc608Sink(null);
+    this.webcodecsPipeline?.setCc608Sink(null);
+
     if (!this.overlay) {
       return;
     }
@@ -368,16 +392,81 @@ export class Player {
   }
 
   /**
-   * Show or hide the caption overlay. The entry point the CC toggle (#165)
-   * drives; caption state is retained while hidden.
+   * True when the selected video track advertises in-band CTA-608 captions.
+   *
+   * The catalog descriptor is the only signal available: the captions live
+   * inside the coded video, so a track that carries them but omits the
+   * descriptor is indistinguishable from one that has none.
    */
-  public setCaptionsEnabled(enabled: boolean): void {
-    this.overlay?.setEnabled(enabled);
+  public areCaptionsAvailable(): boolean {
+    return trackHasCta608(this.videoTrack);
   }
 
-  /** True when the caption overlay is showing. */
+  /**
+   * Register a listener for caption availability. Fires whenever the selected
+   * video track changes in a way that changes the answer, so the CC button can
+   * enable and disable itself. Called immediately with the current value.
+   */
+  public onCaptionAvailabilityChange(
+    listener: (available: boolean) => void,
+  ): void {
+    this.captionAvailabilityListener = listener;
+    listener(this.areCaptionsAvailable());
+  }
+
+  /**
+   * The user's captions on/off intent. Remembered across track and namespace
+   * switches, so returning to a captioned track restores the user's choice
+   * rather than silently dropping it.
+   */
+  public setCaptionsEnabled(enabled: boolean): void {
+    this.captionsEnabled = enabled;
+    this.applyCaptionState();
+  }
+
+  /** The user's captions on/off intent (not whether captions are available). */
   public getCaptionsEnabled(): boolean {
-    return this.overlay?.isEnabled() ?? false;
+    return this.captionsEnabled;
+  }
+
+  /**
+   * Point the active engine's CTA-608 extractor at the overlay channel and
+   * bring the overlay in line with the user's intent.
+   *
+   * **The toggle gates extraction as well as rendering.** Rendering-only
+   * gating would keep paying the per-sample SEI scan and the 608 parse for
+   * captions nobody is looking at; both extractors were built with an
+   * `enabled` flag precisely so the work can be switched off. The visible
+   * consequence is that switching captions on mid-stream starts from a blank
+   * overlay until the next caption flip (up to ~1 s against mlmpub), because
+   * the decoder is rebuilt with no screen state. That is the intended
+   * trade-off: a brief gap on enable, versus continuous cost while off.
+   *
+   * Idempotent, and safe to call before a pipeline exists.
+   */
+  private applyCaptionState(): void {
+    const available = this.areCaptionsAvailable();
+    const gate = resolveCaptionGate({
+      enabled: this.captionsEnabled,
+      available,
+      engine: this.currentPipeline?.engine ?? null,
+    });
+    const sink = gate.active ? this.getCc608Sink() : null;
+
+    // The overlay keeps its timeline while hidden; setEnabled only stops
+    // resolution and painting.
+    this.overlay?.setEnabled(gate.active);
+
+    // Each extractor is fed only by its own engine's path, so the sink goes to
+    // the one that is playing and is cleared everywhere else. A null sink is
+    // what actually stops the extraction work.
+    this.setCc608Sink(gate.mseSink ? sink : null);
+    this.setCc608Enabled(gate.active);
+
+    this.webcodecsPipeline?.setCc608Sink(gate.webcodecsSink ? sink : null);
+    this.webcodecsPipeline?.setCc608Enabled(gate.active);
+
+    this.captionAvailabilityListener?.(available);
   }
 
   /**
@@ -1454,6 +1543,7 @@ export class Player {
     }
 
     this.wireMuteButton();
+    this.wireCaptionButton();
   }
 
   /**
@@ -1465,6 +1555,52 @@ export class Player {
    * expose a mute toggle the same way Chrome's do, and (b) the WebCodecs
    * path hides the <video> entirely.
    */
+  /**
+   * Wire the CC toggle. The button is disabled unless the selected video
+   * track advertises the CTA-608 accessibility descriptor, and follows
+   * availability automatically as tracks and namespaces change.
+   *
+   * Note the button reflects *effective* state (intent AND availability)
+   * while `captionsEnabled` stores intent alone — so a detour through an
+   * uncaptioned track shows "CC Off" and disabled, then comes back on when a
+   * captioned track is selected again.
+   */
+  private wireCaptionButton(): void {
+    const ccBtn = document.getElementById("ccBtn") as HTMLButtonElement | null;
+    if (!ccBtn) {
+      return;
+    }
+
+    const refresh = (available: boolean) => {
+      const on = available && this.getCaptionsEnabled();
+      ccBtn.disabled = !available;
+      ccBtn.setAttribute("aria-pressed", String(on));
+      ccBtn.title = available
+        ? on
+          ? "Turn closed captions off"
+          : "Turn closed captions on"
+        : "This track does not advertise CTA-608 captions";
+      const icon = document.createElement("span");
+      icon.setAttribute("aria-hidden", "true");
+      icon.textContent = "💬";
+      ccBtn.replaceChildren(
+        icon,
+        document.createTextNode(on ? " CC On" : " CC Off"),
+      );
+    };
+
+    // Registering also fires once with the current value.
+    this.onCaptionAvailabilityChange(refresh);
+
+    ccBtn.onclick = () => {
+      if (ccBtn.disabled) {
+        return;
+      }
+      // setCaptionsEnabled -> applyCaptionState -> the listener above.
+      this.setCaptionsEnabled(!this.getCaptionsEnabled());
+    };
+  }
+
   private wireMuteButton(): void {
     const muteBtn = document.getElementById(
       "muteBtn",

--- a/src/warpcatalog.test.ts
+++ b/src/warpcatalog.test.ts
@@ -1,7 +1,9 @@
 import {
+  CTA608_ACCESSIBILITY_SCHEME,
   MSF_SUPPORTED_VERSION,
   WarpCatalog,
   WarpCatalogManager,
+  trackHasCta608,
 } from "./warpcatalog";
 
 describe("WarpCatalogManager draft-01 init data", () => {
@@ -73,5 +75,112 @@ describe("WarpCatalogManager draft-01 init data", () => {
     const mgr = new WarpCatalogManager();
     mgr.handleCatalogData(catalog);
     expect(mgr.getInitData({ name: "x", initRef: "missing" })).toBeUndefined();
+  });
+});
+
+describe("CTA-608 accessibility descriptor", () => {
+  const cc608 = { scheme: CTA608_ACCESSIBILITY_SCHEME, value: "CC1=eng" };
+
+  const captioned: WarpCatalog = {
+    version: "draft-01",
+    tracks: [
+      {
+        name: "video",
+        packaging: "cmaf",
+        role: "video",
+        codec: "avc1.640028",
+        accessibility: [cc608],
+      },
+      { name: "audio", packaging: "cmaf", role: "audio" },
+    ],
+  };
+
+  it("keeps the descriptor through handleCatalogData", () => {
+    const mgr = new WarpCatalogManager();
+    mgr.handleCatalogData(captioned);
+    const track = mgr.getCatalog()?.tracks[0];
+    expect(track?.accessibility).toEqual([cc608]);
+    expect(trackHasCta608(track)).toBe(true);
+  });
+
+  it("keeps the descriptor when the namespace is inherited", () => {
+    // The inherit pass mutates tracks in place; it must not disturb the
+    // descriptor of a track that omits `namespace`.
+    const mgr = new WarpCatalogManager();
+    mgr.handleCatalogData(structuredClone(captioned), "cmsf/clear");
+    const track = mgr.getCatalog()?.tracks[0];
+    expect(track?.namespace).toBe("cmsf/clear");
+    expect(trackHasCta608(track)).toBe(true);
+  });
+
+  it("keeps the descriptor on tracks carried in a deltaUpdate", () => {
+    const mgr = new WarpCatalogManager();
+    mgr.handleCatalogData(
+      {
+        version: "draft-01",
+        tracks: [],
+        deltaUpdate: [
+          {
+            op: "add",
+            tracks: [{ name: "video2", role: "video", accessibility: [cc608] }],
+          },
+        ],
+      },
+      "cmsf/clear",
+    );
+    const added = mgr.getCatalog()?.deltaUpdate?.[0].tracks[0];
+    expect(added?.namespace).toBe("cmsf/clear");
+    expect(trackHasCta608(added)).toBe(true);
+  });
+
+  describe("trackHasCta608", () => {
+    it("is false for a track with no accessibility field", () => {
+      expect(trackHasCta608(captioned.tracks[1])).toBe(false);
+    });
+
+    it("is false for null and undefined tracks", () => {
+      expect(trackHasCta608(null)).toBe(false);
+      expect(trackHasCta608(undefined)).toBe(false);
+    });
+
+    it("is false for an empty accessibility array", () => {
+      expect(trackHasCta608({ name: "v", accessibility: [] })).toBe(false);
+    });
+
+    it("is false for a different accessibility scheme", () => {
+      expect(
+        trackHasCta608({
+          name: "v",
+          accessibility: [{ scheme: "urn:scte:dash:cc:cea-708:2015" }],
+        }),
+      ).toBe(false);
+    });
+
+    it("finds the descriptor alongside unrelated ones", () => {
+      expect(
+        trackHasCta608({
+          name: "v",
+          accessibility: [{ scheme: "urn:example:other" }, cc608],
+        }),
+      ).toBe(true);
+    });
+
+    it("tolerates malformed entries", () => {
+      expect(
+        trackHasCta608({
+          name: "v",
+          accessibility: [null, undefined, {}, cc608] as never,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not match on value alone", () => {
+      expect(
+        trackHasCta608({
+          name: "v",
+          accessibility: [{ scheme: "", value: "CC1=eng" }],
+        }),
+      ).toBe(false);
+    });
   });
 });

--- a/src/warpcatalog.ts
+++ b/src/warpcatalog.ts
@@ -119,7 +119,48 @@ export interface WarpTrack {
   contentProtectionRefIDs?: string[];
   /** Parent track name for cloned tracks (only in cloneTracks). */
   parentName?: string;
+  /**
+   * Accessibility features carried by the track, as {scheme, value}
+   * descriptors (draft-ietf-moq-msf-01 Section 5.2.44). mlmpub uses this to
+   * advertise in-band CTA-608 captions on a video track; see
+   * {@link trackHasCta608}.
+   */
+  accessibility?: Accessibility[];
   [key: string]: any; // For future/custom fields
+}
+
+/**
+ * A single accessibility descriptor on a track
+ * (draft-ietf-moq-msf-01 Section 5.2.44).
+ */
+export interface Accessibility {
+  scheme: string;
+  value?: string;
+}
+
+/**
+ * Scheme identifier for CTA-608 closed captions carried in-band in the video
+ * elementary stream. mlmpub emits `{scheme, value: "CC1=eng"}` on captioned
+ * video tracks in both the MSF and CMSF catalogs.
+ */
+export const CTA608_ACCESSIBILITY_SCHEME = "urn:scte:dash:cc:cea-608:2015";
+
+/**
+ * True when the track advertises in-band CTA-608 captions.
+ *
+ * This is the *only* signal the player has: the captions live inside the
+ * coded video, so there is no separate track to discover and nothing in the
+ * bitstream to check without decoding it. A track that carries captions but
+ * omits the descriptor is indistinguishable from one that has none, which is
+ * why the CC toggle is gated on this rather than on first-sight detection.
+ */
+export function trackHasCta608(track: WarpTrack | null | undefined): boolean {
+  if (!track?.accessibility) {
+    return false;
+  }
+  return track.accessibility.some(
+    (a) => a?.scheme === CTA608_ACCESSIBILITY_SCHEME,
+  );
 }
 
 /** DRM information for a track. */


### PR DESCRIPTION
Closes #165. Part of the overlay-seam map #157.

## The gap this closes

`main` had a complete CTA-608 implementation that rendered nothing. #161, #162 and #164 were built in parallel with disjoint file ownership, so each landed behind a gate that stays inert until a sink is installed — and **no code installed one**. `Player.getCc608Sink()`, `Player.setCc608Sink()` and `WebCodecsLocPipeline.setCc608Sink()` were definitions with no call sites outside tests.

## What landed

- **Catalog** — `Accessibility` type, `accessibility` on `WarpTrack`, `CTA608_ACCESSIBILITY_SCHEME`, and `trackHasCta608()`.
- **Wiring** — `bindOverlay()` now calls `applyCaptionState()`, which installs the sink on whichever engine is playing; `releaseOverlay()` tears both down. Both bind sites already set `currentPipeline` and `videoTrack` first, so this is the one place that knows the engine and the track.
- **Gate** — `src/cc608/gate.ts`, a pure `resolveCaptionGate()`. Captions are active only when intent AND availability AND an engine all hold; the sink goes to exactly one engine, never both, and to neither on teardown.
- **UI** — a `#ccBtn` CC button, disabled unless the selected video track advertises the descriptor, off by default, following availability automatically.

## Decisions

**The toggle gates extraction as well as rendering.** Rendering-only gating would keep paying the per-sample SEI scan and 608 parse for captions nobody is looking at; both extractors were built with an `enabled` flag precisely so the work can be switched off. The visible cost: switching captions on mid-stream starts blank until the next caption flip (up to ~1 s against mlmpub), because the decoder is rebuilt with no screen state.

**Intent and availability are stored separately.** `captionsEnabled` is the user's choice and persists across track and namespace switches; `areCaptionsAvailable()` is a property of the stream. A detour through an uncaptioned track disables the button without discarding the choice.

## Findings

- **`accessibility` already survived parsing.** `WarpTrack` has an index signature and `handleCatalogData` stores the catalog as-is, so this was a typing-and-helper job, not a parser change. The tests assert the field survives, including the namespace-inheritance pass that mutates tracks in place.
- **`deltaUpdate` is never applied.** It is typed and walked for namespace inheritance, but nothing merges `add`/`remove`/`clone` into the catalog. Pre-existing and out of scope here, but it means a captioned track introduced *via a delta update* would never be seen. Worth its own ticket.

## Tests

373 pass (+18). `resolveCaptionGate` is covered exhaustively over the 12-cell truth table; catalog tests cover the descriptor through parsing, namespace inheritance and deltaUpdate carriage, plus malformed entries. typecheck / lint / prettier / build green.

The CC button's DOM rendering is not unit-tested — jsdom lays out no CSS pixels and the decision logic it renders is fully covered by the gate tests. Live verification belongs to #166.