### PR TITLE
fix(webcodecs): hold a steady playback rate in the latency controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-08-29
+
+A playback-rate stability fix for the WebCodecs (LOC) engine, and the audible
+audio artefact that came with it.
+
+### Fixed
+
+- The WebCodecs latency controller no longer flaps the playback rate. Its
+  input is `Date.now() - lastPresentedMs`, and the picture clock only advances
+  when a frame is painted, so the reading is a sawtooth one frame interval
+  deep — 40 ms at 25 fps. The rate branches compared it strictly against the
+  target, so the controller sat permanently in the speed-up or slow-down
+  branch and re-derived a rate every tick, settling into a ~1.003 / ~0.994
+  oscillation twice a second.
+
+  Each rate change re-anchors the audio schedule, and `onDecodedAudio`
+  recomputes every chunk's start from the anchor rather than from the previous
+  chunk's end, so the next chunk shifted by roughly
+  `lead × (1/r_new − 1/r_old)` — about 1.8 ms, or 87 samples at 48 kHz. A gap
+  or overlap between two `AudioBufferSourceNode`s twice a second, heard as a
+  click on the 880 Hz test tone, for both AAC and Opus.
+
+  The reading is now exponentially smoothed, and the controller has
+  hysteresis: it engages past 60 ms of error and disengages back to exactly
+  1.0x once inside 30 ms. The buffer-underrun guard still bypasses the
+  deadband — that is starvation protection, not latency trimming — and the
+  in-deadband case sets 1.0 explicitly, so a rate set during a transient can
+  no longer persist. The MSE engine is unaffected: `<video>.currentTime` is
+  continuous and never carried the sawtooth.
+
 ## [0.13.0] - 2026-08-06
 
 In-band CTA-608 captions on both render engines, delivered through a general

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyevinn/warp-player",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Browser-based Media Player for MOQ protocol with CMSF support",
   "main": "dist/index.js",
   "scripts": {

--- a/src/player.ts
+++ b/src/player.ts
@@ -209,6 +209,17 @@ export class Player {
   // needs more authority to hold target latency (set in the constructor).
   private maxCatchupRate = 1.02; // ceiling for the latency catch-up playback rate
   private catchupBaseGain = 0.03; // proportional gain for latency catch-up
+  // WebCodecs latency-controller state. Unlike <video>.currentTime, the
+  // WebCodecs picture clock (lastPresentedMs) only advances when a frame is
+  // actually painted, so the raw latency reading is a sawtooth one frame
+  // interval (40 ms at 25 fps) deep. Fed straight into the rate branches it
+  // makes the rate flap on every tick, and each flap re-anchors the audio
+  // schedule — an audible click twice a second. Smooth the reading and hold
+  // 1.0x inside a deadband around the target instead.
+  private webcodecsLatencyEmaMs: number | null = null;
+  private webcodecsRateEngaged = false;
+  private readonly webcodecsLatencyEmaAlpha = 0.25; // ~1.7 s at the 500 ms cadence
+  private readonly webcodecsRateDeadbandMs = 60; // engage outside +/- this
   // Drives checkBufferHealth on a fixed cadence (MSE only). timeupdate fires
   // too sparsely on Safari (~1/s) to control latency responsively.
   private mseControlTimer: ReturnType<typeof setInterval> | null = null;
@@ -1823,6 +1834,7 @@ export class Player {
     this.videoBufferReady = false;
     this.audioBufferReady = false;
     this.playbackStarted = false;
+    this.resetWebCodecsRateController();
 
     // Reset counters
     this.videoObjectsReceived = 0;
@@ -3070,6 +3082,7 @@ export class Player {
     this.webcodecsPipeline = pipeline;
     this.currentPipeline = pipeline;
     this.refreshMuteLabel?.();
+    this.resetWebCodecsRateController();
     this.playbackStarted = true;
     this.updateEngineLegend();
 
@@ -5227,7 +5240,13 @@ export class Player {
 
     const minimalBufferSec = this.minimalBufferMs / 1000;
     const targetLatencyMs = this.targetLatencyMs;
-    const currentLatencyMs = snap.currentLatencyMs;
+
+    // Smooth the picture-clock sawtooth out of the reading before it reaches
+    // the rate branches. Without this the raw value straddles the target on
+    // every tick and the rate flaps between roughly 1.003 and 0.994.
+    const smoothedLatencyMs = this.smoothWebCodecsLatency(
+      snap.currentLatencyMs,
+    );
 
     // Use the lower of the two buffers when audio is present, otherwise just
     // video — matches the legacy controller's effectiveMinBuffer semantics.
@@ -5235,34 +5254,43 @@ export class Player {
       ? Math.min(snap.videoBufferedAheadS, snap.audioBufferedAheadS)
       : snap.videoBufferedAheadS;
     const belowMinimalBuffer = effectiveMinBuffer < minimalBufferSec;
-    const aboveTargetLatency = currentLatencyMs > targetLatencyMs;
-    const belowTargetLatency = currentLatencyMs < targetLatencyMs;
 
-    let newRate: number | null = null;
+    // Hysteresis around the target: engage the controller only once the
+    // smoothed latency is more than a deadband away, and disengage (back to
+    // exactly 1.0x) once it has recovered to within half a deadband. This
+    // keeps the rate pinned at 1.000 in steady state rather than chattering
+    // across the target, which is what the audio scheduler hears.
+    const latencyErrorMs = smoothedLatencyMs - targetLatencyMs;
+    if (Math.abs(latencyErrorMs) > this.webcodecsRateDeadbandMs) {
+      this.webcodecsRateEngaged = true;
+    } else if (Math.abs(latencyErrorMs) < this.webcodecsRateDeadbandMs / 2) {
+      this.webcodecsRateEngaged = false;
+    }
+
+    let newRate: number;
     if (belowMinimalBuffer) {
-      // Buffer underrun risk — slow down to let it grow.
+      // Buffer underrun risk — slow down to let it grow. Bypasses the
+      // deadband: this is a starvation guard, not latency trimming.
       newRate = 0.97;
-    } else if (aboveTargetLatency) {
+    } else if (!this.webcodecsRateEngaged) {
+      // Within the deadband — hold nominal speed.
+      newRate = 1.0;
+    } else if (latencyErrorMs > 0) {
       // Above target latency — speed up modestly, capped at 1.02.
-      const latencyError =
-        (currentLatencyMs - targetLatencyMs) / targetLatencyMs;
+      const latencyError = latencyErrorMs / targetLatencyMs;
       const baseGain = 0.03;
       const gainReduction = Math.exp(-Math.abs(latencyError) * 10);
       const effectiveGain = baseGain * (1 - gainReduction * 0.8);
       newRate = Math.min(1.02, 1.0 + latencyError * effectiveGain);
-    } else if (belowTargetLatency) {
+    } else {
       // Below target latency — slow down modestly, floored at 0.95.
-      const latencyError =
-        (targetLatencyMs - currentLatencyMs) / targetLatencyMs;
+      const latencyError = -latencyErrorMs / targetLatencyMs;
       const baseGain = 0.05;
       const gainReduction = Math.exp(-Math.abs(latencyError) * 15);
       const effectiveGain = baseGain * (1 - gainReduction * 0.9);
       newRate = Math.max(0.95, 1.0 - latencyError * effectiveGain);
     }
 
-    if (newRate === null) {
-      return;
-    }
     if (Math.abs(currentRate - newRate) < 0.001) {
       return;
     }
@@ -5270,10 +5298,33 @@ export class Player {
     if (Math.random() < 0.1) {
       this.logger.debug(
         `[BufferHealth] WebCodecs rate ${currentRate.toFixed(3)}→${newRate.toFixed(3)}` +
-          ` (latency ${currentLatencyMs.toFixed(0)}ms target ${targetLatencyMs}ms,` +
+          ` (latency ${smoothedLatencyMs.toFixed(0)}ms smoothed from` +
+          ` ${snap.currentLatencyMs.toFixed(0)}ms, target ${targetLatencyMs}ms,` +
           ` minBuf ${(effectiveMinBuffer * 1000).toFixed(0)}ms)`,
       );
     }
+  }
+
+  /**
+   * Exponentially smooth the WebCodecs latency reading. The reading is
+   * `Date.now() - lastPresentedMs`, and lastPresentedMs steps once per painted
+   * frame, so consecutive samples carry up to a frame interval of quantization
+   * noise that the rate branches would otherwise chase.
+   */
+  private smoothWebCodecsLatency(currentLatencyMs: number): number {
+    const prev = this.webcodecsLatencyEmaMs;
+    const next =
+      prev === null
+        ? currentLatencyMs
+        : prev + this.webcodecsLatencyEmaAlpha * (currentLatencyMs - prev);
+    this.webcodecsLatencyEmaMs = next;
+    return next;
+  }
+
+  /** Clear WebCodecs rate-controller state between sessions. */
+  private resetWebCodecsRateController(): void {
+    this.webcodecsLatencyEmaMs = null;
+    this.webcodecsRateEngaged = false;
   }
 
   /**


### PR DESCRIPTION
## Problem

On the WebCodecs (LOC) engine the playback rate oscillated between roughly
1.003 and 0.994 twice a second, with an audible click at each change. The MSE
engine was unaffected and sat at a steady 1.000.

The controller reads latency as `Date.now() - lastPresentedMs`. That picture
clock only advances when a frame is actually painted, so the reading is a
sawtooth one frame interval deep — 40 ms at 25 fps. The rate branches compared
it strictly against the target:

```js
const aboveTargetLatency = currentLatencyMs > targetLatencyMs;
const belowTargetLatency = currentLatencyMs < targetLatencyMs;
```

With no deadband the controller was always in one branch or the other and
re-derived a rate on every tick, so the sawtooth crossing the target drove a
permanent oscillation.

Each rate change re-anchors the audio schedule, and `onDecodedAudio`
recomputes every chunk's start from the anchor rather than from the previous
chunk's end. The next chunk therefore shifted by roughly
`lead × (1/r_new − 1/r_old)` — about 1.8 ms, or 87 samples at 48 kHz — leaving
a gap or an overlap between two `AudioBufferSourceNode`s. On the 880 Hz test
tone that is a clean click, and it reproduced identically for AAC and Opus,
which rules out the publisher's loop splice (Opus is 500 × 960 = 480000, exactly
the loop duration, so it never splices).

## Fix

- Exponentially smooth the latency reading (α = 0.25, ≈1.7 s at the 500 ms
  cadence) so the picture-clock quantization no longer reaches the rate
  branches.
- Give the controller hysteresis: engage past 60 ms of error, disengage back to
  exactly 1.0x once inside 30 ms.
- Set 1.0 explicitly in the deadband instead of returning, so a rate set during
  a transient cannot persist indefinitely.

The buffer-underrun guard still bypasses the deadband — that is starvation
protection, not latency trimming. The MSE controller is untouched;
`<video>.currentTime` is continuous and never carried the sawtooth.

## Verification

Typecheck, lint and all 415 tests pass. Verified end to end against
`msf/clear` on the demo server: the rate readout now holds a flat 1.000 and the
per-second noise is gone, with CMSF unchanged.

## Notes

- No test covers the new behaviour — `adjustWebCodecsRate` is a private method
  reading instance state, so locking it down means extracting the rate decision
  into a pure function first. Deliberately left out of a patch release.
- The deadband constants are tuned by inspection, not measurement.
- The audio scheduler still recomputes each chunk's start from the anchor
  rather than from the previous chunk's end, so a genuine latency excursion can
  still click. Follow-up, tracked separately — it is a behaviour change rather
  than a patch.
