### PR TITLE
chore: release v0.13.0 (CTA-608 captions, overlay seam, AV1 on LOC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-08-06
+
+In-band CTA-608 captions on both render engines, delivered through a general
+timed-text overlay seam that WebVTT, IMSC-1 and ograf renderers can also use.
+
 ### Added
 
 - Timed-text overlay seam (`src/overlay`): a snapshot timeline with `push`
   (open-ended state) and `addCue` (intervals) channels, resolved by search
-  against the picture clock, plus a CTA-608 renderer that paints screens on
-  the true 32x15 grid.
+  against the picture clock. Renderers own a DOM subtree and are re-rendered
+  on change only.
+- CTA-608 CC1 captions decoded from in-band SEI on **both** engines — MSE
+  (CMAF and LOCMAF) and WebCodecs (LOC) — and painted on the true 32x15 grid
+  inside the CTA-608 safe area, with colours, background boxes and the
+  pop-on / roll-up / paint-on screen model. Encrypted namespaces are covered
+  too: the caption SEI sits in the clear subsample leader, so no key is
+  needed to read it.
+- CC toggle, enabled only when the selected video track advertises
+  `urn:scte:dash:cc:cea-608:2015` **and** its codec can carry CTA-608;
+  default off, and struck through when captions are impossible for the track.
+- AV1 video on the WebCodecs LOC pipeline: raw OBU temporal units fed to the
+  decoder, with keyframes and reconfiguration driven by the in-band sequence
+  header. AV1 carries CTA-608 in a metadata OBU rather than an SEI NAL unit,
+  so AV1 renditions play but are not captioned.
 - `IPlaybackPipeline.getPresentationTimeMs()` — the presentation time of the
   picture on screen, implemented by both render engines.
+- End-to-end verification record with screenshots under
+  `docs/verification/cc608/`.
+
+### Changed
+
+- TypeScript `target` and `lib` raised to ES2022.
+- ESLint 10, with `eslint-plugin-import` replaced by the maintained
+  `eslint-plugin-import-x` fork; the two unused prettier packages are gone,
+  leaving Prettier to run standalone.
+
+### Fixed
+
+- Overlays no longer stack: each Connect built a fresh `Player` without
+  disposing the outgoing one, leaking a renderer root and a
+  `requestAnimationFrame` loop every time.
+- No background box is painted around a cell holding no glyph — the mid-row
+  code that has to precede a coloured row was briefly showing as a lone box
+  while a paint-on or roll-up row was still arriving.
+- The CC button no longer enables itself on tracks whose codec cannot carry
+  CTA-608, where turning it on could never show anything.
 
 ## [0.12.0] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,18 @@ warp-player/
 │   ├── loc/              # LOC payload helpers for the WebCodecs pipeline
 │   │   ├── avc.ts        # AVC (H.264) NALU walker / avcC builder
 │   │   ├── hevc.ts       # HEVC (H.265) NALU walker / hvcC builder
+│   │   ├── av1.ts        # AV1 OBU walker, sequence-header / keyframe detection
 │   │   ├── aac.ts        # AAC AudioSpecificConfig from catalog metadata
 │   │   ├── opus.ts       # Opus ID-header (OpusHead) from catalog metadata
+│   │   ├── cta608.ts     # CTA-608 cc_data extraction from LOC access units
 │   │   └── extensions.ts # LOC extension-header parsing (capture timestamps)
+│   ├── cc608/            # Codec- and container-agnostic CTA-608 decoding
+│   │   ├── source.ts     # Feeds coded samples to @svta/cml-608, emits screens
+│   │   ├── snapshot.ts   # Immutable copy of a live CaptionScreen
+│   │   └── gate.ts       # Where the caption sink goes, and whether to extract
+│   ├── overlay/          # Timed-text / graphics overlay seam
+│   │   ├── overlayLayer.ts        # Snapshot timeline, clock, geometry
+│   │   └── renderers/cta608.ts    # CTA-608 screens on the true 32x15 grid
 │   ├── locmaf/           # LOCMAF (compact CMAF packaging) for the MSE pipeline
 │   │   ├── locmaf.ts     # Version-gating wrapper (LOCMAF v0.3 only)
 │   │   ├── vi64.ts       # MOQT (draft-18 §1.4.1) varints + zigzag
@@ -260,8 +269,17 @@ See [CONFIG.md](CONFIG.md) for detailed configuration options.
 - Two interchangeable render engines selected per session:
   - **MSE / CMAF** — the default for CMAF tracks, also handles encrypted content via EME
   - **WebCodecs / LOC** — clear-only pipeline for `packaging: "loc"` tracks,
-    supporting AVC and HEVC video plus AAC and Opus audio
+    supporting AVC, HEVC and AV1 video plus AAC and Opus audio
     ([draft-mzanaty-moq-loc])
+- In-band **CTA-608** CC1 captions on both engines, decoded from the video SEI
+  and painted on the true 32x15 grid inside the CTA-608 safe area — colours,
+  background boxes and the pop-on / roll-up / paint-on screen model. They work
+  on encrypted namespaces too, because the caption SEI sits in the clear
+  subsample leader. The CC button enables only when the track advertises
+  `urn:scte:dash:cc:cea-608:2015` and its codec can carry the captions, so AV1
+  renditions play but are not captioned (AV1 uses a metadata OBU instead of an
+  SEI NAL unit). Captions ride a general timed-text overlay seam
+  (`src/overlay`) that WebVTT, IMSC-1 and ograf renderers can share
 - Engine selector with `Auto` mode that picks MSE or WebCodecs from the
   selected tracks' packaging and encryption status, and namespace filtering
   that dims out namespaces incompatible with the chosen engine

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Cuts the `[0.13.0]` CHANGELOG entry from the 22 commits since `v0.12.0`, bumps `package.json`, and refreshes the README.

## The release

**In-band CTA-608 CC1 captions on both render engines** — MSE (CMAF and LOCMAF) and WebCodecs (LOC) — decoded from the video SEI and painted on the true 32x15 grid inside the CTA-608 safe area, with colours, background boxes and the pop-on / roll-up / paint-on screen model. Encrypted namespaces are covered: the caption SEI sits in the clear subsample leader, so no key is needed to read it.

They ride a **general timed-text overlay seam** (`src/overlay`) — a snapshot timeline with `push` and `addCue` channels resolved against the picture clock — designed to take WebVTT, IMSC-1 and ograf renderers later. CTA-608 is its first tenant.

**AV1 video on the LOC pipeline** lands in the same release, with the caveat recorded in both the CHANGELOG and the README: AV1 carries CTA-608 in a metadata OBU rather than an SEI NAL unit, so AV1 renditions play but are not captioned, and the CC button stays struck through on them.

Also in: ES2022, ESLint 10, and three fixes — stacked overlays, the empty background box on the mid-row code, and the CC button enabling on codecs that can never show captions.

## README

Its project tree and feature list predated every caption file and still described the WebCodecs engine as AVC/HEVC only. Both are updated; I checked that every path now listed in the tree exists.

## After merge

Needs a `v0.13.0` tag on the merge commit — every prior release is tagged (`v0.6.0` … `v0.12.0`) and I have not created it.

Pairs with **moqlivemock v0.13.0**, which is in the works.

Verified: typecheck, ESLint, Prettier, build and 415 tests pass.