### PR TITLE
fix(docker): make the image build and serve the production bundle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Produced inside the image
+node_modules
+dist
+coverage
+
+# Version control and CI
+.git
+.gitignore
+.github
+.husky
+
+# Local archives, logs and screenshots
+*.tgz
+*.log
+*.png
+
+# Not needed to build the production bundle
+docs
+test
+*.md
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,35 @@
 ARG NODE_IMAGE=node:22-alpine
 
+# ---- Build stage ------------------------------------------------------------
+# The full dependency tree is installed here on purpose: webpack, ts-loader and
+# typescript are all devDependencies, so `npm ci --omit=dev` would leave the
+# image with nothing to build with.
+FROM ${NODE_IMAGE} AS builder
+WORKDIR /app
+
+# Dependency layer, cached until package.json / package-lock.json change.
+COPY ["package.json", "package-lock.json", "./"]
+# husky's prepare script fails in a build context that has no .git directory
+RUN npm pkg delete scripts.prepare \
+    && npm ci
+
+# Source layer
+COPY ["tsconfig.json", "tsconfig.base.json", "webpack.config.mjs", "./"]
+COPY ["src", "./src"]
+RUN npm run build
+
+# ---- Runtime stage ----------------------------------------------------------
+# WARP Player is a static bundle, so the runtime image only needs a file server;
+# the build toolchain and node_modules stay behind in the builder stage.
 FROM ${NODE_IMAGE}
 ENV NODE_ENV=production
-EXPOSE 8080
-RUN mkdir /app
-RUN chown node:node /app
-USER node
 WORKDIR /app
-COPY --chown=node:node ["package.json", "package-lock.json*", "tsconfig*.json", "webpack.config.js", "./"]
-COPY --chown=node:node ["src", "./src"]
-# Delete prepare script to avoid errors from husky
-RUN npm pkg delete scripts.prepare \
-    && npm ci --omit=dev
-# Build for production
-RUN npm run build
-CMD [ "npm", "run", "start" ]
+
+# Same static server that `npm run serve:dist` uses locally
+RUN npm install -g serve@14.2.6
+
+COPY --from=builder --chown=node:node /app/dist ./dist
+
+USER node
+EXPOSE 8080
+CMD ["serve", "--single", "--listen", "tcp://0.0.0.0:8080", "dist"]


### PR DESCRIPTION
## Problem

The Dockerfile could not produce a working image. Three independent failures:

1. It copied `webpack.config.js`, but the config is `webpack.config.mjs` — `COPY` failed outright.
2. It ran `npm ci --omit=dev` and then `npm run build`, but `webpack`, `ts-loader`, `typescript` and the `@types/*` packages are all devDependencies, so there was nothing to build with. `ENV NODE_ENV=production` set before the install compounded this.
3. `CMD ["npm", "run", "start"]` launched `webpack serve` — a development server, and one that `--omit=dev` had not installed either.

There was also no `.dockerignore`, so the build context was 283 MB, 205 MB of it `node_modules`.

## Change

Split into two stages:

- **builder** — installs the full dependency tree (needed for the build) and runs `npm run build`.
- **runtime** — carries only `dist/` plus `serve`, the same static server behind `npm run serve:dist`. No build toolchain, no `node_modules`.

Kept from the original: the `ARG NODE_IMAGE` override, the non-root `node` user, port 8080, and the `npm pkg delete scripts.prepare` workaround for husky (its `prepare` script fails in a build context with no `.git`).

Added `.dockerignore`.

## Verification

`docker build` and `docker run` against this branch:

- Image builds clean; webpack compiles with only the two pre-existing bundle-size warnings
- `whoami` in the container → `node` (non-root)
- `serve` binds `0.0.0.0:8080`
- `GET /` → 200, `<title>MOQ Player - CMSF (draft-14/16)</title>`
- Both JS bundles → 200 with `application/javascript`
- `/config.json` → 200, `/eyevinn-technology-logo-white-400px.png` → 200
- SPA fallback (`--single`) → 200 on unknown routes
- `/app/node_modules` absent in the runtime image

## Notes

- Branched on top of #182, so the base image is `node:22-alpine`, consistent with the `engines.node: ">=22.15.0"` floor that landed there. No conflict.
- Final image is 258 MB, almost entirely the Node base. An `nginx:alpine` runtime stage would cut it to roughly 50 MB but needs its own config to listen on 8080 as non-root — left out of scope here.
- `dist/` ships `.d.ts`, `.d.ts.map` and `.js.map` files, from `declaration: true` and the production `devtool: "source-map"`. That is what `npm run build` already produces locally; changing it is a build-config decision, not a Dockerfile one.