### PR TITLE
feat(cc): strike through the CC button when captions are impossible

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -210,6 +210,25 @@
         cursor: not-allowed;
       }
 
+      /* A disabled CC button is the normal state on most tracks, so dimming
+         alone reads as "nothing here" rather than "captions are unavailable".
+         Strike it through so the state is legible at a glance; the title
+         attribute carries the reason. */
+      .btn-unavailable {
+        position: relative;
+      }
+
+      .btn-unavailable::after {
+        content: "";
+        position: absolute;
+        left: 0.35rem;
+        right: 0.35rem;
+        top: 50%;
+        border-top: 2px solid currentColor;
+        transform: rotate(-12deg);
+        pointer-events: none;
+      }
+
       .btn-primary {
         background-color: var(--bg-button-primary);
         color: var(--text-primary);

--- a/src/player.ts
+++ b/src/player.ts
@@ -1616,6 +1616,17 @@ export class Player {
           : "Turn closed captions on"
         : (REASONS[availability as keyof typeof REASONS] ??
           "Closed captions unavailable on this track");
+      // Dimming alone is too quiet: a greyed CC button is the normal state on
+      // most tracks, so it reads as "nothing here" rather than "this track
+      // cannot be captioned" — the confusion AV1 renditions caused, where
+      // playback works and only captions are impossible. Strike the button
+      // through so the state is legible without hovering for the reason.
+      // "no-track" is excluded: before playback starts nothing is unavailable
+      // yet, it is simply not applicable.
+      ccBtn.classList.toggle(
+        "btn-unavailable",
+        !available && availability !== "no-track",
+      );
       const icon = document.createElement("span");
       icon.setAttribute("aria-hidden", "true");
       icon.textContent = "💬";


### PR DESCRIPTION
A greyed CC button is the ordinary state on most tracks, so dimming alone reads as "nothing here" rather than "this track cannot be captioned".

AV1 is where that bites: the rendition plays perfectly and advertises the CTA-608 accessibility descriptor, but carries the captions in a `metadata_itu_t_t35` OBU rather than an SEI NAL unit, so no SEI-reading receiver can ever show them. Today the button greys out correctly and looks indistinguishable from a player that has simply not finished loading — which is exactly how it was first reported.

Striking the button through makes the state legible at a glance; the existing `title` still carries the reason. The line is a pseudo-element in `currentColor`, so it inherits the disabled dimming and needs no new palette entry.

**Excluded from the strike:** the pre-playback `no-track` case. Nothing is unavailable yet there — it is simply not applicable — and marking it would put a cross on the button on every page load.

Verified in Chrome against `mlmpub -cc608`:

| state | disabled | struck | title |
|---|---|---|---|
| before playback | yes | no | "Start playback to enable closed captions" |
| AVC track | no | no | "Turn closed captions on" |
| AV1 track | yes | **yes** | "…cannot read captions from this codec…" |

Related: [Eyevinn/moqlivemock#126](https://github.com/Eyevinn/moqlivemock/pull/126) reorders the catalog so AV1 is no longer the default video track, which removes the first encounter with this state. The two are independent — this makes the state readable wherever it is still reached (any AV1 rendition a user selects deliberately).

`npm run lint`, `npm run pretty`, `npm run typecheck`, `npm test` (415) and `npm run build` all pass.