### PR TITLE
fix(overlay): do not paint a background box around no glyph

### DIFF
--- a/src/overlay/renderers/cta608.test.ts
+++ b/src/overlay/renderers/cta608.test.ts
@@ -132,19 +132,63 @@ describe("rowSegments", () => {
 
   it("splits at a gap wider than the max", () => {
     // A stray cell left by setPAC stamping the pen under the cursor: a
-    // naive first..last span would bar the whole row.
+    // naive first..last span would bar the whole row. The stray cell is a
+    // styled blank, so the split leaves it in a segment of its own, which is
+    // then dropped for having no glyph in it.
     const cells = write(blankCells(), 0, "CAPTION");
     write(cells, 28, " ", pen({ background: "red" }));
-    expect(rowSegments(cells)).toEqual([
-      { first: 0, last: 6 },
-      { first: 28, last: 28 },
-    ]);
+    expect(rowSegments(cells)).toEqual([{ first: 0, last: 6 }]);
   });
 
   it("honours a caller-supplied max gap", () => {
+    // With the gap allowed, the stray blank merges into the caption's own
+    // segment, which has glyphs and so survives whole.
     const cells = write(blankCells(), 0, "CAPTION");
     write(cells, 28, " ", pen({ background: "red" }));
     expect(rowSegments(cells, 100)).toEqual([{ first: 0, last: 28 }]);
+  });
+
+  // A mid-row code occupies a display cell and renders as a space with the new
+  // attributes, and a PAC cannot carry both a colour and an indent — so an
+  // indented coloured caption always has a styled blank just before its text.
+  // Mid-paint that blank can be the row's only non-empty cell.
+  describe("the mid-row cell ahead of a coloured caption", () => {
+    it("paints nothing while the blank is alone on the row", () => {
+      const cells = write(blankCells(), 10, " ", pen({ foreground: "yellow" }));
+      expect(rowSegments(cells)).toEqual([]);
+      expect(layoutSnapshot(screen(row(14, cells)), RECT)).toEqual([]);
+    });
+
+    it("paints the blank once the first glyphs arrive", () => {
+      // mlmpub's yellow "GRP <n>" row, two characters into the paint.
+      const cells = write(blankCells(), 10, " ", pen({ foreground: "yellow" }));
+      write(cells, 11, "GR", pen({ foreground: "yellow" }));
+      expect(rowSegments(cells)).toEqual([{ first: 10, last: 12 }]);
+      const boxes = layoutSnapshot(screen(row(14, cells)), RECT);
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].text).toBe(" GR");
+      expect(boxes[0].len).toBe(3);
+    });
+
+    it("keeps a lone blank that is underlined, which is visible on its own", () => {
+      const cells = write(blankCells(), 10, " ", pen({ underline: true }));
+      expect(rowSegments(cells)).toEqual([{ first: 10, last: 10 }]);
+    });
+
+    it("drops a blank row without disturbing a captioned one", () => {
+      const clock = write(blankCells(), 10, "12:34:56.000");
+      const groupTag = write(
+        blankCells(),
+        10,
+        " ",
+        pen({ foreground: "yellow" }),
+      );
+      const boxes = layoutSnapshot(
+        screen(row(13, clock), row(14, groupTag)),
+        RECT,
+      );
+      expect(boxes.map((b) => b.row)).toEqual([13]);
+    });
   });
 });
 
@@ -295,15 +339,17 @@ describe("layoutSnapshot", () => {
     expect(boxes[0].background).toBe("transparent");
   });
 
-  it("paints a stray PAC cell as its own box, not a bar across the row", () => {
+  it("does not let a stray PAC cell bar the row, or paint at all", () => {
+    // Two guards in sequence: the gap split keeps the stray cell out of the
+    // caption's box (no bar across the row), and having no glyph in it keeps
+    // it from becoming a box of its own.
     const cells = write(blankCells(), 0, "CAPTION TEXT");
     write(cells, 30, " ", pen({ background: "blue" }));
 
     const boxes = layoutSnapshot(screen(row(14, cells)), RECT);
-    expect(boxes).toHaveLength(2);
-    expect(boxes[0].len).toBe(12);
-    expect(boxes[1]).toMatchObject({ col: 30, len: 1 });
-    expect(boxes[1].width).toBeCloseTo(GRID.cellW, 6);
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0]).toMatchObject({ col: 0, len: 12 });
+    expect(boxes[0].width).toBeCloseTo(12 * GRID.cellW, 6);
   });
 
   it("ignores rows outside the 15-row grid", () => {

--- a/src/overlay/renderers/cta608.ts
+++ b/src/overlay/renderers/cta608.ts
@@ -33,6 +33,16 @@
 //     character is written, so a PAC *creates* a non-empty cell that can sit
 //     far from the caption. A naive first..last span then bars the whole row.
 //     Guard: split the span at gaps of more than MAX_EMPTY_GAP empty cells.
+//
+// And one CTA-608 fact that is not a cml trap but looks like one on screen: a
+// mid-row code occupies a display cell and renders as a space carrying the new
+// attributes (SPEC section 7). A PAC encodes *either* a colour or an indent,
+// never both, so every coloured run at column > 0 is preceded by one — an
+// indented coloured caption always has a styled blank just before its text.
+// While that text is still arriving pair by pair, in paint-on or roll-up, the
+// blank is briefly the row's only non-empty cell and paints as a lone
+// background box: a square that flashes ahead of the first glyph. Rule: a
+// segment with no glyph in it is not painted — see segmentHasInk.
 
 import {
   CC608_COLS,
@@ -138,9 +148,41 @@ export interface Cc608Segment {
 }
 
 /**
+ * True when a segment would show something: any non-blank glyph, or a blank
+ * that is underlined (an underline is visible on its own).
+ *
+ * A segment failing this is a styled blank and nothing else — a mid-row cell
+ * ahead of text that has not arrived yet, or a PAC-stamped cell close enough to
+ * the caption to survive the gap split. Painting it draws a background box with
+ * no content in it, which is the stray square; skipping it loses nothing,
+ * because a box is only ever a backdrop for glyphs.
+ *
+ * Spaces *within* a segment that also has glyphs are unaffected: they are the
+ * caption's own inter-word cells and must keep their background, which is the
+ * whole reason segments are painted first..last rather than per cell.
+ */
+function segmentHasInk(
+  cells: Cc608Cell[],
+  first: number,
+  last: number,
+): boolean {
+  for (let col = first; col <= last; col++) {
+    const cell = cells[col];
+    if (!cell) {
+      continue;
+    }
+    if (cell.uchar.trim() !== "" || cell.pen.underline) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * The painted segments of a row: first..last non-empty cell as ONE segment
  * (so default-styled spaces inside the caption keep their background), split
- * wherever more than MAX_EMPTY_GAP consecutive empty cells appear.
+ * wherever more than MAX_EMPTY_GAP consecutive empty cells appear, and with
+ * segments that would paint a box around no glyph dropped (see segmentHasInk).
  */
 export function rowSegments(
   cells: Cc608Cell[],
@@ -167,7 +209,9 @@ export function rowSegments(
     prev = col;
   }
   segments.push({ first, last: prev });
-  return segments;
+  // Filter after splitting, not before: a stray blank must be judged as its own
+  // segment, and a blank merged into a segment that has glyphs is legitimate.
+  return segments.filter((s) => segmentHasInk(cells, s.first, s.last));
 }
 
 /** True when two pen states paint identically. */


### PR DESCRIPTION
A lone black square flashes ahead of the first character of mlmpub's yellow `GRP <n>` row, for about one frame.

## It is not a leading space in the caption text

mlmpub emits `"GRP %d"` with no leading space, and the white clock row above it shows no such cell. Decoding the stream's token pairs shows what the cell actually is:

```
PAC(row=14 indent=8 white)
MidRow(yellow)          <- this is the square
Chars("GR")
Chars("P ")
...
```

A CTA-608 PAC encodes **either** a colour **or** an indent, never both, so a coloured run at column > 0 must be preceded by a mid-row code — and a mid-row code **occupies a display cell, rendered as a space carrying the new attributes** (SPEC §7). The publisher is correct; row 13 escapes it only because white comes free in the PAC.

So `isEmptyCell` rightly reports that cell as non-empty (it is a styled space, the very case the existing tests call "unambiguous"). While the row's text is still arriving pair by pair — which is exactly what paint-on and roll-up do, and paint-on is now mlmpub's default — the blank is briefly the row's *only* non-empty cell, and becomes a one-cell background box with nothing in it.

## Fix

Drop segments that contain no glyph, applied **after** the gap split rather than before:

- a stray blank is judged as its own segment, and dropped;
- a blank merged into a segment that also has glyphs stays part of that caption's background, so inter-word spaces keep their box — the property `rowSegments` exists to preserve;
- an underlined blank is kept, since an underline is visible without a glyph.

This also improves the older `setPAC` stray-cell case. The gap split already stopped it barring the row, but it was still painted as a lone box; now it is not painted at all. The two tests covering it are updated to expect no box, and renamed to say so.

## Tests

Four new cases under `rowSegments`, driven by the real mlmpub row:

- the blank alone on the row paints nothing (`rowSegments` empty, `layoutSnapshot` empty);
- once `"GR"` arrives, one box of 3 cells with text `" GR"` — the blank is back inside the caption's background, as it should be;
- a lone *underlined* blank is still painted;
- a blank row alongside a captioned row drops only the blank one.

## Verification

`npm test` 1019 passed / 0 failed, `npm run typecheck` clean, `npm run lint` clean, prettier clean.

Note: `@svta/cml-608` was missing from my `node_modules` and 5 suites failed to resolve it before I ran `npm ci` — pre-existing, identical on a clean `main`, and unrelated to this change.

## No publisher change

moqlivemock stays as it is: the centred yellow row and its spec-faithful mid-row code are correct output. Keeping the colour *and* the centring is only possible with that cell, so the renderer is the right place for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
